### PR TITLE
feat(dagml): attest native training losses

### DIFF
--- a/nirs4all/pipeline/dagml/finetune_lowering.py
+++ b/nirs4all/pipeline/dagml/finetune_lowering.py
@@ -24,13 +24,15 @@ def reject_native_training_param_overrides(
     steps: list[Any],
     *,
     context: str = "native DAG-ML",
+    allowed_keys: frozenset[str] = frozenset(),
 ) -> None:
     """Reject fit/refit kwargs that native DAG-ML would otherwise ignore."""
 
+    rejected_keys = UNSUPPORTED_NATIVE_TRAINING_PARAM_KEYS - allowed_keys
     hits: list[str] = []
     for step in steps:
         if isinstance(step, dict):
-            hits.extend(sorted(UNSUPPORTED_NATIVE_TRAINING_PARAM_KEYS & set(step)))
+            hits.extend(sorted(rejected_keys & set(step)))
     if hits:
         raise NotImplementedError(f"{context} does not yet support step-level {sorted(set(hits))}; running natively would ignore fit/refit arguments instead of preserving legacy parity.")
 

--- a/nirs4all/pipeline/dagml/node_runner.py
+++ b/nirs4all/pipeline/dagml/node_runner.py
@@ -32,8 +32,14 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from sklearn.pipeline import make_pipeline
 
-from nirs4all.pipeline.dagml_bridge import _META_MODEL_CONTROLLER_ID
+from nirs4all.pipeline.dagml_bridge import (
+    _META_MODEL_CONTROLLER_ID,
+    _PYTORCH_MODEL_CONTROLLER_ID,
+    _TENSORFLOW_MODEL_CONTROLLER_ID,
+)
 
+from .errors import DagMlUnsupported
+from .loss_runtime import DagMLTrainingLossExecution
 from .operator_routing import route_graph_node
 
 if TYPE_CHECKING:
@@ -353,7 +359,14 @@ def _output_handles(task: dict[str, Any], handle: int) -> dict[str, Any]:
     return outputs
 
 
-def _build_result(task: dict[str, Any], predictions: list[dict[str, Any]], artifacts: list[dict[str, Any]], artifact_handles: dict[str, Any], regression_targets: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+def _build_result(
+    task: dict[str, Any],
+    predictions: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    artifact_handles: dict[str, Any],
+    regression_targets: list[dict[str, Any]] | None = None,
+    loss_attestations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Assemble the schema-complete ``NodeResult`` the runtime validates (outputs + full lineage).
 
     ``regression_targets`` (the real ``y_true`` for the predicted samples) lets dag-ml score the
@@ -394,8 +407,173 @@ def _build_result(task: dict[str, Any], predictions: list[dict[str, Any]], artif
             "seed": task.get("seed"),
             "unsafe_flags": [],
             "metrics": metrics,
+            "loss_attestations": loss_attestations or [],
         },
     }
+
+
+def _bind_training_loss(
+    task: dict[str, Any],
+    controller_id: str,
+    local_implementations: Any,
+) -> DagMLTrainingLossExecution | None:
+    requirements = task.get("required_loss_attestations") or []
+    if not requirements:
+        return None
+    if controller_id not in {
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+    }:
+        raise DagMlUnsupported(
+            f"controller {controller_id!r} cannot execute a configurable training loss"
+        )
+    if len(requirements) != 1:
+        raise DagMlUnsupported(
+            "native nirs4all deep-learning nodes currently support one training loss per task"
+        )
+    if local_implementations is None:
+        raise RuntimeError(
+            "DAG-ML training task requires a process-local loss registry"
+        )
+    return DagMLTrainingLossExecution(task, local_implementations)
+
+
+def _backend_train_params(node: dict[str, Any]) -> dict[str, Any]:
+    params = (node.get("metadata") or {}).get("nirs4all_train_params", {})
+    if not isinstance(params, dict):
+        raise TypeError("nirs4all_train_params graph metadata must be a mapping")
+    return dict(params)
+
+
+def _seed_differentiable_backend(controller_id: str, seed: Any) -> None:
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise TypeError("native differentiable model tasks require an integer core seed")
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        import torch
+
+        torch.manual_seed(seed % (2**64))
+        return
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        import tensorflow as tf
+
+        tf.keras.utils.set_random_seed(seed % (2**32))
+        return
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
+
+
+def _prediction_only_refit_estimator(
+    controller_id: str,
+    estimator: Any,
+    loss_execution: DagMLTrainingLossExecution | None,
+) -> Any:
+    if (
+        controller_id != _TENSORFLOW_MODEL_CONTROLLER_ID
+        or loss_execution is None
+    ):
+        return estimator
+
+    from nirs4all.pipeline.storage.artifacts.artifact_persistence import (
+        from_bytes,
+        to_bytes,
+    )
+
+    data, format_name = to_bytes(estimator, format_hint="tensorflow")
+    return from_bytes(data, format_name)
+
+
+def _train_differentiable_model(
+    controller_id: str,
+    model: Any,
+    x_train: Any,
+    y_train: Any,
+    x_val: Any | None,
+    y_val: Any | None,
+    train_params: dict[str, Any],
+    loss_execution: DagMLTrainingLossExecution | None,
+) -> Any:
+    params = dict(train_params)
+    if loss_execution is not None:
+        params["loss"] = loss_execution
+    params.setdefault("verbose", 0)
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+        from nirs4all.pipeline.config.context import ExecutionContext
+
+        controller = PyTorchModelController()
+        context = ExecutionContext()
+        prepared_x, prepared_y = controller._prepare_data(
+            np.asarray(x_train), np.asarray(y_train), context
+        )
+        prepared_x_val, prepared_y_val = (
+            controller._prepare_data(np.asarray(x_val), np.asarray(y_val), context)
+            if x_val is not None and y_val is not None
+            else (None, None)
+        )
+        return controller._train_model(
+            model,
+            prepared_x,
+            prepared_y,
+            prepared_x_val,
+            prepared_y_val,
+            **params,
+        )
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.tensorflow_model import TensorFlowModelController
+        from nirs4all.core.task_type import TaskType
+
+        tf_controller = TensorFlowModelController()
+        prepared_x, prepared_y = tf_controller._prepare_data(
+            np.asarray(x_train),
+            np.asarray(y_train),
+            {},
+        )
+        prepared_x_val, prepared_y_val = (
+            tf_controller._prepare_data(
+                np.asarray(x_val),
+                np.asarray(y_val),
+                {},
+            )
+            if x_val is not None and y_val is not None
+            else (None, None)
+        )
+        if prepared_y is None:
+            raise RuntimeError("TensorFlow training data preparation dropped targets")
+        params.setdefault("task_type", TaskType.REGRESSION)
+        return tf_controller._train_model(
+            model,
+            prepared_x,
+            prepared_y,
+            prepared_x_val,
+            prepared_y_val,
+            **params,
+        )
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
+
+
+def _predict_differentiable_model(
+    controller_id: str,
+    model: Any,
+    features: Any,
+) -> np.ndarray:
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+
+        return np.asarray(
+            PyTorchModelController()._predict_model(model, np.asarray(features))
+        )
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.tensorflow_model import TensorFlowModelController
+
+        return np.asarray(
+            TensorFlowModelController()._predict_model(model, np.asarray(features))
+        )
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
 
 
 def run_model_node(
@@ -406,6 +584,7 @@ def run_model_node(
     edges: list[dict[str, Any]] | None = None,
     y_transform_node: dict[str, Any] | None = None,
     sample_metadata: dict[str, dict[str, Any]] | None = None,
+    local_implementations: Any = None,
 ) -> dict[str, Any]:
     """Execute a model-kind ``NodeTask`` with the real operator + real data; return a ``NodeResult``.
 
@@ -435,6 +614,10 @@ def run_model_node(
     # fold (the branch_view filtered it out). The model cannot fit, so emit an empty NodeResult — the
     # other partitions cover the fold, and the native concat-merge reassembles full coverage.
     if phase != "PREDICT" and not train_ids:
+        if task.get("required_loss_attestations"):
+            raise DagMlUnsupported(
+                "a required training loss cannot execute on an empty training partition"
+            )
         return _build_result(task, [], [], {}, [])
 
     estimator: Any
@@ -456,11 +639,23 @@ def run_model_node(
         multi_block = isinstance(estimator, _MultiBlockEstimator)
         source_concat = isinstance(estimator, _SourceConcatEstimator)
     else:
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            _seed_differentiable_backend(controller_id, task.get("seed"))
         model = route_graph_node(node_lookup(node_id), variant_overrides=_variant_overrides(task, node_id))
         upstream = [route_graph_node(node_lookup(upstream_id)) for upstream_id in _upstream_x_chain(node_id, edges)]
         source_chains = _source_concat_chains(node_lookup(node_id))
         source_concat = source_chains is not None
         multi_block = not source_concat and _is_multi_block_model(model) and resolver.is_multi_source()
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        } and (upstream or source_concat or multi_block or source_index is not None):
+            raise DagMlUnsupported(
+                "native differentiable model nodes currently require a single raw feature block"
+            )
         if source_concat:
             estimator = _SourceConcatEstimator(
                 model,
@@ -506,7 +701,52 @@ def run_model_node(
             y_fit = y_transform.fit_transform(y_train) if y_transform is not None else y_train
         else:
             y_fit = y_transform.fit_transform(y_train.reshape(-1, 1)).ravel() if y_transform is not None else y_train
-        estimator.fit(x_train, y_fit)
+        loss_execution = _bind_training_loss(
+            task,
+            controller_id,
+            local_implementations,
+        )
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            x_val = None
+            y_val = None
+            if phase == "FIT_CV" and predict_ids:
+                x_val = np.asarray(
+                    resolver.resolve_features(
+                        predict_ids,
+                        include_augmented=False,
+                    )["values"]
+                )
+                raw_y_val = np.asarray(
+                    resolver.resolve_targets(predict_ids)["values"],
+                    dtype=float,
+                )
+                if y_transform is not None:
+                    y_val = (
+                        y_transform.transform(raw_y_val)
+                        if raw_y_val.ndim > 1 and raw_y_val.shape[1] > 1
+                        else y_transform.transform(raw_y_val.reshape(-1, 1)).ravel()
+                    )
+                else:
+                    y_val = raw_y_val
+            estimator = _train_differentiable_model(
+                controller_id,
+                estimator,
+                x_train,
+                y_fit,
+                x_val,
+                y_val,
+                _backend_train_params(node_lookup(node_id)),
+                loss_execution,
+            )
+        else:
+            if loss_execution is not None:
+                raise DagMlUnsupported(
+                    f"controller {controller_id!r} cannot consume a DAG-ML training loss"
+                )
+            estimator.fit(x_train, y_fit)
 
     def _predict(ids: list[str], include_augmented: bool) -> list[list[float]]:
         # Predict X at the dataset's NATIVE storage dtype too (same parity reason as the fit X above):
@@ -518,7 +758,18 @@ def run_model_node(
             x = np.asarray(resolver.resolve_source_block(ids, source_index, include_augmented=include_augmented)["values"])
         else:
             x = np.asarray(resolver.resolve_features(ids, include_augmented=include_augmented)["values"])
-        pred = np.asarray(estimator.predict(x), dtype=float).reshape(len(ids), -1)
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            raw_prediction = _predict_differentiable_model(
+                controller_id,
+                estimator,
+                x,
+            )
+        else:
+            raw_prediction = estimator.predict(x)
+        pred = np.asarray(raw_prediction, dtype=float).reshape(len(ids), -1)
         scaled = np.asarray(y_transform.inverse_transform(pred), dtype=float).reshape(len(ids), -1) if y_transform is not None else pred
         return [[float(value) for value in row] for row in scaled]
 
@@ -594,11 +845,35 @@ def run_model_node(
     artifacts: list[dict[str, Any]] = []
     artifact_handles: dict[str, Any] = {}
     if phase == "REFIT":
-        model_store[artifact_handle] = {"estimator": estimator, "y_transform": y_transform}
-        artifacts.append({"id": artifact_id, "kind": "sklearn_estimator", "controller_id": controller_id, "backend": "joblib"})
+        stored_estimator = _prediction_only_refit_estimator(
+            controller_id,
+            estimator,
+            loss_execution,
+        )
+        model_store[artifact_handle] = {
+            "estimator": stored_estimator,
+            "y_transform": y_transform,
+        }
+        artifact_kind = {
+            _PYTORCH_MODEL_CONTROLLER_ID: "pytorch_model",
+            _TENSORFLOW_MODEL_CONTROLLER_ID: "tensorflow_model",
+        }.get(controller_id, "sklearn_estimator")
+        artifacts.append({"id": artifact_id, "kind": artifact_kind, "controller_id": controller_id, "backend": "joblib"})
         artifact_handles[artifact_id] = {"handle": artifact_handle, "kind": "model", "owner_controller": controller_id}
 
-    return _build_result(task, predictions, artifacts, artifact_handles, regression_targets)
+    attestations = (
+        loss_execution.loss_attestations
+        if phase != "PREDICT" and loss_execution is not None
+        else []
+    )
+    return _build_result(
+        task,
+        predictions,
+        artifacts,
+        artifact_handles,
+        regression_targets,
+        attestations,
+    )
 
 
 def _meta_feature_matrix(specs: list[dict[str, Any]], node_id: str) -> tuple[list[str], np.ndarray]:
@@ -779,6 +1054,7 @@ def run_node(
     edges: list[dict[str, Any]] | None = None,
     y_transform_node: dict[str, Any] | None = None,
     sample_metadata: dict[str, dict[str, Any]] | None = None,
+    local_implementations: Any = None,
 ) -> dict[str, Any]:
     """Dispatch a ``NodeTask`` by node kind.
 
@@ -798,5 +1074,14 @@ def run_node(
     if kind in ("model", "tuner"):
         if node_plan["controller_id"] == _META_MODEL_CONTROLLER_ID:
             return run_meta_model_node(task, resolver, node_lookup, model_store)
-        return run_model_node(task, resolver, node_lookup, model_store, edges, y_transform_node, sample_metadata)
+        return run_model_node(
+            task,
+            resolver,
+            node_lookup,
+            model_store,
+            edges,
+            y_transform_node,
+            sample_metadata,
+            local_implementations,
+        )
     return _build_result(task, [], [], {})

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 import numpy as np
 
 from nirs4all.data.dataset import SpectroDataset
-from nirs4all.pipeline.dagml_bridge import controller_manifests
+from nirs4all.pipeline.dagml_bridge import _model_controller_id, controller_manifests
 
 from .cli_runner import assemble_cv_refit_dsl
 from .envelope import build_envelope
@@ -53,6 +53,8 @@ class RawArrayDagMLTrainingCompiler:
     bundle_id: str = "bundle:nirs4all.raw_fit"
     seed: int = 12345
     dagml_module: str = "dag_ml"
+    training_losses: tuple[Mapping[str, Any], ...] = ()
+    local_implementations: Any = None
 
     def compile_fit(
         self,
@@ -82,6 +84,8 @@ class RawArrayDagMLTrainingCompiler:
             bundle_id=self.bundle_id,
             seed=self.seed,
             dagml_module=self.dagml_module,
+            training_losses=self.training_losses,
+            local_implementations=self.local_implementations,
         )
         compiler = DagMLTrainingRequestCompiler(
             contracts,
@@ -114,6 +118,8 @@ def lower_raw_array_training_contracts(
     bundle_id: str = "bundle:nirs4all.raw_fit",
     seed: int = 12345,
     dagml_module: str = "dag_ml",
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any = None,
 ) -> DagMLTrainingRequestContracts:
     """Lower a linear raw-array pipeline into executable DAG-ML contracts."""
 
@@ -136,7 +142,8 @@ def lower_raw_array_training_contracts(
     envelope["data_content_fingerprint"] = _array_content_fingerprint("X", X)
     envelope["target_content_fingerprint"] = _array_content_fingerprint("y", y)
     dsl = assemble_cv_refit_dsl(steps, identity, envelope, folds, dsl_id="nirs4all-raw-fit", n_splits=len(folds))
-    artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, controller_manifests())
+    manifests = controller_manifests()
+    artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, manifests)
     graph = artifact.graph.to_dict()
     campaign = artifact.campaign_template.to_dict()
     if campaign.get("root_seed") is None:
@@ -148,8 +155,9 @@ def lower_raw_array_training_contracts(
         plan_id=plan_id,
         graph=graph,
         campaign=campaign,
-        controller_manifests=controller_manifests(),
+        controller_manifests=manifests,
         data_identities=data_identities,
+        training_losses=training_losses,
         selection_metric=selection_metric,
         selection_objective=selection_objective,
         output_requests=output_requests,
@@ -172,7 +180,7 @@ def lower_raw_array_training_contracts(
         data_envelopes=data_envelopes,
         relations=copy.deepcopy(envelope["coordinator_relations"]),
         training_influence=training_influence,
-        op_callback=_op_callback(dataset, identity, graph),
+        op_callback=_op_callback(dataset, identity, graph, local_implementations),
         outcome_id=outcome_id,
         run_id=run_id,
         bundle_id=bundle_id,
@@ -231,7 +239,17 @@ def _supported_linear_steps(pipeline: Any) -> tuple[list[Any], Any, dict[str, st
         steps,
         context="native raw-array",
     )
-    reject_native_training_param_overrides(steps, context="native raw-array")
+    model_steps = [step for step in steps if isinstance(step, dict) and "model" in step]
+    allowed_keys = (
+        frozenset({"train_params"})
+        if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None
+        else frozenset()
+    )
+    reject_native_training_param_overrides(
+        steps,
+        context="native raw-array",
+        allowed_keys=allowed_keys,
+    )
     if splitter is None:
         raise ValueError("RawArrayDagMLTrainingCompiler requires a splitter step")
     _reject_multi_model(steps)
@@ -368,13 +386,27 @@ def _first_relation_fingerprint(campaign: Mapping[str, Any]) -> str:
     raise ValueError("campaign contains no data binding relation fingerprint")
 
 
-def _op_callback(dataset: SpectroDataset, identity: IdentityMap, graph: Mapping[str, Any]) -> Any:
+def _op_callback(
+    dataset: SpectroDataset,
+    identity: IdentityMap,
+    graph: Mapping[str, Any],
+    local_implementations: Any,
+) -> Any:
     resolver = MaterializationResolver(dataset, identity)
     nodes = {node["id"]: node for node in graph["nodes"]}
     edges = graph.get("edges", [])
     y_transform_node = next((node for node in graph["nodes"] if node["kind"] == "y_transform"), None)
     store: dict[int, Any] = {}
-    return lambda task: run_node(task, resolver, nodes.__getitem__, store, edges, y_transform_node, None)
+    return lambda task: run_node(
+        task,
+        resolver,
+        nodes.__getitem__,
+        store,
+        edges,
+        y_transform_node,
+        None,
+        local_implementations,
+    )
 
 
 def _import_dagml(module_name: str) -> Any:

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -35,6 +35,8 @@ from nirs4all.pipeline.dagml.errors import DagMlUnsupported
 # operator-selector token that keeps the meta-model manifest out of the generic model-kind catch-all.
 _META_MODEL_CONTROLLER_ID = "controller:nirs4all.meta_model"
 _META_MODEL_REF = "nirs4all.meta_model"
+_PYTORCH_MODEL_CONTROLLER_ID = "controller:nirs4all.pytorch_model"
+_TENSORFLOW_MODEL_CONTROLLER_ID = "controller:nirs4all.tensorflow_model"
 
 # Every nirs4all generation keyword (mirrors config._generator.keywords.GENERATION_KEYWORDS). Used
 # to detect a generator-shaped model sibling that this bridge does NOT lower natively, so it can fail
@@ -124,6 +126,44 @@ def _qualname(obj: Any) -> str:
     """Fully-qualified ``module.QualName`` of an instance or class."""
     cls = obj if isinstance(obj, type) else type(obj)
     return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _model_controller_id(obj: Any) -> str | None:
+    """Return the dedicated native controller for a differentiable model."""
+
+    framework = str(getattr(obj, "framework", "")).lower()
+    cls = obj if isinstance(obj, type) else type(obj)
+    modules = {
+        str(getattr(base, "__module__", "")).lower()
+        for base in getattr(cls, "__mro__", (cls,))
+    }
+    if framework in {"pytorch", "torch"} or any(
+        module == "torch" or module.startswith("torch.") for module in modules
+    ):
+        return _PYTORCH_MODEL_CONTROLLER_ID
+    if framework in {"tensorflow", "keras"} or any(
+        module == "tensorflow"
+        or module.startswith("tensorflow.")
+        or module == "keras"
+        or module.startswith("keras.")
+        for module in modules
+    ):
+        return _TENSORFLOW_MODEL_CONTROLLER_ID
+    return None
+
+
+def _json_safe_mapping(value: Any, *, name: str) -> dict[str, Any]:
+    """Round-trip one mapping through strict JSON for native task metadata."""
+
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a mapping")
+    try:
+        normalized = json.loads(json.dumps(value, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must contain only finite JSON values") from error
+    if not isinstance(normalized, dict):
+        raise TypeError(f"{name} must normalize to a JSON object")
+    return normalized
 
 
 def _json_safe_params(obj: Any) -> dict[str, Any]:
@@ -928,6 +968,17 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             # The model id is the fully-qualified class (like transforms), so any sklearn-style
             # estimator — regressor or classifier — resolves by import, not a hardcoded table.
             dsl_step: dict[str, Any] = {"model": _qualname(op), "params": _json_safe_params(op)}
+            metadata: dict[str, Any] = {}
+            controller_id = _model_controller_id(op)
+            if controller_id is not None:
+                metadata["controller_id"] = controller_id
+            if "train_params" in step:
+                metadata["nirs4all_train_params"] = _json_safe_mapping(
+                    step["train_params"],
+                    name="train_params",
+                )
+            if metadata:
+                dsl_step["metadata"] = metadata
             # Non-reserved siblings are model hyperparameters: plain values extend ``params``;
             # param-level generator dicts lower to native dag-ml ``generators`` so the compiler
             # expands variants and dag-ml runs generation + SELECT + refit natively (no Python expand).
@@ -1078,6 +1129,60 @@ def controller_manifests() -> list[dict[str, Any]]:
             "data_requirements": None,
             "capabilities": ["deterministic", "thread_safe", "process_safe", "uses_core_rng"],
             "operator_selectors": [],  # empty => bind any y_transform-kind node (the {"y_processing": …} wrapper, not the class)
+            "fit_scope": "fold_train",
+            "rng_policy": "uses_core_seed",
+            "artifact_policy": "serializable",
+        },
+        {
+            "controller_id": _PYTORCH_MODEL_CONTROLLER_ID,
+            "controller_version": _NIRS4ALL_VERSION,
+            "operator_kind": "model",
+            "priority": 10,
+            "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
+            "input_ports": [{"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}],
+            "output_ports": [
+                {"name": "y_hat", "kind": "prediction", "representation": None, "cardinality": "one"},
+                {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
+            ],
+            "data_requirements": _model_data_requirements(),
+            "capabilities": [
+                "needs_python_gil",
+                "uses_core_rng",
+                "emits_predictions",
+                "emits_artifacts",
+                "stateful",
+                "supports_configurable_loss",
+                "supports_custom_loss",
+                "supports_differentiable_loss",
+            ],
+            "operator_selectors": [{"refs": ["nirs4all.pytorch_model"]}],
+            "fit_scope": "fold_train",
+            "rng_policy": "uses_core_seed",
+            "artifact_policy": "serializable",
+        },
+        {
+            "controller_id": _TENSORFLOW_MODEL_CONTROLLER_ID,
+            "controller_version": _NIRS4ALL_VERSION,
+            "operator_kind": "model",
+            "priority": 10,
+            "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
+            "input_ports": [{"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}],
+            "output_ports": [
+                {"name": "y_hat", "kind": "prediction", "representation": None, "cardinality": "one"},
+                {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
+            ],
+            "data_requirements": _model_data_requirements(),
+            "capabilities": [
+                "needs_python_gil",
+                "uses_core_rng",
+                "emits_predictions",
+                "emits_artifacts",
+                "stateful",
+                "supports_configurable_loss",
+                "supports_custom_loss",
+                "supports_differentiable_loss",
+            ],
+            "operator_selectors": [{"refs": ["nirs4all.tensorflow_model"]}],
             "fit_scope": "fold_train",
             "rng_policy": "uses_core_seed",
             "artifact_policy": "serializable",

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 import numpy as np
@@ -17,6 +18,42 @@ from nirs4all.pipeline.dagml.raw_training_lowerer import (
     lower_raw_array_training_contracts,
     raw_arrays_to_spectro_dataset,
 )
+
+with contextlib.suppress(ImportError):
+    import torch
+
+with contextlib.suppress(ImportError):
+    import tensorflow as tf
+
+
+if "torch" in globals():
+
+    class _TinyTorchRegressor(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 1, bias=False)
+            torch.nn.init.zeros_(self.linear.weight)
+
+        def forward(self, features: Any) -> Any:
+            return self.linear(features)
+
+
+if "tf" in globals():
+
+    @tf.keras.utils.register_keras_serializable(package="nirs4all_tests")
+    class _TinyTensorFlowRegressor(tf.keras.Model):
+        def __init__(self, **kwargs: Any) -> None:
+            kwargs.setdefault("name", "tiny_tensorflow_regressor")
+            super().__init__(**kwargs)
+            self.flatten = tf.keras.layers.Flatten()
+            self.dense = tf.keras.layers.Dense(
+                1,
+                use_bias=False,
+                kernel_initializer="zeros",
+            )
+
+        def call(self, features: Any) -> Any:
+            return self.dense(self.flatten(features))
 
 
 class _FakeTrainingResult:
@@ -146,6 +183,65 @@ def test_lower_raw_array_training_contracts_rejects_step_level_train_params_unti
         lower_raw_array_training_contracts(pipeline, X, y, identity_frame=frame)
 
 
+def test_model_controller_routing_uses_framework_mro_without_substring_false_positives() -> None:
+    from nirs4all.pipeline.dagml_bridge import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+        _model_controller_id,
+    )
+
+    class _SciKerasLike:
+        pass
+
+    _SciKerasLike.__module__ = "scikeras.wrappers"
+
+    assert _model_controller_id(_SciKerasLike()) is None
+    if "torch" in globals():
+        assert _model_controller_id(_TinyTorchRegressor()) == _PYTORCH_MODEL_CONTROLLER_ID
+    if "tf" in globals():
+        assert _model_controller_id(_TinyTensorFlowRegressor()) == _TENSORFLOW_MODEL_CONTROLLER_ID
+
+
+def test_differentiable_backend_seed_maps_wide_core_seed_deterministically() -> None:
+    from nirs4all.pipeline.dagml.node_runner import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+        _seed_differentiable_backend,
+    )
+
+    seed = 2**63 + 17
+    if "torch" in globals():
+        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+        first_torch = torch.rand(3)
+        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+        assert torch.equal(first_torch, torch.rand(3))
+    if "tf" in globals():
+        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+        first_tensorflow = tf.random.uniform((3,))
+        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+        np.testing.assert_array_equal(first_tensorflow.numpy(), tf.random.uniform((3,)).numpy())
+
+
+def test_node_runner_rejects_missing_registry_and_multiple_loss_requirements() -> None:
+    from nirs4all.pipeline.dagml.node_runner import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _bind_training_loss,
+    )
+
+    task = {
+        "phase": "FIT_CV",
+        "required_loss_attestations": [{"phase": "FIT_CV", "loss_id": "loss@1"}],
+    }
+    with pytest.raises(RuntimeError, match="process-local loss registry"):
+        _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, None)
+
+    task["required_loss_attestations"].append(
+        {"phase": "FIT_CV", "loss_id": "other-loss@1"}
+    )
+    with pytest.raises(NotImplementedError, match="one training loss per task"):
+        _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, object())
+
+
 def test_raw_array_training_compiler_integrates_with_estimator_fit() -> None:
     _require_recent_dag_ml()
     X = np.arange(20, dtype=float).reshape(5, 4)
@@ -193,6 +289,234 @@ def test_raw_array_training_compiler_executes_native_training_when_supported() -
     assert estimator.training_outcome_.to_dict()["refit"]["status"] == "completed"
     assert estimator.outputs_[0]["binding"]["binding_id"] == "output:prediction"
     assert estimator.predictor_package_.to_dict()["package_id"] == "outcome:nirs4all.raw_fit-predictor"
+
+
+@pytest.mark.torch
+@pytest.mark.xdist_group("torch")
+def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -> None:
+    _require_recent_dag_ml()
+    if "torch" not in globals():
+        pytest.skip("PyTorch not available")
+    import dag_ml
+
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+
+    calls: list[tuple[tuple[int, ...], tuple[int, ...], bool, bool]] = []
+
+    def squared_loss(target: Any, prediction: Any) -> Any:
+        calls.append(
+            (
+                tuple(target.shape),
+                tuple(prediction.shape),
+                bool(target.requires_grad),
+                bool(prediction.requires_grad),
+            )
+        )
+        return torch.mean(torch.square(prediction - target))
+
+    registry = dag_ml.LocalImplementationRegistry()
+    loss_reference = registry.register_local_loss(
+        {
+            "schema_version": 1,
+            "loss_id": "example.loss.nirs4all-torch-squared@1",
+            "kind": "custom",
+            "task_kinds": ["regression"],
+            "prediction_kinds": ["regression_point"],
+            "objective": "minimize",
+            "reduction": "mean",
+            "required_inputs": ["target", "prediction"],
+            "capabilities": ["differentiable"],
+            "parameters": {},
+        },
+        squared_loss,
+        registry_key="loss:nirs4all:test-torch-squared",
+        implementation_fingerprint="a" * 64,
+        capabilities=["differentiable"],
+    )
+    bind_calls: list[tuple[str, str | None, str | None, int]] = []
+
+    class _CountingRegistry:
+        def bind_training_loss(
+            self,
+            task: dict[str, Any],
+            *,
+            role_index: int,
+        ) -> Any:
+            bind_calls.append(
+                (
+                    task["phase"],
+                    task.get("fold_id"),
+                    task.get("variant_id"),
+                    role_index,
+                )
+            )
+            return registry.bind_training_loss(task, role_index=role_index)
+
+    role = {
+        "schema_version": 1,
+        "node_id": "model:compat.0",
+        "output_id": "oof",
+        "phases": ["FIT_CV", "REFIT"],
+        "loss": loss_reference,
+    }
+    estimator = DagMLPipelineEstimator(
+        pipeline=[
+            KFold(n_splits=2),
+            {
+                "model": _TinyTorchRegressor(),
+                "train_params": {
+                    "epochs": 1,
+                    "batch_size": 2,
+                    "optimizer": "SGD",
+                    "learning_rate": 0.1,
+                    "patience": 1,
+                    "verbose": 0,
+                },
+            },
+        ],
+        training_compiler=RawArrayDagMLTrainingCompiler(
+            dagml_module="dag_ml",
+            training_losses=(role,),
+            local_implementations=_CountingRegistry(),
+        ),
+        dagml_module="dag_ml",
+    )
+    X = np.ones((6, 2), dtype=np.float32)
+    y = np.ones(6, dtype=np.float32)
+
+    estimator.fit(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    assert calls
+    assert all(not target_requires_grad for _, _, target_requires_grad, _ in calls)
+    assert any(prediction_requires_grad for _, _, _, prediction_requires_grad in calls)
+    assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
+    assert all(role_index == 0 for _, _, _, role_index in bind_calls)
+    outcome = estimator.training_outcome_.to_dict()
+    model_lineage = [
+        record
+        for record in outcome["lineage"]
+        if record["node_id"] == "model:compat.0"
+        and record["phase"] in {"FIT_CV", "REFIT"}
+    ]
+    assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
+    assert all(
+        [attestation["loss_id"] for attestation in record["loss_attestations"]]
+        == ["example.loss.nirs4all-torch-squared@1"]
+        for record in model_lineage
+    )
+    assert outcome["execution_bundle"]["refit_artifacts"][0][
+        "training_loss_fingerprint"
+    ]
+
+
+@pytest.mark.tensorflow
+@pytest.mark.xdist_group("tensorflow")
+def test_raw_array_training_executes_local_tensorflow_loss_and_detaches_refit_artifact() -> None:
+    _require_recent_dag_ml()
+    if "tf" not in globals():
+        pytest.skip("TensorFlow not available")
+    import dag_ml
+
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+
+    calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def squared_loss(target: Any, prediction: Any) -> Any:
+        calls.append((tuple(target.shape), tuple(prediction.shape)))
+        return tf.reduce_mean(tf.square(prediction - target))
+
+    registry = dag_ml.LocalImplementationRegistry()
+    loss_reference = registry.register_local_loss(
+        {
+            "schema_version": 1,
+            "loss_id": "example.loss.nirs4all-tensorflow-squared@1",
+            "kind": "custom",
+            "task_kinds": ["regression"],
+            "prediction_kinds": ["regression_point"],
+            "objective": "minimize",
+            "reduction": "mean",
+            "required_inputs": ["target", "prediction"],
+            "capabilities": ["differentiable"],
+            "parameters": {},
+        },
+        squared_loss,
+        registry_key="loss:nirs4all:test-tensorflow-squared",
+        implementation_fingerprint="b" * 64,
+        capabilities=["differentiable"],
+    )
+    bind_calls: list[tuple[str, str | None, str | None, int]] = []
+
+    class _CountingRegistry:
+        def bind_training_loss(
+            self,
+            task: dict[str, Any],
+            *,
+            role_index: int,
+        ) -> Any:
+            bind_calls.append(
+                (
+                    task["phase"],
+                    task.get("fold_id"),
+                    task.get("variant_id"),
+                    role_index,
+                )
+            )
+            return registry.bind_training_loss(task, role_index=role_index)
+
+    estimator = DagMLPipelineEstimator(
+        pipeline=[
+            KFold(n_splits=2),
+            {
+                "model": _TinyTensorFlowRegressor(),
+                "train_params": {
+                    "epochs": 1,
+                    "batch_size": 2,
+                    "optimizer": "sgd",
+                    "learning_rate": 0.1,
+                    "patience": 1,
+                    "best_model_memory": False,
+                    "verbose": 0,
+                },
+            },
+        ],
+        training_compiler=RawArrayDagMLTrainingCompiler(
+            dagml_module="dag_ml",
+            training_losses=(
+                {
+                    "schema_version": 1,
+                    "node_id": "model:compat.0",
+                    "output_id": "oof",
+                    "phases": ["FIT_CV", "REFIT"],
+                    "loss": loss_reference,
+                },
+            ),
+            local_implementations=_CountingRegistry(),
+        ),
+        dagml_module="dag_ml",
+    )
+    X = np.ones((6, 2), dtype=np.float32)
+    y = np.ones(6, dtype=np.float32)
+
+    estimator.fit(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    assert calls
+    assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
+    assert all(role_index == 0 for _, _, _, role_index in bind_calls)
+    outcome = estimator.training_outcome_.to_dict()
+    model_lineage = [
+        record
+        for record in outcome["lineage"]
+        if record["node_id"] == "model:compat.0"
+        and record["phase"] in {"FIT_CV", "REFIT"}
+    ]
+    assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
+    assert all(
+        [attestation["loss_id"] for attestation in record["loss_attestations"]]
+        == ["example.loss.nirs4all-tensorflow-squared@1"]
+        for record in model_lineage
+    )
 
 
 def test_raw_array_training_compiler_executes_native_deterministic_finetune_when_supported() -> None:


### PR DESCRIPTION
## Summary
- declare dedicated native PyTorch and TensorFlow DAG-ML controllers with truthful configurable/custom/differentiable loss capabilities
- transport training loss roles into native requests, bind process-local implementations once per callback task, and emit exact NodeResult loss attestations after successful execution
- train native FIT_CV/REFIT tasks through the existing backend controllers, apply DAG-ML core seeds, preserve backend data layouts, and detach TensorFlow process-local compile state before refit storage
- keep sklearn on its existing controller and reject unsupported step-level training parameters

## Validation
- `ruff check` on all five changed files
- targeted `mypy` on four source files: no local errors; existing `nirs4all/api/tuning.py` three-symbol baseline remains
- 44 focused tests passed against the DAG-ML loss-runtime worktree: raw native training, node-runner parity, training contracts, PyTorch controller, TensorFlow controller
- independent review completed; initial findings addressed and re-review returned no findings

## Stack
- base: #49 (`agent/loss-tensorflow-controller`)
- native DAG-ML loss runtime: GBeurier/dag-ml#24