### PR TITLE
feat(dagml): carry native training loss roles

### DIFF
--- a/nirs4all/pipeline/dagml/training_contracts.py
+++ b/nirs4all/pipeline/dagml/training_contracts.py
@@ -45,6 +45,7 @@ class DagMLTrainingRequestSpec:
     parameter_patches: Sequence[Mapping[str, Any]] = ()
     patch_policies: Sequence[Mapping[str, Any]] = ()
     influence_requirements: Sequence[Mapping[str, Any]] = ()
+    training_losses: Sequence[Mapping[str, Any]] = ()
     selection_required_metric_level: str | None = None
     selection_evaluation_scope: str | None = None
 
@@ -66,6 +67,8 @@ def assemble_training_request(spec: DagMLTrainingRequestSpec) -> dict[str, Any]:
         "options": _training_options(spec),
         "request_fingerprint": "0" * 64,
     }
+    if spec.training_losses:
+        request["training_losses"] = _sorted_training_losses(spec.training_losses)
     request["request_fingerprint"] = tcv1_fingerprint_without(request, "request_fingerprint")
     return request
 
@@ -159,6 +162,35 @@ def _sorted_controller_manifests(manifests: Sequence[Mapping[str, Any]]) -> list
 
 _PHASE_ORDER = {name: index for index, name in enumerate(("COMPILE", "PLAN", "FIT_CV", "SELECT", "REFIT", "PREDICT", "EXPLAIN"))}
 
+
+def _sorted_training_losses(roles: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    canonical_roles = [_canonical_training_loss_role(role) for role in roles]
+    return sorted(canonical_roles, key=_training_loss_sort_key)
+
+
+def _canonical_training_loss_role(role: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(role)
+    phases = out.get("phases")
+    if not isinstance(phases, Sequence) or isinstance(phases, str | bytes | bytearray):
+        raise TypeError("training loss role phases must be a sequence")
+    out["phases"] = sorted(set(phases), key=_PHASE_ORDER.__getitem__)
+    return out
+
+
+def _training_loss_sort_key(role: Mapping[str, Any]) -> tuple[str, tuple[bool, str], tuple[int, ...]]:
+    node_id = role.get("node_id")
+    output_id = role.get("output_id")
+    phases = role["phases"]
+    if not isinstance(node_id, str):
+        raise TypeError("training loss role node_id must be a string")
+    if output_id is not None and not isinstance(output_id, str):
+        raise TypeError("training loss role output_id must be a string or None")
+    return (
+        node_id,
+        (output_id is not None, output_id or ""),
+        tuple(_PHASE_ORDER[phase] for phase in phases),
+    )
+
 _CAPABILITY_ORDER = {
     name: index
     for index, name in enumerate(
@@ -182,6 +214,9 @@ _CAPABILITY_ORDER = {
             "supports_row_resampling",
             "supports_backend_loss_weights",
             "supports_missing_masks",
+            "supports_configurable_loss",
+            "supports_custom_loss",
+            "supports_differentiable_loss",
             "uses_training_weights",
             "uses_early_stopping",
             "performs_internal_tuning",

--- a/tests/unit/pipeline/dagml/test_training_contracts.py
+++ b/tests/unit/pipeline/dagml/test_training_contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -17,8 +18,16 @@ from nirs4all.pipeline.dagml.training_contracts import (
 
 
 def _dagml_training_fixture() -> dict:
-    fixture_path = Path(__file__).resolve().parents[5] / "dag-ml" / "examples" / "fixtures" / "training" / "python_training_smoke.v1.json"
-    if not fixture_path.exists():
+    relative_path = Path("dag-ml/examples/fixtures/training/python_training_smoke.v1.json")
+    fixture_path = next(
+        (
+            parent / relative_path
+            for parent in Path(__file__).resolve().parents
+            if (parent / relative_path).exists()
+        ),
+        None,
+    )
+    if fixture_path is None:
         pytest.skip("sibling dag-ml training fixture is not available")
     return json.loads(fixture_path.read_text(encoding="utf-8"))
 
@@ -79,6 +88,134 @@ def test_assemble_training_request_reproduces_and_validates_native_fixture() -> 
     assert validated.to_dict() == source
 
 
+def test_assemble_training_request_transports_and_orders_loss_roles_without_fixture() -> None:
+    later_role = _custom_training_loss_role()
+    later_role["node_id"] = "model:z"
+    later_role["output_id"] = None
+    later_role["phases"] = ["REFIT", "FIT_CV"]
+    earlier_role = deepcopy(later_role)
+    earlier_role["node_id"] = "model:a"
+    request = assemble_training_request(
+        DagMLTrainingRequestSpec(
+            request_id="training:test.loss-order",
+            plan_id="plan:test.loss-order",
+            graph={},
+            campaign={},
+            controller_manifests=(),
+            data_identities=(),
+            training_losses=(later_role, earlier_role),
+            output_requests=(),
+        )
+    )
+
+    assert [role["node_id"] for role in request["training_losses"]] == [
+        "model:a",
+        "model:z",
+    ]
+    assert all(
+        role["phases"] == ["FIT_CV", "REFIT"]
+        for role in request["training_losses"]
+    )
+    assert request["request_fingerprint"] == tcv1_fingerprint_without(
+        request, "request_fingerprint"
+    )
+
+
+def test_assemble_training_request_validates_native_training_loss_role() -> None:
+    fixture = _dagml_training_fixture()
+    source = fixture["request"]
+    controller_manifests = deepcopy(source["controller_manifests"])
+    model_manifest = next(
+        manifest
+        for manifest in controller_manifests
+        if manifest["controller_id"] == "controller:model.mock"
+    )
+    model_manifest["capabilities"] = sorted(
+        {
+            *model_manifest["capabilities"],
+            "needs_python_gil",
+            "supports_configurable_loss",
+            "supports_custom_loss",
+            "supports_differentiable_loss",
+        }
+    )
+    training_loss = _custom_training_loss_role()
+    spec = DagMLTrainingRequestSpec(
+        request_id=source["request_id"],
+        plan_id=source["plan_id"],
+        graph=source["graph"],
+        campaign=source["campaign"],
+        controller_manifests=controller_manifests,
+        data_identities=source["data_identities"],
+        training_losses=(training_loss,),
+        selection_metric=source["options"]["selection"]["metric"]["name"],
+        selection_objective=source["options"]["selection"]["metric"]["objective"],
+        selection_output_id=source["options"]["selection_output_id"],
+        output_requests=source["options"]["outputs"],
+        seed=source["options"]["seed"],
+        refit=source["options"]["refit"],
+        scheduler_workers=source["options"]["scheduler"]["workers"],
+        cpu_threads=source["options"]["resources"]["cpu_threads"],
+        cv_artifacts=source["options"]["artifacts"]["cv_artifacts"],
+        prediction_caches=source["options"]["artifacts"]["prediction_caches"],
+        fitted_artifacts=source["options"]["artifacts"]["fitted_artifacts"],
+        selection_required_metric_level=source["options"]["selection"]["required_metric_level"],
+        selection_evaluation_scope=source["options"]["selection"]["evaluation_scope"],
+    )
+
+    assembled = assemble_training_request(spec)
+
+    assert assembled["training_losses"] == [training_loss]
+    assert assembled["request_fingerprint"] == tcv1_fingerprint_without(
+        assembled, "request_fingerprint"
+    )
+    dag_ml = pytest.importorskip("dag_ml")
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+    validated = validate_training_request_with_dagml(assembled, dag_ml)
+    assert validated.to_dict()["training_losses"] == [training_loss]
+
+
 def test_tcv1_rejects_nonfinite_values() -> None:
     with pytest.raises(ValueError, match="NaN and infinity"):
         tcv1_fingerprint_without({"x": float("nan"), "fp": "0" * 64}, "fp")
+
+
+def _custom_training_loss_role() -> dict:
+    spec = {
+        "schema_version": 1,
+        "loss_id": "example.loss.asymmetric@1",
+        "kind": "custom",
+        "task_kinds": ["regression"],
+        "prediction_kinds": ["regression_point"],
+        "objective": "minimize",
+        "reduction": "mean",
+        "required_inputs": ["target", "prediction"],
+        "capabilities": ["differentiable"],
+        "parameters": {"over_weight": 1.0, "under_weight": 2.0},
+        "spec_fingerprint": "cf661225cc7137ab5ef9b87871ed5736a8479dd21587b7e17150c442b1e43eb0",
+    }
+    implementation = {
+        "schema_version": 1,
+        "semantic_kind": "loss",
+        "semantic_id": spec["loss_id"],
+        "semantic_fingerprint": spec["spec_fingerprint"],
+        "provider_id": "provider:python-local",
+        "binding_id": "binding:python",
+        "implementation_version": "1.0.0",
+        "implementation_fingerprint": "1f4c71b0b758c5ed25b4e38b132b9ad56fb2f5ff2cf490f7eb8786c4350a62f7",
+        "supported_controller_families": [],
+        "runtime_requirements": [],
+        "capabilities": ["deterministic", "differentiable", "needs_gil"],
+        "portability": "host_local",
+        "replayability": "registry_required",
+        "registry_key": "loss:run-123:asymmetric",
+        "descriptor_fingerprint": "031c7b120740620dade9ba14a5f2e142831ecb1be47ea7181f68511dfafdd807",
+    }
+    return {
+        "schema_version": 1,
+        "node_id": "model:base",
+        "output_id": "oof",
+        "phases": ["FIT_CV", "REFIT"],
+        "loss": {"spec": spec, "implementation": implementation},
+    }


### PR DESCRIPTION
## Summary
- add DAG-ML `training_losses` roles to the native nirs4all TrainingRequest seam
- preserve existing request fingerprints by omitting empty roles
- canonicalize phase and role ordering without mutating fingerprinted nested loss references
- recognize the three loss-related controller capabilities

## Dependency
This phase targets the contracts published in GBeurier/dag-ml#24 and must not merge before the corresponding DAG-ML loss contracts are released or merged.

## Validation
- `ruff check nirs4all/pipeline/dagml/training_contracts.py tests/unit/pipeline/dagml/test_training_contracts.py`
- `mypy nirs4all/pipeline/dagml/training_contracts.py`
- released dependency: 4 passed, 2 skipped (loss APIs not released)
- exact DAG-ML loss branch: 28 passed across training contracts/compiler/raw lowerer
- independent review completed; two findings fixed; re-review clean

## Scope
Phase 1 only. This transports authoritative DAG-ML loss roles; controller callback execution is a separate follow-up phase.