### PR TITLE
feat(dagml): execute local losses in PyTorch

### DIFF
--- a/nirs4all/controllers/models/torch_model.py
+++ b/nirs4all/controllers/models/torch_model.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from nirs4all.controllers.registry import register_controller
 from nirs4all.core.logging import get_logger
+from nirs4all.pipeline.dagml.loss_runtime import DagMLTrainingLossExecution
 from nirs4all.utils.backend import is_available, is_gpu_available, require_backend
 
 from ..models.base_model import BaseModelController
@@ -65,6 +66,8 @@ def _get_nn():
 
 def _resolve_loss_function(loss_config: Any, nn: Any) -> Any:
     """Resolve a configured PyTorch loss without silently changing intent."""
+    if isinstance(loss_config, DagMLTrainingLossExecution):
+        return loss_config.invoke_prediction_target
     if not isinstance(loss_config, str):
         return loss_config
 

--- a/nirs4all/controllers/models/torch_model.py
+++ b/nirs4all/controllers/models/torch_model.py
@@ -63,6 +63,27 @@ def _get_nn():
         _get_torch()
     return _torch_modules['nn']
 
+def _resolve_loss_function(loss_config: Any, nn: Any) -> Any:
+    """Resolve a configured PyTorch loss without silently changing intent."""
+    if not isinstance(loss_config, str):
+        return loss_config
+
+    aliases = {
+        'mse': nn.MSELoss,
+        'mae': nn.L1Loss,
+        'crossentropy': nn.CrossEntropyLoss,
+    }
+    loss_class = aliases.get(loss_config.lower())
+    if loss_class is None and hasattr(nn, loss_config):
+        loss_class = getattr(nn, loss_config)
+    if loss_class is None:
+        raise ValueError(
+            f"Unknown PyTorch loss {loss_config!r}. "
+            "Use a torch.nn loss class name, one of the aliases "
+            "'mse', 'mae', or 'crossentropy', or pass a callable."
+        )
+    return loss_class()
+
 @register_controller
 class PyTorchModelController(BaseModelController):
     """Controller for PyTorch models.
@@ -194,21 +215,7 @@ class PyTorchModelController(BaseModelController):
             optimizer = optimizer_config
 
         # Setup loss function
-        loss_fn_config = train_params.get('loss', 'MSELoss')
-        if isinstance(loss_fn_config, str):
-            # Handle common loss names
-            if loss_fn_config.lower() == 'mse':
-                loss_fn = nn.MSELoss()
-            elif loss_fn_config.lower() == 'mae':
-                loss_fn = nn.L1Loss()
-            elif loss_fn_config.lower() == 'crossentropy':
-                loss_fn = nn.CrossEntropyLoss()
-            elif hasattr(nn, loss_fn_config):
-                loss_fn = getattr(nn, loss_fn_config)()
-            else:
-                loss_fn = nn.MSELoss() # Default
-        else:
-            loss_fn = loss_fn_config
+        loss_fn = _resolve_loss_function(train_params.get('loss', 'MSELoss'), nn)
 
         # Training parameters
         epochs = train_params.get('epochs', 100)

--- a/nirs4all/pipeline/dagml/__init__.py
+++ b/nirs4all/pipeline/dagml/__init__.py
@@ -7,12 +7,16 @@ import-guarded — production ``nirs4all`` never imports this unless the dag-ml
 backend is selected. See ``dag-ml/docs/migration-nirs4all/``.
 """
 
+from .loss_runtime import DagMLTrainingLossExecution
+
 __all__ = [
+    "DagMLTrainingLossExecution",
     "conformal_contracts",
     "conformal_store",
     "estimator",
     "finetune_lowering",
     "fit_identity",
+    "loss_runtime",
     "native_client",
     "pipeline_objective",
     "pipeline_objective_compiler",

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -1,0 +1,100 @@
+"""Process-local execution handoff for DAG-ML training losses."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+
+class DagMLTrainingLossExecution:
+    """Bind one native ``NodeTask`` loss requirement to its local registry.
+
+    The object is deliberately process-local. It keeps executable state out of
+    DAG-ML contracts while allowing backend controllers to invoke the exact
+    callback selected for one ``FIT_CV`` or ``REFIT`` task.
+    """
+
+    __slots__ = (
+        "_attestation",
+        "_invocation_count",
+        "_invoke",
+        "_phase",
+        "_required_attestation",
+    )
+
+    def __init__(
+        self,
+        task: Mapping[str, Any],
+        registry: Any,
+        *,
+        role_index: int = 0,
+    ) -> None:
+        if not isinstance(task, Mapping):
+            raise TypeError("DAG-ML training loss task must be a mapping")
+        phase = task.get("phase")
+        if phase not in {"FIT_CV", "REFIT"}:
+            raise ValueError("DAG-ML training losses can execute only in FIT_CV or REFIT")
+        bind_training_loss = getattr(registry, "bind_training_loss", None)
+        if not callable(bind_training_loss):
+            raise TypeError("DAG-ML loss registry must expose bind_training_loss()")
+        if isinstance(role_index, bool) or not isinstance(role_index, int) or role_index < 0:
+            raise ValueError("DAG-ML training loss role_index must be a non-negative integer")
+
+        binding = bind_training_loss(
+            copy.deepcopy(dict(task)),
+            role_index=role_index,
+        )
+        if not isinstance(binding, Mapping):
+            raise TypeError("DAG-ML loss registry returned a non-mapping binding")
+        invoke = binding.get("invoke")
+        required_attestation = binding.get("required_attestation")
+        if not callable(invoke) or not isinstance(required_attestation, Mapping):
+            raise ValueError("DAG-ML loss binding lacks invoke or required_attestation")
+        if required_attestation.get("phase") != phase:
+            raise ValueError("DAG-ML loss binding attestation phase does not match its task")
+
+        self._invoke = invoke
+        self._phase = str(phase)
+        self._required_attestation = copy.deepcopy(dict(required_attestation))
+        self._attestation: dict[str, Any] | None = None
+        self._invocation_count = 0
+
+    @property
+    def phase(self) -> str:
+        """Return the task phase bound to this execution."""
+
+        return self._phase
+
+    @property
+    def invocation_count(self) -> int:
+        """Return the number of successful local callback invocations."""
+
+        return self._invocation_count
+
+    @property
+    def loss_attestations(self) -> list[dict[str, Any]]:
+        """Return the attestation only after at least one successful invocation."""
+
+        if self._attestation is None:
+            return []
+        return [copy.deepcopy(self._attestation)]
+
+    def __call__(self, target: Any, prediction: Any, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the semantic ``(target, prediction)`` DAG-ML loss callback."""
+
+        value = self._invoke(target, prediction, *args, **kwargs)
+        self._attestation = copy.deepcopy(self._required_attestation)
+        self._invocation_count += 1
+        return value
+
+    def invoke_prediction_target(self, prediction: Any, target: Any) -> Any:
+        """Adapt a backend ``(prediction, target)`` call to semantic ordering."""
+
+        return self(target, prediction)
+
+    def __reduce__(self) -> Any:
+        raise TypeError("DAG-ML training loss executions cannot be serialized")
+
+
+__all__ = ["DagMLTrainingLossExecution"]

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -1,10 +1,47 @@
 """Tests for PyTorch models."""
 
+import pickle
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from nirs4all.utils.backend import TORCH_AVAILABLE
+
+
+class _RecordingLossRegistry:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.bind_calls: list[tuple[dict[str, Any], int]] = []
+        self.calls: list[tuple[dict[str, Any], Any, Any, int]] = []
+        self.fail = fail
+
+    def bind_training_loss(
+        self,
+        task: dict[str, Any],
+        *,
+        role_index: int,
+    ) -> dict[str, Any]:
+        self.bind_calls.append((task, role_index))
+
+        def invoke(target: Any, prediction: Any) -> Any:
+            if self.fail:
+                raise RuntimeError("custom loss failed")
+            self.calls.append((task, target, prediction, role_index))
+            value = (prediction - target) ** 2
+            mean = getattr(value, "mean", None)
+            return mean() if callable(mean) else value
+
+        return {
+            "invoke": invoke,
+            "required_attestation": {
+                "phase": task["phase"],
+                "loss_id": "example.loss.squared@1",
+            },
+        }
+
+
+def _loss_task(phase: str = "FIT_CV") -> dict[str, Any]:
+    return {"phase": phase, "node_plan": {"training_losses": [{}]}}
 
 
 class TestPyTorchLossResolution:
@@ -55,6 +92,62 @@ class TestPyTorchLossResolution:
         with pytest.raises(ValueError, match="Unknown PyTorch loss 'not_a_loss'"):
             _resolve_loss_function("not_a_loss", self._fake_nn())
 
+    def test_dagml_execution_adapts_prediction_target_order(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        registry = _RecordingLossRegistry()
+        execution = DagMLTrainingLossExecution(_loss_task(), registry)
+        loss_fn = _resolve_loss_function(execution, self._fake_nn())
+
+        assert loss_fn(3.0, 1.0) == 4.0
+
+        assert len(registry.bind_calls) == 1
+        assert registry.calls[0][1:] == (1.0, 3.0, 0)
+        assert execution.loss_attestations == [
+            {"phase": "FIT_CV", "loss_id": "example.loss.squared@1"}
+        ]
+
+    def test_dagml_execution_is_process_local_and_attests_only_after_success(self):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        execution = DagMLTrainingLossExecution(
+            _loss_task("REFIT"), _RecordingLossRegistry(fail=True)
+        )
+
+        assert execution.loss_attestations == []
+        with pytest.raises(RuntimeError, match="custom loss failed"):
+            execution(1.0, 2.0)
+        assert execution.loss_attestations == []
+        with pytest.raises(TypeError, match="cannot be serialized"):
+            pickle.dumps(execution)
+
+    @pytest.mark.parametrize(
+        ("phase", "role_index", "message"),
+        [
+            ("PREDICT", 0, "only in FIT_CV or REFIT"),
+            ("FIT_CV", -1, "non-negative integer"),
+            ("FIT_CV", True, "non-negative integer"),
+        ],
+    )
+    def test_dagml_execution_rejects_invalid_scope(
+        self, phase: str, role_index: int, message: str
+    ):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        with pytest.raises(ValueError, match=message):
+            DagMLTrainingLossExecution(
+                _loss_task(phase), _RecordingLossRegistry(), role_index=role_index
+            )
+
+    def test_dagml_execution_rejects_malformed_binding(self):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        registry = SimpleNamespace(bind_training_loss=lambda *_args, **_kwargs: {})
+
+        with pytest.raises(ValueError, match="lacks invoke or required_attestation"):
+            DagMLTrainingLossExecution(_loss_task(), registry)
+
 
 @pytest.mark.xdist_group("gpu")
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch not available")
@@ -79,3 +172,34 @@ class TestPyTorchModels:
         x = torch.randn(1, 5)
         y = model(x)
         assert y.shape == (1, 1)
+
+    def test_training_loop_executes_dagml_loss_and_captures_attestation(self):
+        import torch
+        import torch.nn as nn
+
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        model = nn.Linear(1, 1, bias=False)
+        with torch.no_grad():
+            model.weight.zero_()
+        registry = _RecordingLossRegistry()
+        execution = DagMLTrainingLossExecution(_loss_task(), registry)
+
+        trained = PyTorchModelController()._train_model(
+            model,
+            torch.ones((4, 1)),
+            torch.ones((4, 1)),
+            optimizer="SGD",
+            lr=0.1,
+            epochs=1,
+            batch_size=2,
+            loss=execution,
+        )
+
+        assert trained.weight.detach().cpu().item() > 0.0
+        assert execution.invocation_count == 2
+        assert len(registry.bind_calls) == 1
+        assert execution.loss_attestations == [
+            {"phase": "FIT_CV", "loss_id": "example.loss.squared@1"}
+        ]

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -1,8 +1,59 @@
 """Tests for PyTorch models."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from nirs4all.utils.backend import TORCH_AVAILABLE
+
+
+class TestPyTorchLossResolution:
+    """Test loss configuration without importing the optional backend."""
+
+    @staticmethod
+    def _fake_nn():
+        class MSELoss:
+            pass
+
+        class L1Loss:
+            pass
+
+        class CrossEntropyLoss:
+            pass
+
+        return SimpleNamespace(
+            MSELoss=MSELoss,
+            L1Loss=L1Loss,
+            CrossEntropyLoss=CrossEntropyLoss,
+        )
+
+    def test_known_alias_is_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("mse", nn), nn.MSELoss)
+
+    def test_torch_class_name_and_default_are_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("L1Loss", nn), nn.L1Loss)
+        assert isinstance(_resolve_loss_function("MSELoss", nn), nn.MSELoss)
+
+    def test_callable_is_preserved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        custom_loss = object()
+
+        assert _resolve_loss_function(custom_loss, self._fake_nn()) is custom_loss
+
+    def test_unknown_loss_name_is_rejected(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        with pytest.raises(ValueError, match="Unknown PyTorch loss 'not_a_loss'"):
+            _resolve_loss_function("not_a_loss", self._fake_nn())
 
 
 @pytest.mark.xdist_group("gpu")
@@ -28,4 +79,3 @@ class TestPyTorchModels:
         x = torch.randn(1, 5)
         y = model(x)
         assert y.shape == (1, 1)
-


### PR DESCRIPTION
## Summary
- add a process-local DAG-ML training-loss execution adapter for FIT_CV and REFIT
- bind each native-validated local loss once per task and preserve semantic target/prediction ordering in the PyTorch loop
- expose loss attestations only after successful callback execution and reject serialization
- retain the fail-closed unknown PyTorch loss handling from #46

## Dependencies
- stacked on #47 (`agent/loss-contract-lowering`)
- requires GBeurier/dag-ml#24, including `LocalImplementationRegistry.bind_training_loss`
- incorporates the safety P0 branch from #46

## Validation
- `pytest tests/unit/operators/models/test_pytorch.py -q`: 12 passed with CPU Torch
- same PyTorch tests against exact DAG-ML loss branch: 12 passed
- DAG-ML local registry tests: 14 passed
- DAG-ML package exports/training contracts: 5 passed, 2 skipped with installed dependency; 6 passed against exact branch
- Ruff: passed
- mypy on runtime adapter and PyTorch controller: passed
- independent review: no findings after one-time binding and fail-closed coverage fixes

## Deferred scope
The native `node_runner` conversion from a `NodeTask` to this adapter, plus transfer of `loss_attestations` into `NodeResult`, remains a separate end-to-end phase. This PR establishes the backend-safe handoff and does not claim native FIT_CV/REFIT routing completion.