### PR TITLE
fix(models): reject unknown PyTorch loss names

### DIFF
--- a/nirs4all/controllers/models/torch_model.py
+++ b/nirs4all/controllers/models/torch_model.py
@@ -63,6 +63,27 @@ def _get_nn():
         _get_torch()
     return _torch_modules['nn']
 
+def _resolve_loss_function(loss_config: Any, nn: Any) -> Any:
+    """Resolve a configured PyTorch loss without silently changing intent."""
+    if not isinstance(loss_config, str):
+        return loss_config
+
+    aliases = {
+        'mse': nn.MSELoss,
+        'mae': nn.L1Loss,
+        'crossentropy': nn.CrossEntropyLoss,
+    }
+    loss_class = aliases.get(loss_config.lower())
+    if loss_class is None and hasattr(nn, loss_config):
+        loss_class = getattr(nn, loss_config)
+    if loss_class is None:
+        raise ValueError(
+            f"Unknown PyTorch loss {loss_config!r}. "
+            "Use a torch.nn loss class name, one of the aliases "
+            "'mse', 'mae', or 'crossentropy', or pass a callable."
+        )
+    return loss_class()
+
 @register_controller
 class PyTorchModelController(BaseModelController):
     """Controller for PyTorch models.
@@ -194,21 +215,7 @@ class PyTorchModelController(BaseModelController):
             optimizer = optimizer_config
 
         # Setup loss function
-        loss_fn_config = train_params.get('loss', 'MSELoss')
-        if isinstance(loss_fn_config, str):
-            # Handle common loss names
-            if loss_fn_config.lower() == 'mse':
-                loss_fn = nn.MSELoss()
-            elif loss_fn_config.lower() == 'mae':
-                loss_fn = nn.L1Loss()
-            elif loss_fn_config.lower() == 'crossentropy':
-                loss_fn = nn.CrossEntropyLoss()
-            elif hasattr(nn, loss_fn_config):
-                loss_fn = getattr(nn, loss_fn_config)()
-            else:
-                loss_fn = nn.MSELoss() # Default
-        else:
-            loss_fn = loss_fn_config
+        loss_fn = _resolve_loss_function(train_params.get('loss', 'MSELoss'), nn)
 
         # Training parameters
         epochs = train_params.get('epochs', 100)

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -1,8 +1,59 @@
 """Tests for PyTorch models."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from nirs4all.utils.backend import TORCH_AVAILABLE
+
+
+class TestPyTorchLossResolution:
+    """Test loss configuration without importing the optional backend."""
+
+    @staticmethod
+    def _fake_nn():
+        class MSELoss:
+            pass
+
+        class L1Loss:
+            pass
+
+        class CrossEntropyLoss:
+            pass
+
+        return SimpleNamespace(
+            MSELoss=MSELoss,
+            L1Loss=L1Loss,
+            CrossEntropyLoss=CrossEntropyLoss,
+        )
+
+    def test_known_alias_is_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("mse", nn), nn.MSELoss)
+
+    def test_torch_class_name_and_default_are_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("L1Loss", nn), nn.L1Loss)
+        assert isinstance(_resolve_loss_function("MSELoss", nn), nn.MSELoss)
+
+    def test_callable_is_preserved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        custom_loss = object()
+
+        assert _resolve_loss_function(custom_loss, self._fake_nn()) is custom_loss
+
+    def test_unknown_loss_name_is_rejected(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        with pytest.raises(ValueError, match="Unknown PyTorch loss 'not_a_loss'"):
+            _resolve_loss_function("not_a_loss", self._fake_nn())
 
 
 @pytest.mark.xdist_group("gpu")
@@ -28,4 +79,3 @@ class TestPyTorchModels:
         x = torch.randn(1, 5)
         y = model(x)
         assert y.shape == (1, 1)
-


### PR DESCRIPTION
## Summary
- preserve callable and torch.nn loss resolution
- reject unknown loss strings instead of silently training with MSE
- add backend-independent targeted tests for aliases, class names, defaults, callables, and failures

## Validation
- pytest tests/unit/operators/models/test_pytorch.py -q (4 passed, 1 skipped)
- ruff check nirs4all/controllers/models/torch_model.py tests/unit/operators/models/test_pytorch.py
- independent implementation review: approved

## Notes
- Full tests intentionally deferred to the larger implementation batch.
- Targeted mypy reached existing unrelated project errors; no reported error was in the changed files.