### PR TITLE
chore(deps): bump docker/metadata-action from 5 to 6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -201,7 +201,7 @@ jobs:
 
       - name: Extract version tag
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |


### PR DESCRIPTION
## Summary
- Bumps `docker/metadata-action` from v5 to v6 in the publish workflow

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)