### PR TITLE
feat(dagml): route process-local training losses

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -80,7 +80,12 @@ jobs:
             grep -v -E '^(jax|jaxlib|flax)' requirements-test.txt > requirements-test-filtered.txt
             python -m pip install numpy -r requirements-test-filtered.txt
           else
-            python -m pip install numpy -r requirements-test.txt
+            # PyPI's Linux wheel now pulls CUDA/Triton dependencies even on the
+            # CPU runner. The official CPU wheel avoids that unstable runtime.
+            grep -v '^torch' requirements-test.txt > requirements-test-filtered.txt
+            python -m pip install numpy -r requirements-test-filtered.txt
+            python -m pip install --index-url https://download.pytorch.org/whl/cpu \
+              'torch==2.13.0+cpu'
           fi
 
       - name: Install package (editable, no-deps — deps already from requirements-test.txt)
@@ -111,6 +116,8 @@ jobs:
               -m tensorflow \
               tests/unit/operators/models/test_tensorflow.py \
               tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+            python -m pytest -v --timeout=300 \
+              -m jax tests/unit/operators/models/test_jax.py
             python -m pytest -v -n auto --dist worksteal --timeout=300 \
               -m "not torch and not tensorflow and not keras and not jax" tests/unit/
           fi

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,10 +100,12 @@ jobs:
             # macOS: run serially to avoid fork() deadlocks
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/unit/
           else
-            # ``loadgroup`` honors @pytest.mark.xdist_group. This keeps native
-            # deep-learning runtimes in one worker instead of concurrently
-            # initializing PyTorch/TensorFlow in separate workers.
-            python -m pytest -v -n auto --dist loadgroup --timeout=300 tests/unit/
+            # Native DL runtimes are process-global and unsafe under concurrent
+            # xdist workers. Exercise them serially, then keep the remainder fast.
+            python -m pytest -v --timeout=300 \
+              -m "torch or tensorflow or keras or jax" tests/unit/
+            python -m pytest -v -n auto --dist worksteal --timeout=300 \
+              -m "not torch and not tensorflow and not keras and not jax" tests/unit/
           fi
 
       - name: Run quick integration pytest
@@ -125,8 +127,14 @@ jobs:
               tests/integration/pipeline/test_merge_mixed.py \
               tests/integration/pipeline/test_merge_per_branch.py
 
+            # Native DL replays persist framework artifacts and must not share
+            # xdist workers with another initialized framework runtime.
+            python -m pytest -v --timeout=300 \
+              -m "torch or tensorflow or keras or jax" tests/integration/pipeline/
+
             # Parallel remainder
             python -m pytest -v -n auto --dist worksteal --timeout=300 tests/integration/pipeline/ \
+              -m "not torch and not tensorflow and not keras and not jax" \
               --ignore=tests/integration/pipeline/test_merge_mixed.py \
               --ignore=tests/integration/pipeline/test_merge_per_branch.py
           fi

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,10 +100,17 @@ jobs:
             # macOS: run serially to avoid fork() deadlocks
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/unit/
           else
-            # Native DL runtimes are process-global and unsafe under concurrent
-            # xdist workers. Exercise them serially, then keep the remainder fast.
+            # TensorFlow and PyTorch both claim process-global native state. Run
+            # each framework's explicit test files in a fresh interpreter; marker
+            # selection over tests/unit would still import every test module.
             python -m pytest -v --timeout=300 \
-              -m "torch or tensorflow or keras or jax" tests/unit/
+              -m torch \
+              tests/unit/operators/models/test_pytorch.py \
+              tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+            python -m pytest -v --timeout=300 \
+              -m tensorflow \
+              tests/unit/operators/models/test_tensorflow.py \
+              tests/unit/pipeline/dagml/test_raw_training_lowerer.py
             python -m pytest -v -n auto --dist worksteal --timeout=300 \
               -m "not torch and not tensorflow and not keras and not jax" tests/unit/
           fi
@@ -127,10 +134,12 @@ jobs:
               tests/integration/pipeline/test_merge_mixed.py \
               tests/integration/pipeline/test_merge_per_branch.py
 
-            # Native DL replays persist framework artifacts and must not share
-            # xdist workers with another initialized framework runtime.
+            # Keep TensorFlow persistence/replay tests in their own interpreter.
             python -m pytest -v --timeout=300 \
-              -m "torch or tensorflow or keras or jax" tests/integration/pipeline/
+              -m tensorflow \
+              tests/integration/pipeline/test_classification_integration.py \
+              tests/integration/pipeline/test_finetune_integration.py \
+              tests/integration/pipeline/test_prediction_reuse_integration.py
 
             # Parallel remainder
             python -m pytest -v -n auto --dist worksteal --timeout=300 tests/integration/pipeline/ \

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -100,7 +100,10 @@ jobs:
             # macOS: run serially to avoid fork() deadlocks
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/unit/
           else
-            python -m pytest -v -n auto --dist worksteal --timeout=300 tests/unit/
+            # ``loadgroup`` honors @pytest.mark.xdist_group. This keeps native
+            # deep-learning runtimes in one worker instead of concurrently
+            # initializing PyTorch/TensorFlow in separate workers.
+            python -m pytest -v -n auto --dist loadgroup --timeout=300 tests/unit/
           fi
 
       - name: Run quick integration pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.11.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ If you use NIRS4ALL in your research, please cite:
   author = {Gregory Beurier and Denis Cornet and Lauriane Rouan},
   title = {NIRS4ALL: Open spectroscopy for everyone},
   url = {https://github.com/GBeurier/nirs4all},
-  version = {0.11.0},
+  version = {0.12.0},
   year = {2026},
 }
 ```

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.11.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/nirs4all/api/result.py
+++ b/nirs4all/api/result.py
@@ -813,6 +813,11 @@ class RunResult:
     # default (the writer fires solely when native results are enabled).
     _dagml_refit_artifacts: list[dict[str, Any]] = field(default_factory=list, repr=False)
 
+    # Native dag-ml node results retained for controller-level audit attestations
+    # (including process-local training losses). They are in-memory metadata only
+    # and empty for legacy results.
+    _dagml_node_results: list[dict[str, Any]] = field(default_factory=list, repr=False)
+
     # The on-disk native results directory the 2b-i writer produced for this dag-ml run (recorded by
     # ``run_via_dagml`` when native results were enabled; ``None`` for an in-memory-only dag-ml run or a
     # legacy result). It holds ``manifest.json`` + ``score_set.json`` + ``predictions.parquet`` + the

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -220,6 +220,8 @@ def run(
     tuning: Any | None = None,
     calibration: Any | None = None,
     results_path: str | Path | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
     # All other PipelineRunner options
     **runner_kwargs: Any,
 ) -> "RunResult | TunedSingleEstimatorConformalResult":
@@ -331,6 +333,15 @@ def run(
             an explicit ``results_path`` is threaded as a named ``run()`` parameter (not a runner_kwarg),
             so it bypasses the dag-ml runner_kwarg allowlist. It has no effect on ``engine="legacy"``.
 
+        training_losses: DAG-ML-native training loss role references for
+            process-local custom training losses. This is honored only with
+            ``engine="dag-ml"`` and must be paired with ``local_implementations``.
+
+        local_implementations: Process-local DAG-ML implementation registry
+            (for Python, typically ``dag_ml.LocalImplementationRegistry``) used
+            to bind ``training_losses`` to callable custom losses. It cannot be
+            serialized or forwarded to the legacy backend.
+
         **runner_kwargs: Additional PipelineRunner parameters. See
             PipelineRunner.__init__ for full list. Common options:
             - workspace_path: Workspace root directory
@@ -433,6 +444,9 @@ def run(
         - :func:`nirs4all.session`: Create execution session for resource reuse
         - :class:`nirs4all.PipelineRunner`: Direct runner access for advanced use
     """
+    custom_training_loss_requested = bool(training_losses) or local_implementations is not None
+    if custom_training_loss_requested and resolve_engine(engine) != "dag-ml":
+        raise ValueError("training_losses/local_implementations require engine='dag-ml'")
 
     if calibration is not None:
         if tuning is None:
@@ -446,6 +460,12 @@ def run(
         tuning["calibration"] = _coerce_public_runtime_payload(calibration)
 
     if tuning is not None:
+        if custom_training_loss_requested:
+            raise NotImplementedError(
+                "run(tuning=...) does not yet thread DAG-ML process-local training losses; "
+                "use a concrete engine='dag-ml' pipeline until the native tuning adapter binds "
+                "training_losses and local_implementations."
+            )
         tuning = _coerce_public_tuning_payload(tuning)
         if resolve_engine(engine) == "dag-ml":
             return _run_single_estimator_tuning_subset(
@@ -656,14 +676,20 @@ def run(
                 cache=cache,
                 runner_kwargs=runner_kwargs,
                 results_path=results_path,
+                training_losses=training_losses,
+                local_implementations=local_implementations,
             )
         except DagMlUnavailable as e:
+            if custom_training_loss_requested:
+                raise
             warnings.warn(
                 f"the dag-ml backend is not available ({e}); falling back to the legacy engine",
                 stacklevel=2,
             )
             return _run_legacy()
         except (DagMlUnsupported, NotImplementedError) as e:
+            if custom_training_loss_requested:
+                raise
             warnings.warn(
                 f"engine='dag-ml' does not support this pipeline shape ({e}); falling back to the legacy engine",
                 stacklevel=2,

--- a/nirs4all/controllers/models/tensorflow_model.py
+++ b/nirs4all/controllers/models/tensorflow_model.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 from nirs4all.controllers.registry import register_controller
 from nirs4all.core.logging import get_logger
 from nirs4all.core.task_type import TaskType
+from nirs4all.pipeline.dagml.loss_runtime import DagMLTrainingLossExecution
 from nirs4all.pipeline.storage.artifacts.artifact_persistence import ArtifactMeta
 from nirs4all.utils.backend import is_available, is_gpu_available, require_backend
 
@@ -60,6 +61,12 @@ def _get_keras():
     if 'keras' not in _tf_modules:
         _get_tf()  # This will populate the cache
     return _tf_modules['keras']
+
+def _resolve_loss_function(loss_config: Any) -> Any:
+    """Resolve a configured Keras loss while preserving DAG-ML semantics."""
+    if isinstance(loss_config, DagMLTrainingLossExecution):
+        return loss_config.invoke_target_prediction
+    return loss_config
 
 @register_controller
 class TensorFlowModelController(BaseModelController):
@@ -314,6 +321,7 @@ class TensorFlowModelController(BaseModelController):
 
         # 1. Prepare compilation configuration
         compile_config = TensorFlowCompilationConfig.prepare(train_params, task_type)
+        compile_config['loss'] = _resolve_loss_function(compile_config['loss'])
         model.compile(**compile_config)
         if verbose > 2:
             print(f"   Compilation config: {compile_config}")
@@ -685,4 +693,3 @@ class TensorFlowModelController(BaseModelController):
 
         # Call parent execute method
         return super().execute(step_info, dataset, context, runtime_context, source, mode, loaded_binaries, prediction_store)
-

--- a/nirs4all/controllers/models/torch_model.py
+++ b/nirs4all/controllers/models/torch_model.py
@@ -21,6 +21,7 @@ import numpy as np
 
 from nirs4all.controllers.registry import register_controller
 from nirs4all.core.logging import get_logger
+from nirs4all.pipeline.dagml.loss_runtime import DagMLTrainingLossExecution
 from nirs4all.utils.backend import is_available, is_gpu_available, require_backend
 
 from ..models.base_model import BaseModelController
@@ -65,6 +66,8 @@ def _get_nn():
 
 def _resolve_loss_function(loss_config: Any, nn: Any) -> Any:
     """Resolve a configured PyTorch loss without silently changing intent."""
+    if isinstance(loss_config, DagMLTrainingLossExecution):
+        return loss_config.invoke_prediction_target
     if not isinstance(loss_config, str):
         return loss_config
 

--- a/nirs4all/controllers/models/torch_model.py
+++ b/nirs4all/controllers/models/torch_model.py
@@ -63,6 +63,27 @@ def _get_nn():
         _get_torch()
     return _torch_modules['nn']
 
+def _resolve_loss_function(loss_config: Any, nn: Any) -> Any:
+    """Resolve a configured PyTorch loss without silently changing intent."""
+    if not isinstance(loss_config, str):
+        return loss_config
+
+    aliases = {
+        'mse': nn.MSELoss,
+        'mae': nn.L1Loss,
+        'crossentropy': nn.CrossEntropyLoss,
+    }
+    loss_class = aliases.get(loss_config.lower())
+    if loss_class is None and hasattr(nn, loss_config):
+        loss_class = getattr(nn, loss_config)
+    if loss_class is None:
+        raise ValueError(
+            f"Unknown PyTorch loss {loss_config!r}. "
+            "Use a torch.nn loss class name, one of the aliases "
+            "'mse', 'mae', or 'crossentropy', or pass a callable."
+        )
+    return loss_class()
+
 @register_controller
 class PyTorchModelController(BaseModelController):
     """Controller for PyTorch models.
@@ -194,21 +215,7 @@ class PyTorchModelController(BaseModelController):
             optimizer = optimizer_config
 
         # Setup loss function
-        loss_fn_config = train_params.get('loss', 'MSELoss')
-        if isinstance(loss_fn_config, str):
-            # Handle common loss names
-            if loss_fn_config.lower() == 'mse':
-                loss_fn = nn.MSELoss()
-            elif loss_fn_config.lower() == 'mae':
-                loss_fn = nn.L1Loss()
-            elif loss_fn_config.lower() == 'crossentropy':
-                loss_fn = nn.CrossEntropyLoss()
-            elif hasattr(nn, loss_fn_config):
-                loss_fn = getattr(nn, loss_fn_config)()
-            else:
-                loss_fn = nn.MSELoss() # Default
-        else:
-            loss_fn = loss_fn_config
+        loss_fn = _resolve_loss_function(train_params.get('loss', 'MSELoss'), nn)
 
         # Training parameters
         epochs = train_params.get('epochs', 100)

--- a/nirs4all/pipeline/dagml/__init__.py
+++ b/nirs4all/pipeline/dagml/__init__.py
@@ -7,12 +7,16 @@ import-guarded — production ``nirs4all`` never imports this unless the dag-ml
 backend is selected. See ``dag-ml/docs/migration-nirs4all/``.
 """
 
+from .loss_runtime import DagMLTrainingLossExecution
+
 __all__ = [
+    "DagMLTrainingLossExecution",
     "conformal_contracts",
     "conformal_store",
     "estimator",
     "finetune_lowering",
     "fit_identity",
+    "loss_runtime",
     "native_client",
     "pipeline_objective",
     "pipeline_objective_compiler",

--- a/nirs4all/pipeline/dagml/finetune_lowering.py
+++ b/nirs4all/pipeline/dagml/finetune_lowering.py
@@ -24,13 +24,15 @@ def reject_native_training_param_overrides(
     steps: list[Any],
     *,
     context: str = "native DAG-ML",
+    allowed_keys: frozenset[str] = frozenset(),
 ) -> None:
     """Reject fit/refit kwargs that native DAG-ML would otherwise ignore."""
 
+    rejected_keys = UNSUPPORTED_NATIVE_TRAINING_PARAM_KEYS - allowed_keys
     hits: list[str] = []
     for step in steps:
         if isinstance(step, dict):
-            hits.extend(sorted(UNSUPPORTED_NATIVE_TRAINING_PARAM_KEYS & set(step)))
+            hits.extend(sorted(rejected_keys & set(step)))
     if hits:
         raise NotImplementedError(f"{context} does not yet support step-level {sorted(set(hits))}; running natively would ignore fit/refit arguments instead of preserving legacy parity.")
 

--- a/nirs4all/pipeline/dagml/in_process_runner.py
+++ b/nirs4all/pipeline/dagml/in_process_runner.py
@@ -23,11 +23,13 @@ from __future__ import annotations
 import json
 import os
 import pickle
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
 from nirs4all.pipeline.dagml_bridge import controller_manifests
 
+from .errors import DagMlUnsupported
 from .identity import mint_identity
 from .node_runner import run_node
 from .resolver import MaterializationResolver
@@ -102,6 +104,8 @@ def run_cv_refit_bundle(
     dataset_pickle: str | None = None,
     dataset: Any | None = None,
     fold_children: dict[str, dict[int, list[int]]] | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> dict[str, Any]:
     """Run a CV+refit bundle IN-PROCESS; return ``{returncode, stdout, results, scores}``.
 
@@ -122,6 +126,10 @@ def run_cv_refit_bundle(
     reloadable path's, verified in :func:`dataset._dataset_inputs`) and, for augmentation / rep-fusion,
     it IS the object that was pickled for the subprocess — so the resolver is byte-identical to the
     reload/pickle path. When ``dataset`` is ``None`` the dataset is loaded per :func:`_load_dataset`.
+
+    ``training_losses`` are DAG-ML-native role references. They stay contract data; only
+    ``local_implementations`` is process-local executable state, and it is passed solely to the
+    Python node runner callback for ``FIT_CV`` / ``REFIT`` model tasks.
     """
     import importlib
 
@@ -143,17 +151,37 @@ def run_cv_refit_bundle(
     edges = graph.get("edges", [])
     y_transform_node = next((node for node in graph["nodes"] if node["kind"] == "y_transform"), None)
     store: dict[int, Any] = {}
-    op_callback = lambda task: run_node(task, resolver, nodes.__getitem__, store, edges, y_transform_node, sample_metadata)  # noqa: E731
+    op_callback = lambda task: run_node(task, resolver, nodes.__getitem__, store, edges, y_transform_node, sample_metadata, local_implementations)  # noqa: E731
 
-    payload = json.loads(
-        dag_ml_ext.run_cv_refit_in_process(
+    if training_losses:
+        run_with_training_losses = getattr(
+            dag_ml_ext,
+            "run_cv_refit_in_process_with_training_losses",
+            None,
+        )
+        if not callable(run_with_training_losses):
+            raise DagMlUnsupported(
+                "installed dag_ml._dag_ml does not expose "
+                "run_cv_refit_in_process_with_training_losses; rebuild dag-ml with native "
+                "training-loss execution-plan binding."
+            )
+        payload_json = run_with_training_losses(
+            json.dumps(dsl),
+            json.dumps(envelope),
+            json.dumps(controller_manifests()),
+            json.dumps(list(training_losses)),
+            op_callback,
+            selection_metric,
+        )
+    else:
+        payload_json = dag_ml_ext.run_cv_refit_in_process(
             json.dumps(dsl),
             json.dumps(envelope),
             json.dumps(controller_manifests()),
             op_callback,
             selection_metric,
         )
-    )
+    payload = json.loads(payload_json)
     node_results = payload.get("node_results", [])
     return {
         "returncode": 0,
@@ -229,6 +257,8 @@ def run_cv_refit_bundle_router(
     dataset: Any | None = None,
     fold_children: dict[str, dict[int, list[int]]] | None = None,
     random_state: int | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> dict[str, Any]:
     """Route a CV+refit bundle run to the in-process (Mechanism B) or subprocess (Mechanism A) runner.
 
@@ -263,6 +293,10 @@ def run_cv_refit_bundle_router(
     branch ignores it: it fits operators in THIS process, whose global RNG ``run_via_dagml`` already
     seeded — so re-seeding here would be redundant.
     """
+    if local_implementations is not None and not training_losses:
+        raise DagMlUnsupported("local_implementations was supplied without DAG-ML training_losses")
+    if training_losses and local_implementations is None:
+        raise DagMlUnsupported("DAG-ML training_losses require a process-local implementation registry")
     if in_process_enabled() and _dagml_extension_loads():
         return run_cv_refit_bundle(
             dsl=dsl,
@@ -274,9 +308,16 @@ def run_cv_refit_bundle_router(
             dataset_pickle=dataset_pickle,
             dataset=dataset,
             fold_children=fold_children,
+            training_losses=training_losses,
+            local_implementations=local_implementations,
         )
 
     # Subprocess branch (Mechanism A): either in-process was disabled or its extension did not load.
+    if training_losses:
+        raise DagMlUnsupported(
+            "DAG-ML process-local training losses require the in-process backend; "
+            "the subprocess adapter cannot receive local callables."
+        )
     # The dag-ml-cli existence check belongs HERE (not at the run() entry) so an in-process-capable
     # wheel never requires the sibling cargo-built CLI; a missing CLI here means NEITHER mechanism is
     # available, so raise DagMlUnavailable for run() to fall back to legacy with a warning.

--- a/nirs4all/pipeline/dagml/in_process_runner.py
+++ b/nirs4all/pipeline/dagml/in_process_runner.py
@@ -2,8 +2,8 @@
 
 ``cli_runner.run_cv_refit_bundle`` drives ``dag-ml-cli`` as a SUBPROCESS: it writes the DSL /
 envelope / graph to disk, launches the process adapter, and reads back ``bundle.json``. This module
-runs the SAME campaign IN-PROCESS through the PyO3 bridge (``dag_ml._dag_ml.run_cv_refit_in_process``)
-— no subprocess, no per-call import tax. The bridge owns the data path (the SAME envelope-based Rust
+runs the SAME campaign IN-PROCESS through the DAG-ML Python facade
+(``dag_ml.run_cv_refit_in_process``) — no subprocess, no per-call import tax. The bridge owns the data path (the SAME envelope-based Rust
 ``InMemoryDataProvider`` the CLI uses, so the per-fold ``data_views``/``sample_ids`` are produced
 IDENTICALLY); only operator execution crosses back to Python, through an ``op_callback`` that closes
 over the SAME :func:`node_runner.run_node` the subprocess adapter calls.
@@ -93,6 +93,40 @@ def _load_dataset(dataset_path: str, dataset_pickle: str | None) -> tuple[Any, d
     return DatasetConfigs(dataset_path).get_dataset_at(0), None
 
 
+def _dagml_in_process_runner(name: str) -> tuple[Any, bool]:
+    """Return a DAG-ML in-process runner and whether it is the public facade.
+
+    dag-ml PR #31 exposes these functions on the typed Python facade and returns
+    decoded dictionaries. Older wheels only expose the private extension symbols,
+    which return JSON strings; keep that fallback until the DAG-ML stack is fully
+    released and pinned.
+    """
+    import importlib
+
+    dag_ml = importlib.import_module("dag_ml")
+    runner = getattr(dag_ml, name, None)
+    if callable(runner):
+        return runner, True
+    dag_ml_ext = importlib.import_module("dag_ml._dag_ml")
+    runner = getattr(dag_ml_ext, name, None)
+    if callable(runner):
+        return runner, False
+    raise DagMlUnsupported(
+        f"installed dag_ml does not expose {name}; rebuild dag-ml with native "
+        "in-process scheduler bindings."
+    )
+
+
+def _decode_dagml_runner_payload(payload: Any) -> dict[str, Any]:
+    if isinstance(payload, str):
+        decoded = json.loads(payload)
+    else:
+        decoded = payload
+    if not isinstance(decoded, dict):
+        raise TypeError(f"dag_ml in-process runner returned {type(payload).__name__}, expected dict or JSON object")
+    return decoded
+
+
 def run_cv_refit_bundle(
     *,
     dsl: dict[str, Any],
@@ -131,12 +165,6 @@ def run_cv_refit_bundle(
     ``local_implementations`` is process-local executable state, and it is passed solely to the
     Python node runner callback for ``FIT_CV`` / ``REFIT`` model tasks.
     """
-    import importlib
-
-    # The compiled PyO3 extension `dag_ml._dag_ml` is not re-exported by the package facade and
-    # ships no stub, so import it dynamically (the facade only wraps the control-plane JSON fns).
-    dag_ml_ext = importlib.import_module("dag_ml._dag_ml")
-
     if dataset is None:
         dataset, fold_children = _load_dataset(dataset_path, dataset_pickle)
     if sample_metadata is None:
@@ -154,34 +182,31 @@ def run_cv_refit_bundle(
     op_callback = lambda task: run_node(task, resolver, nodes.__getitem__, store, edges, y_transform_node, sample_metadata, local_implementations)  # noqa: E731
 
     if training_losses:
-        run_with_training_losses = getattr(
-            dag_ml_ext,
-            "run_cv_refit_in_process_with_training_losses",
-            None,
-        )
-        if not callable(run_with_training_losses):
-            raise DagMlUnsupported(
-                "installed dag_ml._dag_ml does not expose "
-                "run_cv_refit_in_process_with_training_losses; rebuild dag-ml with native "
-                "training-loss execution-plan binding."
+        runner, is_facade = _dagml_in_process_runner("run_cv_refit_in_process_with_training_losses")
+        if is_facade:
+            payload = runner(dsl, envelope, controller_manifests(), list(training_losses), op_callback, selection_metric)
+        else:
+            payload = runner(
+                json.dumps(dsl),
+                json.dumps(envelope),
+                json.dumps(controller_manifests()),
+                json.dumps(list(training_losses)),
+                op_callback,
+                selection_metric,
             )
-        payload_json = run_with_training_losses(
-            json.dumps(dsl),
-            json.dumps(envelope),
-            json.dumps(controller_manifests()),
-            json.dumps(list(training_losses)),
-            op_callback,
-            selection_metric,
-        )
     else:
-        payload_json = dag_ml_ext.run_cv_refit_in_process(
-            json.dumps(dsl),
-            json.dumps(envelope),
-            json.dumps(controller_manifests()),
-            op_callback,
-            selection_metric,
-        )
-    payload = json.loads(payload_json)
+        runner, is_facade = _dagml_in_process_runner("run_cv_refit_in_process")
+        if is_facade:
+            payload = runner(dsl, envelope, controller_manifests(), op_callback, selection_metric)
+        else:
+            payload = runner(
+                json.dumps(dsl),
+                json.dumps(envelope),
+                json.dumps(controller_manifests()),
+                op_callback,
+                selection_metric,
+            )
+    payload = _decode_dagml_runner_payload(payload)
     node_results = payload.get("node_results", [])
     return {
         "returncode": 0,

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -1,0 +1,100 @@
+"""Process-local execution handoff for DAG-ML training losses."""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any
+
+
+class DagMLTrainingLossExecution:
+    """Bind one native ``NodeTask`` loss requirement to its local registry.
+
+    The object is deliberately process-local. It keeps executable state out of
+    DAG-ML contracts while allowing backend controllers to invoke the exact
+    callback selected for one ``FIT_CV`` or ``REFIT`` task.
+    """
+
+    __slots__ = (
+        "_attestation",
+        "_invocation_count",
+        "_invoke",
+        "_phase",
+        "_required_attestation",
+    )
+
+    def __init__(
+        self,
+        task: Mapping[str, Any],
+        registry: Any,
+        *,
+        role_index: int = 0,
+    ) -> None:
+        if not isinstance(task, Mapping):
+            raise TypeError("DAG-ML training loss task must be a mapping")
+        phase = task.get("phase")
+        if phase not in {"FIT_CV", "REFIT"}:
+            raise ValueError("DAG-ML training losses can execute only in FIT_CV or REFIT")
+        bind_training_loss = getattr(registry, "bind_training_loss", None)
+        if not callable(bind_training_loss):
+            raise TypeError("DAG-ML loss registry must expose bind_training_loss()")
+        if isinstance(role_index, bool) or not isinstance(role_index, int) or role_index < 0:
+            raise ValueError("DAG-ML training loss role_index must be a non-negative integer")
+
+        binding = bind_training_loss(
+            copy.deepcopy(dict(task)),
+            role_index=role_index,
+        )
+        if not isinstance(binding, Mapping):
+            raise TypeError("DAG-ML loss registry returned a non-mapping binding")
+        invoke = binding.get("invoke")
+        required_attestation = binding.get("required_attestation")
+        if not callable(invoke) or not isinstance(required_attestation, Mapping):
+            raise ValueError("DAG-ML loss binding lacks invoke or required_attestation")
+        if required_attestation.get("phase") != phase:
+            raise ValueError("DAG-ML loss binding attestation phase does not match its task")
+
+        self._invoke = invoke
+        self._phase = str(phase)
+        self._required_attestation = copy.deepcopy(dict(required_attestation))
+        self._attestation: dict[str, Any] | None = None
+        self._invocation_count = 0
+
+    @property
+    def phase(self) -> str:
+        """Return the task phase bound to this execution."""
+
+        return self._phase
+
+    @property
+    def invocation_count(self) -> int:
+        """Return the number of successful local callback invocations."""
+
+        return self._invocation_count
+
+    @property
+    def loss_attestations(self) -> list[dict[str, Any]]:
+        """Return the attestation only after at least one successful invocation."""
+
+        if self._attestation is None:
+            return []
+        return [copy.deepcopy(self._attestation)]
+
+    def __call__(self, target: Any, prediction: Any, *args: Any, **kwargs: Any) -> Any:
+        """Invoke the semantic ``(target, prediction)`` DAG-ML loss callback."""
+
+        value = self._invoke(target, prediction, *args, **kwargs)
+        self._attestation = copy.deepcopy(self._required_attestation)
+        self._invocation_count += 1
+        return value
+
+    def invoke_prediction_target(self, prediction: Any, target: Any) -> Any:
+        """Adapt a backend ``(prediction, target)`` call to semantic ordering."""
+
+        return self(target, prediction)
+
+    def __reduce__(self) -> Any:
+        raise TypeError("DAG-ML training loss executions cannot be serialized")
+
+
+__all__ = ["DagMLTrainingLossExecution"]

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -40,20 +40,20 @@ class DagMLTrainingLossExecution:
             raise TypeError("DAG-ML loss registry must expose bind_training_loss()")
         if isinstance(role_index, bool) or not isinstance(role_index, int) or role_index < 0:
             raise ValueError("DAG-ML training loss role_index must be a non-negative integer")
-        expected_attestations = task.get("required_loss_attestations") or ()
-        expected_attestation: dict[str, Any] | None = None
-        if expected_attestations:
-            if not isinstance(expected_attestations, Sequence) or isinstance(
-                expected_attestations,
-                (str, bytes),
-            ):
-                raise TypeError("DAG-ML required_loss_attestations must be a sequence")
-            if role_index >= len(expected_attestations):
-                raise ValueError("DAG-ML training loss role_index is outside required_loss_attestations")
-            expected = expected_attestations[role_index]
-            if not isinstance(expected, Mapping):
-                raise TypeError("DAG-ML required loss attestation must be a mapping")
-            expected_attestation = copy.deepcopy(dict(expected))
+        expected_attestations = task.get("required_loss_attestations")
+        if not isinstance(expected_attestations, Sequence) or isinstance(
+            expected_attestations,
+            (str, bytes),
+        ):
+            raise TypeError("DAG-ML required_loss_attestations must be a sequence")
+        if not expected_attestations:
+            raise ValueError("DAG-ML training loss tasks require a loss attestation")
+        if role_index >= len(expected_attestations):
+            raise ValueError("DAG-ML training loss role_index is outside required_loss_attestations")
+        expected = expected_attestations[role_index]
+        if not isinstance(expected, Mapping):
+            raise TypeError("DAG-ML required loss attestation must be a mapping")
+        expected_attestation = copy.deepcopy(dict(expected))
 
         binding = bind_training_loss(
             copy.deepcopy(dict(task)),
@@ -68,7 +68,7 @@ class DagMLTrainingLossExecution:
         required_attestation_dict = copy.deepcopy(dict(required_attestation))
         if required_attestation_dict.get("phase") != phase:
             raise ValueError("DAG-ML loss binding attestation phase does not match its task")
-        if expected_attestation is not None and required_attestation_dict != expected_attestation:
+        if required_attestation_dict != expected_attestation:
             raise ValueError("DAG-ML loss binding attestation does not match the NodeTask requirement")
 
         self._invoke = invoke

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -93,6 +93,11 @@ class DagMLTrainingLossExecution:
 
         return self(target, prediction)
 
+    def invoke_target_prediction(self, target: Any, prediction: Any) -> Any:
+        """Expose the semantic ordering expected by TensorFlow/Keras."""
+
+        return self(target, prediction)
+
     def __reduce__(self) -> Any:
         raise TypeError("DAG-ML training loss executions cannot be serialized")
 

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import copy
+import math
 from collections.abc import Mapping, Sequence
+from numbers import Real
 from typing import Any
 
 
@@ -101,6 +103,8 @@ class DagMLTrainingLossExecution:
         """Invoke the semantic ``(target, prediction)`` DAG-ML loss callback."""
 
         value = self._invoke(target, prediction, *args, **kwargs)
+        if isinstance(value, Real) and not isinstance(value, bool) and not math.isfinite(value):
+            raise ValueError("DAG-ML training loss callback returned a non-finite scalar")
         self._attestation = copy.deepcopy(self._required_attestation)
         self._invocation_count += 1
         return value

--- a/nirs4all/pipeline/dagml/loss_runtime.py
+++ b/nirs4all/pipeline/dagml/loss_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 
@@ -40,6 +40,20 @@ class DagMLTrainingLossExecution:
             raise TypeError("DAG-ML loss registry must expose bind_training_loss()")
         if isinstance(role_index, bool) or not isinstance(role_index, int) or role_index < 0:
             raise ValueError("DAG-ML training loss role_index must be a non-negative integer")
+        expected_attestations = task.get("required_loss_attestations") or ()
+        expected_attestation: dict[str, Any] | None = None
+        if expected_attestations:
+            if not isinstance(expected_attestations, Sequence) or isinstance(
+                expected_attestations,
+                (str, bytes),
+            ):
+                raise TypeError("DAG-ML required_loss_attestations must be a sequence")
+            if role_index >= len(expected_attestations):
+                raise ValueError("DAG-ML training loss role_index is outside required_loss_attestations")
+            expected = expected_attestations[role_index]
+            if not isinstance(expected, Mapping):
+                raise TypeError("DAG-ML required loss attestation must be a mapping")
+            expected_attestation = copy.deepcopy(dict(expected))
 
         binding = bind_training_loss(
             copy.deepcopy(dict(task)),
@@ -51,12 +65,15 @@ class DagMLTrainingLossExecution:
         required_attestation = binding.get("required_attestation")
         if not callable(invoke) or not isinstance(required_attestation, Mapping):
             raise ValueError("DAG-ML loss binding lacks invoke or required_attestation")
-        if required_attestation.get("phase") != phase:
+        required_attestation_dict = copy.deepcopy(dict(required_attestation))
+        if required_attestation_dict.get("phase") != phase:
             raise ValueError("DAG-ML loss binding attestation phase does not match its task")
+        if expected_attestation is not None and required_attestation_dict != expected_attestation:
+            raise ValueError("DAG-ML loss binding attestation does not match the NodeTask requirement")
 
         self._invoke = invoke
         self._phase = str(phase)
-        self._required_attestation = copy.deepcopy(dict(required_attestation))
+        self._required_attestation = required_attestation_dict
         self._attestation: dict[str, Any] | None = None
         self._invocation_count = 0
 

--- a/nirs4all/pipeline/dagml/node_runner.py
+++ b/nirs4all/pipeline/dagml/node_runner.py
@@ -32,8 +32,14 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from sklearn.pipeline import make_pipeline
 
-from nirs4all.pipeline.dagml_bridge import _META_MODEL_CONTROLLER_ID
+from nirs4all.pipeline.dagml_bridge import (
+    _META_MODEL_CONTROLLER_ID,
+    _PYTORCH_MODEL_CONTROLLER_ID,
+    _TENSORFLOW_MODEL_CONTROLLER_ID,
+)
 
+from .errors import DagMlUnsupported
+from .loss_runtime import DagMLTrainingLossExecution
 from .operator_routing import route_graph_node
 
 if TYPE_CHECKING:
@@ -353,7 +359,14 @@ def _output_handles(task: dict[str, Any], handle: int) -> dict[str, Any]:
     return outputs
 
 
-def _build_result(task: dict[str, Any], predictions: list[dict[str, Any]], artifacts: list[dict[str, Any]], artifact_handles: dict[str, Any], regression_targets: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+def _build_result(
+    task: dict[str, Any],
+    predictions: list[dict[str, Any]],
+    artifacts: list[dict[str, Any]],
+    artifact_handles: dict[str, Any],
+    regression_targets: list[dict[str, Any]] | None = None,
+    loss_attestations: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     """Assemble the schema-complete ``NodeResult`` the runtime validates (outputs + full lineage).
 
     ``regression_targets`` (the real ``y_true`` for the predicted samples) lets dag-ml score the
@@ -394,8 +407,173 @@ def _build_result(task: dict[str, Any], predictions: list[dict[str, Any]], artif
             "seed": task.get("seed"),
             "unsafe_flags": [],
             "metrics": metrics,
+            "loss_attestations": loss_attestations or [],
         },
     }
+
+
+def _bind_training_loss(
+    task: dict[str, Any],
+    controller_id: str,
+    local_implementations: Any,
+) -> DagMLTrainingLossExecution | None:
+    requirements = task.get("required_loss_attestations") or []
+    if not requirements:
+        return None
+    if controller_id not in {
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+    }:
+        raise DagMlUnsupported(
+            f"controller {controller_id!r} cannot execute a configurable training loss"
+        )
+    if len(requirements) != 1:
+        raise DagMlUnsupported(
+            "native nirs4all deep-learning nodes currently support one training loss per task"
+        )
+    if local_implementations is None:
+        raise RuntimeError(
+            "DAG-ML training task requires a process-local loss registry"
+        )
+    return DagMLTrainingLossExecution(task, local_implementations)
+
+
+def _backend_train_params(node: dict[str, Any]) -> dict[str, Any]:
+    params = (node.get("metadata") or {}).get("nirs4all_train_params", {})
+    if not isinstance(params, dict):
+        raise TypeError("nirs4all_train_params graph metadata must be a mapping")
+    return dict(params)
+
+
+def _seed_differentiable_backend(controller_id: str, seed: Any) -> None:
+    if isinstance(seed, bool) or not isinstance(seed, int):
+        raise TypeError("native differentiable model tasks require an integer core seed")
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        import torch
+
+        torch.manual_seed(seed % (2**64))
+        return
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        import tensorflow as tf
+
+        tf.keras.utils.set_random_seed(seed % (2**32))
+        return
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
+
+
+def _prediction_only_refit_estimator(
+    controller_id: str,
+    estimator: Any,
+    loss_execution: DagMLTrainingLossExecution | None,
+) -> Any:
+    if (
+        controller_id != _TENSORFLOW_MODEL_CONTROLLER_ID
+        or loss_execution is None
+    ):
+        return estimator
+
+    from nirs4all.pipeline.storage.artifacts.artifact_persistence import (
+        from_bytes,
+        to_bytes,
+    )
+
+    data, format_name = to_bytes(estimator, format_hint="tensorflow")
+    return from_bytes(data, format_name)
+
+
+def _train_differentiable_model(
+    controller_id: str,
+    model: Any,
+    x_train: Any,
+    y_train: Any,
+    x_val: Any | None,
+    y_val: Any | None,
+    train_params: dict[str, Any],
+    loss_execution: DagMLTrainingLossExecution | None,
+) -> Any:
+    params = dict(train_params)
+    if loss_execution is not None:
+        params["loss"] = loss_execution
+    params.setdefault("verbose", 0)
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+        from nirs4all.pipeline.config.context import ExecutionContext
+
+        controller = PyTorchModelController()
+        context = ExecutionContext()
+        prepared_x, prepared_y = controller._prepare_data(
+            np.asarray(x_train), np.asarray(y_train), context
+        )
+        prepared_x_val, prepared_y_val = (
+            controller._prepare_data(np.asarray(x_val), np.asarray(y_val), context)
+            if x_val is not None and y_val is not None
+            else (None, None)
+        )
+        return controller._train_model(
+            model,
+            prepared_x,
+            prepared_y,
+            prepared_x_val,
+            prepared_y_val,
+            **params,
+        )
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.tensorflow_model import TensorFlowModelController
+        from nirs4all.core.task_type import TaskType
+
+        tf_controller = TensorFlowModelController()
+        prepared_x, prepared_y = tf_controller._prepare_data(
+            np.asarray(x_train),
+            np.asarray(y_train),
+            {},
+        )
+        prepared_x_val, prepared_y_val = (
+            tf_controller._prepare_data(
+                np.asarray(x_val),
+                np.asarray(y_val),
+                {},
+            )
+            if x_val is not None and y_val is not None
+            else (None, None)
+        )
+        if prepared_y is None:
+            raise RuntimeError("TensorFlow training data preparation dropped targets")
+        params.setdefault("task_type", TaskType.REGRESSION)
+        return tf_controller._train_model(
+            model,
+            prepared_x,
+            prepared_y,
+            prepared_x_val,
+            prepared_y_val,
+            **params,
+        )
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
+
+
+def _predict_differentiable_model(
+    controller_id: str,
+    model: Any,
+    features: Any,
+) -> np.ndarray:
+    if controller_id == _PYTORCH_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+
+        return np.asarray(
+            PyTorchModelController()._predict_model(model, np.asarray(features))
+        )
+    if controller_id == _TENSORFLOW_MODEL_CONTROLLER_ID:
+        from nirs4all.controllers.models.tensorflow_model import TensorFlowModelController
+
+        return np.asarray(
+            TensorFlowModelController()._predict_model(model, np.asarray(features))
+        )
+    raise DagMlUnsupported(
+        f"controller {controller_id!r} is not a differentiable model controller"
+    )
 
 
 def run_model_node(
@@ -406,6 +584,7 @@ def run_model_node(
     edges: list[dict[str, Any]] | None = None,
     y_transform_node: dict[str, Any] | None = None,
     sample_metadata: dict[str, dict[str, Any]] | None = None,
+    local_implementations: Any = None,
 ) -> dict[str, Any]:
     """Execute a model-kind ``NodeTask`` with the real operator + real data; return a ``NodeResult``.
 
@@ -435,6 +614,10 @@ def run_model_node(
     # fold (the branch_view filtered it out). The model cannot fit, so emit an empty NodeResult — the
     # other partitions cover the fold, and the native concat-merge reassembles full coverage.
     if phase != "PREDICT" and not train_ids:
+        if task.get("required_loss_attestations"):
+            raise DagMlUnsupported(
+                "a required training loss cannot execute on an empty training partition"
+            )
         return _build_result(task, [], [], {}, [])
 
     estimator: Any
@@ -456,11 +639,23 @@ def run_model_node(
         multi_block = isinstance(estimator, _MultiBlockEstimator)
         source_concat = isinstance(estimator, _SourceConcatEstimator)
     else:
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            _seed_differentiable_backend(controller_id, task.get("seed"))
         model = route_graph_node(node_lookup(node_id), variant_overrides=_variant_overrides(task, node_id))
         upstream = [route_graph_node(node_lookup(upstream_id)) for upstream_id in _upstream_x_chain(node_id, edges)]
         source_chains = _source_concat_chains(node_lookup(node_id))
         source_concat = source_chains is not None
         multi_block = not source_concat and _is_multi_block_model(model) and resolver.is_multi_source()
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        } and (upstream or source_concat or multi_block or source_index is not None):
+            raise DagMlUnsupported(
+                "native differentiable model nodes currently require a single raw feature block"
+            )
         if source_concat:
             estimator = _SourceConcatEstimator(
                 model,
@@ -506,7 +701,52 @@ def run_model_node(
             y_fit = y_transform.fit_transform(y_train) if y_transform is not None else y_train
         else:
             y_fit = y_transform.fit_transform(y_train.reshape(-1, 1)).ravel() if y_transform is not None else y_train
-        estimator.fit(x_train, y_fit)
+        loss_execution = _bind_training_loss(
+            task,
+            controller_id,
+            local_implementations,
+        )
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            x_val = None
+            y_val = None
+            if phase == "FIT_CV" and predict_ids:
+                x_val = np.asarray(
+                    resolver.resolve_features(
+                        predict_ids,
+                        include_augmented=False,
+                    )["values"]
+                )
+                raw_y_val = np.asarray(
+                    resolver.resolve_targets(predict_ids)["values"],
+                    dtype=float,
+                )
+                if y_transform is not None:
+                    y_val = (
+                        y_transform.transform(raw_y_val)
+                        if raw_y_val.ndim > 1 and raw_y_val.shape[1] > 1
+                        else y_transform.transform(raw_y_val.reshape(-1, 1)).ravel()
+                    )
+                else:
+                    y_val = raw_y_val
+            estimator = _train_differentiable_model(
+                controller_id,
+                estimator,
+                x_train,
+                y_fit,
+                x_val,
+                y_val,
+                _backend_train_params(node_lookup(node_id)),
+                loss_execution,
+            )
+        else:
+            if loss_execution is not None:
+                raise DagMlUnsupported(
+                    f"controller {controller_id!r} cannot consume a DAG-ML training loss"
+                )
+            estimator.fit(x_train, y_fit)
 
     def _predict(ids: list[str], include_augmented: bool) -> list[list[float]]:
         # Predict X at the dataset's NATIVE storage dtype too (same parity reason as the fit X above):
@@ -518,7 +758,18 @@ def run_model_node(
             x = np.asarray(resolver.resolve_source_block(ids, source_index, include_augmented=include_augmented)["values"])
         else:
             x = np.asarray(resolver.resolve_features(ids, include_augmented=include_augmented)["values"])
-        pred = np.asarray(estimator.predict(x), dtype=float).reshape(len(ids), -1)
+        if controller_id in {
+            _PYTORCH_MODEL_CONTROLLER_ID,
+            _TENSORFLOW_MODEL_CONTROLLER_ID,
+        }:
+            raw_prediction = _predict_differentiable_model(
+                controller_id,
+                estimator,
+                x,
+            )
+        else:
+            raw_prediction = estimator.predict(x)
+        pred = np.asarray(raw_prediction, dtype=float).reshape(len(ids), -1)
         scaled = np.asarray(y_transform.inverse_transform(pred), dtype=float).reshape(len(ids), -1) if y_transform is not None else pred
         return [[float(value) for value in row] for row in scaled]
 
@@ -594,11 +845,35 @@ def run_model_node(
     artifacts: list[dict[str, Any]] = []
     artifact_handles: dict[str, Any] = {}
     if phase == "REFIT":
-        model_store[artifact_handle] = {"estimator": estimator, "y_transform": y_transform}
-        artifacts.append({"id": artifact_id, "kind": "sklearn_estimator", "controller_id": controller_id, "backend": "joblib"})
+        stored_estimator = _prediction_only_refit_estimator(
+            controller_id,
+            estimator,
+            loss_execution,
+        )
+        model_store[artifact_handle] = {
+            "estimator": stored_estimator,
+            "y_transform": y_transform,
+        }
+        artifact_kind = {
+            _PYTORCH_MODEL_CONTROLLER_ID: "pytorch_model",
+            _TENSORFLOW_MODEL_CONTROLLER_ID: "tensorflow_model",
+        }.get(controller_id, "sklearn_estimator")
+        artifacts.append({"id": artifact_id, "kind": artifact_kind, "controller_id": controller_id, "backend": "joblib"})
         artifact_handles[artifact_id] = {"handle": artifact_handle, "kind": "model", "owner_controller": controller_id}
 
-    return _build_result(task, predictions, artifacts, artifact_handles, regression_targets)
+    attestations = (
+        loss_execution.loss_attestations
+        if phase != "PREDICT" and loss_execution is not None
+        else []
+    )
+    return _build_result(
+        task,
+        predictions,
+        artifacts,
+        artifact_handles,
+        regression_targets,
+        attestations,
+    )
 
 
 def _meta_feature_matrix(specs: list[dict[str, Any]], node_id: str) -> tuple[list[str], np.ndarray]:
@@ -779,6 +1054,7 @@ def run_node(
     edges: list[dict[str, Any]] | None = None,
     y_transform_node: dict[str, Any] | None = None,
     sample_metadata: dict[str, dict[str, Any]] | None = None,
+    local_implementations: Any = None,
 ) -> dict[str, Any]:
     """Dispatch a ``NodeTask`` by node kind.
 
@@ -798,5 +1074,14 @@ def run_node(
     if kind in ("model", "tuner"):
         if node_plan["controller_id"] == _META_MODEL_CONTROLLER_ID:
             return run_meta_model_node(task, resolver, node_lookup, model_store)
-        return run_model_node(task, resolver, node_lookup, model_store, edges, y_transform_node, sample_metadata)
+        return run_model_node(
+            task,
+            resolver,
+            node_lookup,
+            model_store,
+            edges,
+            y_transform_node,
+            sample_metadata,
+            local_implementations,
+        )
     return _build_result(task, [], [], {})

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 import numpy as np
 
 from nirs4all.data.dataset import SpectroDataset
-from nirs4all.pipeline.dagml_bridge import controller_manifests
+from nirs4all.pipeline.dagml_bridge import _model_controller_id, controller_manifests
 
 from .cli_runner import assemble_cv_refit_dsl
 from .envelope import build_envelope
@@ -53,6 +53,8 @@ class RawArrayDagMLTrainingCompiler:
     bundle_id: str = "bundle:nirs4all.raw_fit"
     seed: int = 12345
     dagml_module: str = "dag_ml"
+    training_losses: tuple[Mapping[str, Any], ...] = ()
+    local_implementations: Any = None
 
     def compile_fit(
         self,
@@ -82,6 +84,8 @@ class RawArrayDagMLTrainingCompiler:
             bundle_id=self.bundle_id,
             seed=self.seed,
             dagml_module=self.dagml_module,
+            training_losses=self.training_losses,
+            local_implementations=self.local_implementations,
         )
         compiler = DagMLTrainingRequestCompiler(
             contracts,
@@ -114,6 +118,8 @@ def lower_raw_array_training_contracts(
     bundle_id: str = "bundle:nirs4all.raw_fit",
     seed: int = 12345,
     dagml_module: str = "dag_ml",
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any = None,
 ) -> DagMLTrainingRequestContracts:
     """Lower a linear raw-array pipeline into executable DAG-ML contracts."""
 
@@ -136,7 +142,8 @@ def lower_raw_array_training_contracts(
     envelope["data_content_fingerprint"] = _array_content_fingerprint("X", X)
     envelope["target_content_fingerprint"] = _array_content_fingerprint("y", y)
     dsl = assemble_cv_refit_dsl(steps, identity, envelope, folds, dsl_id="nirs4all-raw-fit", n_splits=len(folds))
-    artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, controller_manifests())
+    manifests = controller_manifests()
+    artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, manifests)
     graph = artifact.graph.to_dict()
     campaign = artifact.campaign_template.to_dict()
     if campaign.get("root_seed") is None:
@@ -148,8 +155,9 @@ def lower_raw_array_training_contracts(
         plan_id=plan_id,
         graph=graph,
         campaign=campaign,
-        controller_manifests=controller_manifests(),
+        controller_manifests=manifests,
         data_identities=data_identities,
+        training_losses=training_losses,
         selection_metric=selection_metric,
         selection_objective=selection_objective,
         output_requests=output_requests,
@@ -172,7 +180,7 @@ def lower_raw_array_training_contracts(
         data_envelopes=data_envelopes,
         relations=copy.deepcopy(envelope["coordinator_relations"]),
         training_influence=training_influence,
-        op_callback=_op_callback(dataset, identity, graph),
+        op_callback=_op_callback(dataset, identity, graph, local_implementations),
         outcome_id=outcome_id,
         run_id=run_id,
         bundle_id=bundle_id,
@@ -231,7 +239,17 @@ def _supported_linear_steps(pipeline: Any) -> tuple[list[Any], Any, dict[str, st
         steps,
         context="native raw-array",
     )
-    reject_native_training_param_overrides(steps, context="native raw-array")
+    model_steps = [step for step in steps if isinstance(step, dict) and "model" in step]
+    allowed_keys = (
+        frozenset({"train_params"})
+        if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None
+        else frozenset()
+    )
+    reject_native_training_param_overrides(
+        steps,
+        context="native raw-array",
+        allowed_keys=allowed_keys,
+    )
     if splitter is None:
         raise ValueError("RawArrayDagMLTrainingCompiler requires a splitter step")
     _reject_multi_model(steps)
@@ -368,13 +386,27 @@ def _first_relation_fingerprint(campaign: Mapping[str, Any]) -> str:
     raise ValueError("campaign contains no data binding relation fingerprint")
 
 
-def _op_callback(dataset: SpectroDataset, identity: IdentityMap, graph: Mapping[str, Any]) -> Any:
+def _op_callback(
+    dataset: SpectroDataset,
+    identity: IdentityMap,
+    graph: Mapping[str, Any],
+    local_implementations: Any,
+) -> Any:
     resolver = MaterializationResolver(dataset, identity)
     nodes = {node["id"]: node for node in graph["nodes"]}
     edges = graph.get("edges", [])
     y_transform_node = next((node for node in graph["nodes"] if node["kind"] == "y_transform"), None)
     store: dict[int, Any] = {}
-    return lambda task: run_node(task, resolver, nodes.__getitem__, store, edges, y_transform_node, None)
+    return lambda task: run_node(
+        task,
+        resolver,
+        nodes.__getitem__,
+        store,
+        edges,
+        y_transform_node,
+        None,
+        local_implementations,
+    )
 
 
 def _import_dagml(module_name: str) -> Any:

--- a/nirs4all/pipeline/dagml/result.py
+++ b/nirs4all/pipeline/dagml/result.py
@@ -66,6 +66,20 @@ _CV_PARTITIONS = ("train", "val", "test")
 _MISSING = object()
 
 
+def _audit_node_results(
+    results: list[dict[str, Any]] | None,
+    results_by_variant: dict[Any, list[dict[str, Any]]] | None,
+) -> list[dict[str, Any]]:
+    if results is not None:
+        return results
+    if not results_by_variant:
+        return []
+    frames: list[dict[str, Any]] = []
+    for variant_frames in results_by_variant.values():
+        frames.extend(variant_frames)
+    return frames
+
+
 def _index_sample_blocks(results: list[dict[str, Any]] | None) -> dict[tuple[str, str, str | None], tuple[dict[str, Any], dict[str, Any] | None]]:
     """Index the node_results' per-sample prediction blocks for the direct-block row projection (2a-i).
 
@@ -601,6 +615,10 @@ def _scores_to_run_result(
     # in-memory metadata only, OFF by default (the writer fires solely when native results are enabled),
     # so a plain run is untouched.
     run_result._dagml_refit_artifacts = refit_artifacts or []  # noqa: SLF001
+    # Keep the native NodeResult frames as an audit trail for controller-level
+    # attestations such as process-local training losses. This is the same
+    # in-memory-only posture as the ScoreSet/refit artifact captures above.
+    run_result._dagml_node_results = _audit_node_results(results, results_by_variant)  # noqa: SLF001
     return run_result
 
 

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import shutil
 import sys
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -272,6 +273,23 @@ def preflight_dagml_backend(cli: str) -> None:
     )
 
 
+def _reject_unavailable_process_local_losses(training_losses: tuple[Mapping[str, Any], ...], local_implementations: Any | None) -> None:
+    if not training_losses and local_implementations is None:
+        return
+    if not training_losses:
+        raise DagMlUnsupported("local_implementations was supplied without DAG-ML training_losses")
+    if local_implementations is None:
+        raise DagMlUnsupported("DAG-ML training_losses require a process-local implementation registry")
+
+    from .in_process_runner import _dagml_extension_loads, in_process_enabled
+
+    if not in_process_enabled() or not _dagml_extension_loads():
+        raise DagMlUnsupported(
+            "DAG-ML process-local training losses require the in-process backend; "
+            "they cannot be serialized through the subprocess adapter or legacy fallback."
+        )
+
+
 def run_via_dagml(
     pipeline: Any,
     dataset: Any,
@@ -287,6 +305,8 @@ def run_via_dagml(
     venv_python: str | None = None,
     workdir: str | Path | None = None,
     results_path: str | Path | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> RunResult:
     """Execute ``pipeline`` on ``dataset`` via dag-ml-cli; return a RunResult of dag-ml's native scores.
 
@@ -330,6 +350,11 @@ def run_via_dagml(
             ``predictions.parquet``); env-only defaults to ``./nirs4all_results/<run_id>/``. ``None`` +
             unset env → nothing written (behaviorally identical to a pure in-memory run). The writer
             NEVER touches the legacy workspace store.
+        training_losses: DAG-ML-native training loss role references to bind
+            into the execution plan for ``FIT_CV`` / ``REFIT`` model tasks.
+            Process-local losses are supported only by the in-process backend.
+        local_implementations: Process-local DAG-ML implementation registry
+            used by nirs4all controllers to invoke the training loss callables.
 
     Returns:
         A :class:`~nirs4all.api.result.RunResult` whose ``best_rmse`` is the native final-test score
@@ -358,6 +383,7 @@ def run_via_dagml(
     # — a genuine dag-ml runtime/operator error is NOT caught here (it surfaces later and propagates).
     cli = str(dagml_cli or _DEFAULT_CLI)
     preflight_dagml_backend(cli)
+    _reject_unavailable_process_local_losses(training_losses, local_implementations)
 
     # Materialize the host dataset from ANY input legacy `run()` accepts (path / config /
     # DatasetConfigs / live SpectroDataset / (X, y) tuple / array) — DatasetConfigs alone silently
@@ -375,7 +401,19 @@ def run_via_dagml(
     # `_scores_to_run_result`), so it is safe to delete on every dispatch return/raise path. A
     # caller-provided `workdir` is theirs — never delete it.
     try:
-        result = _dispatch_run(pipeline, spectro, base_dir, dataset_arg, host_pickle, cli, venv_python, name, random_state)
+        result = _dispatch_run(
+            pipeline,
+            spectro,
+            base_dir,
+            dataset_arg,
+            host_pickle,
+            cli,
+            venv_python,
+            name,
+            random_state,
+            training_losses=training_losses,
+            local_implementations=local_implementations,
+        )
         _attach_export_spec(result, pipeline, dataset, name, random_state)
         # NATIVE RESULTS SEAM (P3 Slice 2b-i): write the ADDITIVE native results directory when enabled
         # (explicit `results_path` OR $N4A_NATIVE_RESULTS) — OFF by default, so a plain run skips this
@@ -586,6 +624,8 @@ def _dispatch_run(
     venv_python: str | None,
     name: str = "",
     random_state: int | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> RunResult:
     """Route the materialized run to the matching native dag-ml path and map its scores.
 
@@ -635,6 +675,7 @@ def _dispatch_run(
                 f"engine='dag-ml' does not yet support overriding the native selection direction for metric {metric!r}; use direction={expected_objective!r} or choose a metric with the desired objective."
             )
     task_type = "classification" if is_classification else "regression"
+    custom_training_loss_requested = bool(training_losses) or local_implementations is not None
 
     # Detect the special-composition steps UP FRONT so the repetition guard below can reject an
     # unsupported combination BEFORE any non-group dispatch path (branch/augmentation/exclude) runs.
@@ -654,6 +695,25 @@ def _dispatch_run(
             "engine='dag-ml' does not yet support stateful concat_transform with Python-reference "
             "pre-CV materialization semantics; the native FeatureConcat path fits PCA/SVD/scalers "
             "fold-locally and would not preserve legacy parity (backlog #27)."
+        )
+    if custom_training_loss_requested and (
+        detected is not None
+        or detected_duplication is not None
+        or detected_stacking is not None
+        or detected_by_source is not None
+        or detected_by_source_distinct_concat is not None
+        or detected_rep_fusion is not None
+        or detected_source_concat is not None
+        or augmentation_steps
+        or _is_repetition_dataset(spectro)
+        or _generation_kind(list(pipeline)) != "none"
+        or any(_is_exclude_step(step) for step in pipeline)
+    ):
+        raise DagMlUnsupported(
+            "DAG-ML process-local training losses are currently wired only for one concrete "
+            "linear model pipeline with a cross-validator; branch, augmentation, repetition, "
+            "source-layout, exclude and generator shapes must fail explicitly until their "
+            "controllers thread local loss registries."
         )
 
     # REP FUSION (`rep_to_sources` / `rep_to_pp`, #31): a one-time HOST RESHAPE that turns each replicate
@@ -974,7 +1034,21 @@ def _dispatch_run(
     # nirs4all) and emitting the winner's refit rows only.
     variants = _expand_operator_generators(list(pipeline))
     variant_runs = [
-        _run_concrete_scores(variant, spectro, dataset_arg, cli, venv_python or sys.executable, base_dir / f"variant{index}", cv_pool, excluded, tags_by_sample, dataset_pickle=host_pickle, random_state=random_state)
+        _run_concrete_scores(
+            variant,
+            spectro,
+            dataset_arg,
+            cli,
+            venv_python or sys.executable,
+            base_dir / f"variant{index}",
+            cv_pool,
+            excluded,
+            tags_by_sample,
+            dataset_pickle=host_pickle,
+            random_state=random_state,
+            training_losses=training_losses,
+            local_implementations=local_implementations,
+        )
         for index, variant in enumerate(variants)
     ]
     if len(variant_runs) == 1:

--- a/nirs4all/pipeline/dagml/run_paths.py
+++ b/nirs4all/pipeline/dagml/run_paths.py
@@ -9,6 +9,7 @@ into a :class:`~nirs4all.api.result.RunResult`.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -291,6 +292,8 @@ def _run_concrete_scores(
     tags_by_sample: dict[int, list[str]] | None = None,
     dataset_pickle: str | None = None,
     random_state: int | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> tuple[dict[str, Any], str, bool, list[dict[str, Any]], Any, list[dict[str, Any]]]:
     """Run one concrete (generator-free) pipeline through dag-ml-cli; return ``(scores, model_name, skip_refit, results, identity, refit_artifacts)``.
 
@@ -325,7 +328,18 @@ def _run_concrete_scores(
 
     graph = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, controller_manifests()).graph.to_dict()
     outcome = run_cv_refit_bundle(
-        dsl=dsl, envelope=envelope, graph=graph, dataset_path=dataset_arg, workdir=run_dir, dagml_cli=cli, venv_python=venv_python, dataset_pickle=dataset_pickle, dataset=spectro, random_state=random_state
+        dsl=dsl,
+        envelope=envelope,
+        graph=graph,
+        dataset_path=dataset_arg,
+        workdir=run_dir,
+        dagml_cli=cli,
+        venv_python=venv_python,
+        dataset_pickle=dataset_pickle,
+        dataset=spectro,
+        random_state=random_state,
+        training_losses=training_losses,
+        local_implementations=local_implementations,
     )
     if outcome["returncode"] != 0:
         _raise_run_failure(outcome, "dag-ml engine run failed")
@@ -348,6 +362,8 @@ def _run_concrete(
     dataset_pickle: str | None = None,
     config_name: str = "",
     random_state: int | None = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any | None = None,
 ) -> RunResult:
     """Run one concrete (generator-free) pipeline through dag-ml-cli; map its native scores.
 
@@ -355,7 +371,19 @@ def _run_concrete(
     mode); ``excluded`` is marked in the envelope only in the opt-in (``keep_in_oof=True``) mode.
     """
     scores, model_name, skip_refit, results, identity, refit_artifacts = _run_concrete_scores(
-        pipeline, spectro, dataset_arg, cli, venv_python, run_dir, cv_pool, excluded, tags_by_sample, dataset_pickle=dataset_pickle, random_state=random_state
+        pipeline,
+        spectro,
+        dataset_arg,
+        cli,
+        venv_python,
+        run_dir,
+        cv_pool,
+        excluded,
+        tags_by_sample,
+        dataset_pickle=dataset_pickle,
+        random_state=random_state,
+        training_losses=training_losses,
+        local_implementations=local_implementations,
     )
     return _scores_to_run_result(scores, spectro.name, model_name, metric, task_type, config_name=config_name, skip_refit=skip_refit, results=results, identity=identity, refit_artifacts=refit_artifacts)
 

--- a/nirs4all/pipeline/dagml/training_contracts.py
+++ b/nirs4all/pipeline/dagml/training_contracts.py
@@ -45,6 +45,7 @@ class DagMLTrainingRequestSpec:
     parameter_patches: Sequence[Mapping[str, Any]] = ()
     patch_policies: Sequence[Mapping[str, Any]] = ()
     influence_requirements: Sequence[Mapping[str, Any]] = ()
+    training_losses: Sequence[Mapping[str, Any]] = ()
     selection_required_metric_level: str | None = None
     selection_evaluation_scope: str | None = None
 
@@ -66,6 +67,8 @@ def assemble_training_request(spec: DagMLTrainingRequestSpec) -> dict[str, Any]:
         "options": _training_options(spec),
         "request_fingerprint": "0" * 64,
     }
+    if spec.training_losses:
+        request["training_losses"] = _sorted_training_losses(spec.training_losses)
     request["request_fingerprint"] = tcv1_fingerprint_without(request, "request_fingerprint")
     return request
 
@@ -159,6 +162,35 @@ def _sorted_controller_manifests(manifests: Sequence[Mapping[str, Any]]) -> list
 
 _PHASE_ORDER = {name: index for index, name in enumerate(("COMPILE", "PLAN", "FIT_CV", "SELECT", "REFIT", "PREDICT", "EXPLAIN"))}
 
+
+def _sorted_training_losses(roles: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    canonical_roles = [_canonical_training_loss_role(role) for role in roles]
+    return sorted(canonical_roles, key=_training_loss_sort_key)
+
+
+def _canonical_training_loss_role(role: Mapping[str, Any]) -> dict[str, Any]:
+    out = dict(role)
+    phases = out.get("phases")
+    if not isinstance(phases, Sequence) or isinstance(phases, str | bytes | bytearray):
+        raise TypeError("training loss role phases must be a sequence")
+    out["phases"] = sorted(set(phases), key=_PHASE_ORDER.__getitem__)
+    return out
+
+
+def _training_loss_sort_key(role: Mapping[str, Any]) -> tuple[str, tuple[bool, str], tuple[int, ...]]:
+    node_id = role.get("node_id")
+    output_id = role.get("output_id")
+    phases = role["phases"]
+    if not isinstance(node_id, str):
+        raise TypeError("training loss role node_id must be a string")
+    if output_id is not None and not isinstance(output_id, str):
+        raise TypeError("training loss role output_id must be a string or None")
+    return (
+        node_id,
+        (output_id is not None, output_id or ""),
+        tuple(_PHASE_ORDER[phase] for phase in phases),
+    )
+
 _CAPABILITY_ORDER = {
     name: index
     for index, name in enumerate(
@@ -182,6 +214,9 @@ _CAPABILITY_ORDER = {
             "supports_row_resampling",
             "supports_backend_loss_weights",
             "supports_missing_masks",
+            "supports_configurable_loss",
+            "supports_custom_loss",
+            "supports_differentiable_loss",
             "uses_training_weights",
             "uses_early_stopping",
             "performs_internal_tuning",

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -35,6 +35,8 @@ from nirs4all.pipeline.dagml.errors import DagMlUnsupported
 # operator-selector token that keeps the meta-model manifest out of the generic model-kind catch-all.
 _META_MODEL_CONTROLLER_ID = "controller:nirs4all.meta_model"
 _META_MODEL_REF = "nirs4all.meta_model"
+_PYTORCH_MODEL_CONTROLLER_ID = "controller:nirs4all.pytorch_model"
+_TENSORFLOW_MODEL_CONTROLLER_ID = "controller:nirs4all.tensorflow_model"
 
 # Every nirs4all generation keyword (mirrors config._generator.keywords.GENERATION_KEYWORDS). Used
 # to detect a generator-shaped model sibling that this bridge does NOT lower natively, so it can fail
@@ -124,6 +126,44 @@ def _qualname(obj: Any) -> str:
     """Fully-qualified ``module.QualName`` of an instance or class."""
     cls = obj if isinstance(obj, type) else type(obj)
     return f"{cls.__module__}.{cls.__qualname__}"
+
+
+def _model_controller_id(obj: Any) -> str | None:
+    """Return the dedicated native controller for a differentiable model."""
+
+    framework = str(getattr(obj, "framework", "")).lower()
+    cls = obj if isinstance(obj, type) else type(obj)
+    modules = {
+        str(getattr(base, "__module__", "")).lower()
+        for base in getattr(cls, "__mro__", (cls,))
+    }
+    if framework in {"pytorch", "torch"} or any(
+        module == "torch" or module.startswith("torch.") for module in modules
+    ):
+        return _PYTORCH_MODEL_CONTROLLER_ID
+    if framework in {"tensorflow", "keras"} or any(
+        module == "tensorflow"
+        or module.startswith("tensorflow.")
+        or module == "keras"
+        or module.startswith("keras.")
+        for module in modules
+    ):
+        return _TENSORFLOW_MODEL_CONTROLLER_ID
+    return None
+
+
+def _json_safe_mapping(value: Any, *, name: str) -> dict[str, Any]:
+    """Round-trip one mapping through strict JSON for native task metadata."""
+
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a mapping")
+    try:
+        normalized = json.loads(json.dumps(value, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise TypeError(f"{name} must contain only finite JSON values") from error
+    if not isinstance(normalized, dict):
+        raise TypeError(f"{name} must normalize to a JSON object")
+    return normalized
 
 
 def _json_safe_params(obj: Any) -> dict[str, Any]:
@@ -928,6 +968,17 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             # The model id is the fully-qualified class (like transforms), so any sklearn-style
             # estimator — regressor or classifier — resolves by import, not a hardcoded table.
             dsl_step: dict[str, Any] = {"model": _qualname(op), "params": _json_safe_params(op)}
+            metadata: dict[str, Any] = {}
+            controller_id = _model_controller_id(op)
+            if controller_id is not None:
+                metadata["controller_id"] = controller_id
+            if "train_params" in step:
+                metadata["nirs4all_train_params"] = _json_safe_mapping(
+                    step["train_params"],
+                    name="train_params",
+                )
+            if metadata:
+                dsl_step["metadata"] = metadata
             # Non-reserved siblings are model hyperparameters: plain values extend ``params``;
             # param-level generator dicts lower to native dag-ml ``generators`` so the compiler
             # expands variants and dag-ml runs generation + SELECT + refit natively (no Python expand).
@@ -1078,6 +1129,60 @@ def controller_manifests() -> list[dict[str, Any]]:
             "data_requirements": None,
             "capabilities": ["deterministic", "thread_safe", "process_safe", "uses_core_rng"],
             "operator_selectors": [],  # empty => bind any y_transform-kind node (the {"y_processing": …} wrapper, not the class)
+            "fit_scope": "fold_train",
+            "rng_policy": "uses_core_seed",
+            "artifact_policy": "serializable",
+        },
+        {
+            "controller_id": _PYTORCH_MODEL_CONTROLLER_ID,
+            "controller_version": _NIRS4ALL_VERSION,
+            "operator_kind": "model",
+            "priority": 10,
+            "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
+            "input_ports": [{"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}],
+            "output_ports": [
+                {"name": "y_hat", "kind": "prediction", "representation": None, "cardinality": "one"},
+                {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
+            ],
+            "data_requirements": _model_data_requirements(),
+            "capabilities": [
+                "needs_python_gil",
+                "uses_core_rng",
+                "emits_predictions",
+                "emits_artifacts",
+                "stateful",
+                "supports_configurable_loss",
+                "supports_custom_loss",
+                "supports_differentiable_loss",
+            ],
+            "operator_selectors": [{"refs": ["nirs4all.pytorch_model"]}],
+            "fit_scope": "fold_train",
+            "rng_policy": "uses_core_seed",
+            "artifact_policy": "serializable",
+        },
+        {
+            "controller_id": _TENSORFLOW_MODEL_CONTROLLER_ID,
+            "controller_version": _NIRS4ALL_VERSION,
+            "operator_kind": "model",
+            "priority": 10,
+            "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
+            "input_ports": [{"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}],
+            "output_ports": [
+                {"name": "y_hat", "kind": "prediction", "representation": None, "cardinality": "one"},
+                {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
+            ],
+            "data_requirements": _model_data_requirements(),
+            "capabilities": [
+                "needs_python_gil",
+                "uses_core_rng",
+                "emits_predictions",
+                "emits_artifacts",
+                "stateful",
+                "supports_configurable_loss",
+                "supports_custom_loss",
+                "supports_differentiable_loss",
+            ],
+            "operator_selectors": [{"refs": ["nirs4all.tensorflow_model"]}],
             "fit_scope": "fold_train",
             "rng_policy": "uses_core_seed",
             "artifact_policy": "serializable",

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -1087,9 +1087,10 @@ def pipeline_to_dsl(pipeline: list[Any], dsl_id: str = "nirs4all-pipeline") -> d
 def controller_manifests() -> list[dict[str, Any]]:
     """The host-controller manifests for the vertical-slice node kinds.
 
-    One manifest per ``operator_kind`` — a dag-ml manifest serves exactly one node
-    kind, so ``transform`` / ``y_transform`` / ``model`` each need their own. These
-    are **control-plane declarations only**: no process-adapter command lives here
+    Each manifest serves exactly one node kind. The registry supplies catch-all
+    transform, y-transform, and model controllers, plus targeted model controllers
+    for PyTorch and TensorFlow and the specialized merge/stacking roles. These are
+    **control-plane declarations only**: no process-adapter command lives here
     (that is a runtime concern of the later execution phase).
 
     Binding is **by node kind**, mirroring nirs4all's one-controller-per-role

--- a/nirs4all/pipeline/storage/artifacts/artifact_persistence.py
+++ b/nirs4all/pipeline/storage/artifacts/artifact_persistence.py
@@ -191,7 +191,10 @@ def to_bytes(obj: Any, format_hint: str | None = None) -> tuple[bytes, str]:
         (bytes, format_string) tuple
     """
     # Determine format
-    format = f"{format_hint}_pickle" if format_hint else _detect_framework(obj)
+    if format_hint == 'tensorflow':
+        format = 'tensorflow_keras'
+    else:
+        format = f"{format_hint}_pickle" if format_hint else _detect_framework(obj)
 
     try:
         # Sklearn objects - use joblib if available, else pickle
@@ -340,7 +343,8 @@ def from_bytes(data: bytes, format: str) -> Any:
                 tmp_path = tmp.name
 
             try:
-                model = tf.keras.models.load_model(tmp_path)
+                # Training compile state may reference process-local callbacks.
+                model = tf.keras.models.load_model(tmp_path, compile=False)
                 return model
             finally:
                 Path(tmp_path).unlink(missing_ok=True)

--- a/nirs4all/pipeline/storage/workspace_store.py
+++ b/nirs4all/pipeline/storage/workspace_store.py
@@ -273,9 +273,17 @@ def _deserialize_artifact(data: bytes, fmt: str) -> Any:
         import joblib
 
         return joblib.load(io.BytesIO(data))
-    import pickle
+    if fmt == "pickle":
+        import pickle
 
-    return pickle.loads(data)  # noqa: S301
+        return pickle.loads(data)  # noqa: S301
+
+    # ArtifactRegistry may register framework-native payloads directly in the
+    # workspace (for example ``tensorflow_keras``). Delegate those formats to
+    # the single format-aware loader instead of treating their bytes as pickle.
+    from nirs4all.pipeline.storage.artifacts.artifact_persistence import from_bytes
+
+    return from_bytes(data, fmt)
 
 
 def _format_to_ext(fmt: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.2.7",
+    "dag-ml>=0.3.0",
     "dag-ml-data>=0.2.8",
 ]
 

--- a/tests/integration/parity/test_dagml_bridge_spike.py
+++ b/tests/integration/parity/test_dagml_bridge_spike.py
@@ -65,12 +65,22 @@ def test_vertical_slice_controller_manifests_validate() -> None:
     import dag_ml
 
     manifests = controller_manifests()
-    # Two model-kind manifests: the base model controller (generic catch-all) + the stacking meta-model
-    # controller (bound by metadata.controller_id, declaring consumes_oof_predictions); the others are
-    # one each. Distinguished by controller_id (the kind alone is no longer unique for model).
-    assert sorted(m["operator_kind"] for m in manifests) == ["model", "model", "prediction_join", "transform", "y_transform"]
+    # Four model-kind manifests: targeted PyTorch and TensorFlow controllers,
+    # the generic base-model catch-all, and the stacking meta-model. The latter
+    # binds via metadata.controller_id and consumes OOF predictions. The other
+    # node kinds each have one controller.
+    assert sorted(m["operator_kind"] for m in manifests) == [
+        "model",
+        "model",
+        "model",
+        "model",
+        "prediction_join",
+        "transform",
+        "y_transform",
+    ]
     assert sorted(m["controller_id"] for m in manifests) == [
         "controller:nirs4all.merge_concat", "controller:nirs4all.meta_model", "controller:nirs4all.model",
+        "controller:nirs4all.pytorch_model", "controller:nirs4all.tensorflow_model",
         "controller:nirs4all.transform", "controller:nirs4all.y_transform",
     ]
     for manifest in manifests:

--- a/tests/integration/parity/test_dagml_bridge_spike.py
+++ b/tests/integration/parity/test_dagml_bridge_spike.py
@@ -69,20 +69,15 @@ def test_vertical_slice_controller_manifests_validate() -> None:
     # the generic base-model catch-all, and the stacking meta-model. The latter
     # binds via metadata.controller_id and consumes OOF predictions. The other
     # node kinds each have one controller.
-    assert sorted(m["operator_kind"] for m in manifests) == [
-        "model",
-        "model",
-        "model",
-        "model",
-        "prediction_join",
-        "transform",
-        "y_transform",
-    ]
-    assert sorted(m["controller_id"] for m in manifests) == [
-        "controller:nirs4all.merge_concat", "controller:nirs4all.meta_model", "controller:nirs4all.model",
-        "controller:nirs4all.pytorch_model", "controller:nirs4all.tensorflow_model",
-        "controller:nirs4all.transform", "controller:nirs4all.y_transform",
-    ]
+    assert {(m["controller_id"], m["operator_kind"]) for m in manifests} == {
+        ("controller:nirs4all.merge_concat", "prediction_join"),
+        ("controller:nirs4all.meta_model", "model"),
+        ("controller:nirs4all.model", "model"),
+        ("controller:nirs4all.pytorch_model", "model"),
+        ("controller:nirs4all.tensorflow_model", "model"),
+        ("controller:nirs4all.transform", "transform"),
+        ("controller:nirs4all.y_transform", "y_transform"),
+    }
     for manifest in manifests:
         dag_ml.ControllerManifest(manifest)  # raises on an invalid manifest
     dag_ml.ControllerManifests(manifests)  # raises on an invalid list / duplicate controller_id

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -12,9 +12,12 @@ A GENUINE dag-ml bug still propagates untouched.
 
 from __future__ import annotations
 
+import contextlib
 import warnings
 from pathlib import Path
+from typing import Any
 
+import numpy as np
 import pytest
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.model_selection import KFold
@@ -32,6 +35,21 @@ from ._datasets import dataset_path  # noqa: E402
 _DAGML_CLI = Path(__file__).resolve().parents[3].parent / "dag-ml" / "target" / "release" / "dag-ml-cli"
 
 _FALLBACK_WARNING = "falling back to the legacy engine"
+
+with contextlib.suppress(ImportError):
+    import torch
+
+
+if "torch" in globals():
+
+    class _TinyTorchRegressor(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 1, bias=False)
+            torch.nn.init.zeros_(self.linear.weight)
+
+        def forward(self, features: Any) -> Any:
+            return self.linear(features)
 
 
 def test_resolve_engine_default_is_legacy() -> None:
@@ -155,6 +173,113 @@ def test_run_forwards_dagml_training_losses_without_legacy_fallback(monkeypatch:
             training_losses=(role,),
             local_implementations=registry,
         )
+
+
+@pytest.mark.torch
+@pytest.mark.xdist_group("torch")
+def test_public_run_executes_local_torch_loss_and_carries_native_attestations() -> None:
+    """Public run() uses DAG-ML-owned loss roles all the way through FIT_CV and REFIT."""
+    if "torch" not in globals():
+        pytest.skip("PyTorch not available")
+    dag_ml = pytest.importorskip("dag_ml")
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+
+    calls: list[tuple[tuple[int, ...], tuple[int, ...], bool]] = []
+
+    def squared_loss(target: Any, prediction: Any) -> Any:
+        calls.append((tuple(target.shape), tuple(prediction.shape), bool(prediction.requires_grad)))
+        return torch.mean(torch.square(prediction - target))
+
+    registry = dag_ml.LocalImplementationRegistry()
+    loss_reference = registry.register_local_loss(
+        {
+            "schema_version": 1,
+            "loss_id": "example.loss.nirs4all-public-run-torch-squared@1",
+            "kind": "custom",
+            "task_kinds": ["regression"],
+            "prediction_kinds": ["regression_point"],
+            "objective": "minimize",
+            "reduction": "mean",
+            "required_inputs": ["target", "prediction"],
+            "capabilities": ["differentiable"],
+            "parameters": {},
+        },
+        squared_loss,
+        registry_key="loss:nirs4all:public-run-torch-squared",
+        implementation_fingerprint="d" * 64,
+        capabilities=["differentiable"],
+    )
+
+    class _CountingRegistry:
+        def __init__(self) -> None:
+            self.bind_calls: list[tuple[str, str | None, int]] = []
+
+        def bind_training_loss(
+            self,
+            task: dict[str, Any],
+            *,
+            role_index: int,
+        ) -> Any:
+            self.bind_calls.append((task["phase"], task.get("fold_id"), role_index))
+            return registry.bind_training_loss(task, role_index=role_index)
+
+    local_implementations = _CountingRegistry()
+    role = {
+        "schema_version": 1,
+        "node_id": "model:compat.0",
+        "output_id": "oof",
+        "phases": ["FIT_CV", "REFIT"],
+        "loss": loss_reference,
+    }
+
+    result = nirs4all.run(
+        [
+            KFold(n_splits=2),
+            {
+                "model": _TinyTorchRegressor(),
+                "train_params": {
+                    "epochs": 1,
+                    "batch_size": 2,
+                    "optimizer": "SGD",
+                    "learning_rate": 0.1,
+                    "patience": 1,
+                    "verbose": 0,
+                },
+            },
+        ],
+        (
+            np.ones((8, 2), dtype=np.float32),
+            np.ones(8, dtype=np.float32),
+        ),
+        engine="dag-ml",
+        training_losses=(role,),
+        local_implementations=local_implementations,
+        random_state=42,
+    )
+
+    assert isinstance(result, RunResult)
+    assert calls
+    assert any(prediction_requires_grad for _, _, prediction_requires_grad in calls)
+    assert {phase for phase, _, _ in local_implementations.bind_calls} == {"FIT_CV", "REFIT"}
+    assert all(role_index == 0 for _, _, role_index in local_implementations.bind_calls)
+
+    node_results = result._dagml_node_results  # noqa: SLF001
+    assert node_results
+    model_lineage = [
+        node_result["lineage"]
+        for frame in node_results
+        for node_result in [frame.get("result") if frame.get("type") == "result" else frame]
+        if node_result
+        and (node_result.get("lineage") or {}).get("node_id") == "model:compat.0"
+        and (node_result.get("lineage") or {}).get("phase") in {"FIT_CV", "REFIT"}
+    ]
+    assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
+    assert all(
+        [attestation["loss_id"] for attestation in record["loss_attestations"]]
+        == ["example.loss.nirs4all-public-run-torch-squared@1"]
+        for record in model_lineage
+    )
 
 
 def test_run_rejects_process_local_losses_on_legacy_engine() -> None:

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -114,6 +114,76 @@ def test_dagml_run_uses_in_process(monkeypatch: pytest.MonkeyPatch) -> None:
     assert result is marker
 
 
+def test_run_forwards_dagml_training_losses_without_legacy_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Public process-local custom losses are a DAG-ML-only contract: run() forwards the native role
+    references and local registry, and a DAG-ML refusal is not hidden by legacy fallback."""
+    import nirs4all.pipeline.dagml.run_backend as run_backend
+    from nirs4all.data.predictions import Predictions
+    from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV", "REFIT"], "loss": {"loss_id": "example.loss@1"}}
+    registry = object()
+    marker = RunResult(predictions=Predictions(), per_dataset={})
+    captured: dict[str, object] = {}
+
+    def _fake_dagml(*_args: object, **kwargs: object) -> RunResult:
+        captured.update(kwargs)
+        return marker
+
+    monkeypatch.setattr(run_backend, "run_via_dagml", _fake_dagml)
+    result = nirs4all.run(
+        [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+        dataset_path("regression"),
+        engine="dag-ml",
+        training_losses=(role,),
+        local_implementations=registry,
+    )
+
+    assert result is marker
+    assert captured["training_losses"] == (role,)
+    assert captured["local_implementations"] is registry
+
+    def _unsupported(*_args: object, **_kwargs: object) -> RunResult:
+        raise DagMlUnsupported("custom loss unsupported")
+
+    monkeypatch.setattr(run_backend, "run_via_dagml", _unsupported)
+    with pytest.raises(DagMlUnsupported, match="custom loss unsupported"):
+        nirs4all.run(
+            [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            training_losses=(role,),
+            local_implementations=registry,
+        )
+
+
+def test_run_rejects_process_local_losses_on_legacy_engine() -> None:
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV"], "loss": {"loss_id": "example.loss@1"}}
+
+    with pytest.raises(ValueError, match="require engine='dag-ml'"):
+        nirs4all.run(
+            [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="legacy",
+            training_losses=(role,),
+            local_implementations=object(),
+        )
+
+
+def test_run_rejects_process_local_losses_on_native_tuning_bypass() -> None:
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV"], "loss": {"loss_id": "example.loss@1"}}
+
+    with pytest.raises(NotImplementedError, match="does not yet thread DAG-ML process-local training losses"):
+        nirs4all.run(
+            [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            tuning={"space": {}, "score_data": {"X": [[1.0, 2.0]], "y": [1.0]}},
+            training_losses=(role,),
+            local_implementations=object(),
+        )
+
+
 def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
     """An explicit ``engine="dag-ml"`` run() transparently falls back to the LEGACY engine WITH A
     WARNING when the dag-ml backend is unavailable — simulated by the preflight raising

--- a/tests/unit/operators/models/test_jax.py
+++ b/tests/unit/operators/models/test_jax.py
@@ -4,6 +4,7 @@ import pytest
 from nirs4all.utils.backend import JAX_AVAILABLE
 
 
+@pytest.mark.jax
 @pytest.mark.xdist_group("gpu")
 @pytest.mark.skipif(not JAX_AVAILABLE, reason="JAX not available")
 class TestJaxModels:

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -154,6 +154,32 @@ class TestPyTorchLossResolution:
         with pytest.raises(ValueError, match="lacks invoke or required_attestation"):
             DagMLTrainingLossExecution(_loss_task(), registry)
 
+    @pytest.mark.parametrize(
+        ("required_loss_attestations", "error_type", "message"),
+        [
+            (None, TypeError, "must be a sequence"),
+            ("loss@1", TypeError, "must be a sequence"),
+            ([], ValueError, "require a loss attestation"),
+            ([object()], TypeError, "must be a mapping"),
+        ],
+    )
+    def test_dagml_execution_requires_task_owned_attestation(
+        self,
+        required_loss_attestations: Any,
+        error_type: type[Exception],
+        message: str,
+    ):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        task = _loss_task()
+        if required_loss_attestations is None:
+            task.pop("required_loss_attestations")
+        else:
+            task["required_loss_attestations"] = required_loss_attestations
+
+        with pytest.raises(error_type, match=message):
+            DagMLTrainingLossExecution(task, _RecordingLossRegistry())
+
     def test_dagml_execution_rejects_attestation_mismatch(self):
         from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
 

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -1,10 +1,47 @@
 """Tests for PyTorch models."""
 
+import pickle
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
 from nirs4all.utils.backend import TORCH_AVAILABLE
+
+
+class _RecordingLossRegistry:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.bind_calls: list[tuple[dict[str, Any], int]] = []
+        self.calls: list[tuple[dict[str, Any], Any, Any, int]] = []
+        self.fail = fail
+
+    def bind_training_loss(
+        self,
+        task: dict[str, Any],
+        *,
+        role_index: int,
+    ) -> dict[str, Any]:
+        self.bind_calls.append((task, role_index))
+
+        def invoke(target: Any, prediction: Any) -> Any:
+            if self.fail:
+                raise RuntimeError("custom loss failed")
+            self.calls.append((task, target, prediction, role_index))
+            value = (prediction - target) ** 2
+            mean = getattr(value, "mean", None)
+            return mean() if callable(mean) else value
+
+        return {
+            "invoke": invoke,
+            "required_attestation": {
+                "phase": task["phase"],
+                "loss_id": "example.loss.squared@1",
+            },
+        }
+
+
+def _loss_task(phase: str = "FIT_CV") -> dict[str, Any]:
+    return {"phase": phase, "node_plan": {"training_losses": [{}]}}
 
 
 class TestPyTorchLossResolution:
@@ -55,6 +92,62 @@ class TestPyTorchLossResolution:
         with pytest.raises(ValueError, match="Unknown PyTorch loss 'not_a_loss'"):
             _resolve_loss_function("not_a_loss", self._fake_nn())
 
+    def test_dagml_execution_adapts_prediction_target_order(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        registry = _RecordingLossRegistry()
+        execution = DagMLTrainingLossExecution(_loss_task(), registry)
+        loss_fn = _resolve_loss_function(execution, self._fake_nn())
+
+        assert loss_fn(3.0, 1.0) == 4.0
+
+        assert len(registry.bind_calls) == 1
+        assert registry.calls[0][1:] == (1.0, 3.0, 0)
+        assert execution.loss_attestations == [
+            {"phase": "FIT_CV", "loss_id": "example.loss.squared@1"}
+        ]
+
+    def test_dagml_execution_is_process_local_and_attests_only_after_success(self):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        execution = DagMLTrainingLossExecution(
+            _loss_task("REFIT"), _RecordingLossRegistry(fail=True)
+        )
+
+        assert execution.loss_attestations == []
+        with pytest.raises(RuntimeError, match="custom loss failed"):
+            execution(1.0, 2.0)
+        assert execution.loss_attestations == []
+        with pytest.raises(TypeError, match="cannot be serialized"):
+            pickle.dumps(execution)
+
+    @pytest.mark.parametrize(
+        ("phase", "role_index", "message"),
+        [
+            ("PREDICT", 0, "only in FIT_CV or REFIT"),
+            ("FIT_CV", -1, "non-negative integer"),
+            ("FIT_CV", True, "non-negative integer"),
+        ],
+    )
+    def test_dagml_execution_rejects_invalid_scope(
+        self, phase: str, role_index: int, message: str
+    ):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        with pytest.raises(ValueError, match=message):
+            DagMLTrainingLossExecution(
+                _loss_task(phase), _RecordingLossRegistry(), role_index=role_index
+            )
+
+    def test_dagml_execution_rejects_malformed_binding(self):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        registry = SimpleNamespace(bind_training_loss=lambda *_args, **_kwargs: {})
+
+        with pytest.raises(ValueError, match="lacks invoke or required_attestation"):
+            DagMLTrainingLossExecution(_loss_task(), registry)
+
 
 @pytest.mark.xdist_group("gpu")
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch not available")
@@ -79,3 +172,34 @@ class TestPyTorchModels:
         x = torch.randn(1, 5)
         y = model(x)
         assert y.shape == (1, 1)
+
+    def test_training_loop_executes_dagml_loss_and_captures_attestation(self):
+        import torch
+        import torch.nn as nn
+
+        from nirs4all.controllers.models.torch_model import PyTorchModelController
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        model = nn.Linear(1, 1, bias=False)
+        with torch.no_grad():
+            model.weight.zero_()
+        registry = _RecordingLossRegistry()
+        execution = DagMLTrainingLossExecution(_loss_task(), registry)
+
+        trained = PyTorchModelController()._train_model(
+            model,
+            torch.ones((4, 1)),
+            torch.ones((4, 1)),
+            optimizer="SGD",
+            lr=0.1,
+            epochs=1,
+            batch_size=2,
+            loss=execution,
+        )
+
+        assert trained.weight.detach().cpu().item() > 0.0
+        assert execution.invocation_count == 2
+        assert len(registry.bind_calls) == 1
+        assert execution.loss_attestations == [
+            {"phase": "FIT_CV", "loss_id": "example.loss.squared@1"}
+        ]

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -41,7 +41,13 @@ class _RecordingLossRegistry:
 
 
 def _loss_task(phase: str = "FIT_CV") -> dict[str, Any]:
-    return {"phase": phase, "node_plan": {"training_losses": [{}]}}
+    return {
+        "phase": phase,
+        "node_plan": {"training_losses": [{}]},
+        "required_loss_attestations": [
+            {"phase": phase, "loss_id": "example.loss.squared@1"}
+        ],
+    }
 
 
 class TestPyTorchLossResolution:
@@ -147,6 +153,26 @@ class TestPyTorchLossResolution:
 
         with pytest.raises(ValueError, match="lacks invoke or required_attestation"):
             DagMLTrainingLossExecution(_loss_task(), registry)
+
+    def test_dagml_execution_rejects_attestation_mismatch(self):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        class _MismatchedRegistry(_RecordingLossRegistry):
+            def bind_training_loss(
+                self,
+                task: dict[str, Any],
+                *,
+                role_index: int,
+            ) -> dict[str, Any]:
+                binding = super().bind_training_loss(task, role_index=role_index)
+                binding["required_attestation"] = {
+                    "phase": task["phase"],
+                    "loss_id": "example.loss.other@1",
+                }
+                return binding
+
+        with pytest.raises(ValueError, match="does not match the NodeTask requirement"):
+            DagMLTrainingLossExecution(_loss_task(), _MismatchedRegistry())
 
 
 @pytest.mark.xdist_group("gpu")

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -10,10 +10,11 @@ from nirs4all.utils.backend import TORCH_AVAILABLE
 
 
 class _RecordingLossRegistry:
-    def __init__(self, *, fail: bool = False) -> None:
+    def __init__(self, *, fail: bool = False, value: Any = None) -> None:
         self.bind_calls: list[tuple[dict[str, Any], int]] = []
         self.calls: list[tuple[dict[str, Any], Any, Any, int]] = []
         self.fail = fail
+        self.value = value
 
     def bind_training_loss(
         self,
@@ -27,6 +28,8 @@ class _RecordingLossRegistry:
             if self.fail:
                 raise RuntimeError("custom loss failed")
             self.calls.append((task, target, prediction, role_index))
+            if self.value is not None:
+                return self.value
             value = (prediction - target) ** 2
             mean = getattr(value, "mean", None)
             return mean() if callable(mean) else value
@@ -127,6 +130,19 @@ class TestPyTorchLossResolution:
         assert execution.loss_attestations == []
         with pytest.raises(TypeError, match="cannot be serialized"):
             pickle.dumps(execution)
+
+    @pytest.mark.parametrize("value", [float("nan"), float("inf"), -float("inf")])
+    def test_dagml_execution_rejects_non_finite_scalar_before_attestation(self, value: float):
+        from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+        execution = DagMLTrainingLossExecution(
+            _loss_task("REFIT"), _RecordingLossRegistry(value=value)
+        )
+
+        with pytest.raises(ValueError, match="non-finite scalar"):
+            execution(1.0, 2.0)
+        assert execution.invocation_count == 0
+        assert execution.loss_attestations == []
 
     @pytest.mark.parametrize(
         ("phase", "role_index", "message"),

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -1,8 +1,59 @@
 """Tests for PyTorch models."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from nirs4all.utils.backend import TORCH_AVAILABLE
+
+
+class TestPyTorchLossResolution:
+    """Test loss configuration without importing the optional backend."""
+
+    @staticmethod
+    def _fake_nn():
+        class MSELoss:
+            pass
+
+        class L1Loss:
+            pass
+
+        class CrossEntropyLoss:
+            pass
+
+        return SimpleNamespace(
+            MSELoss=MSELoss,
+            L1Loss=L1Loss,
+            CrossEntropyLoss=CrossEntropyLoss,
+        )
+
+    def test_known_alias_is_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("mse", nn), nn.MSELoss)
+
+    def test_torch_class_name_and_default_are_resolved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        nn = self._fake_nn()
+
+        assert isinstance(_resolve_loss_function("L1Loss", nn), nn.L1Loss)
+        assert isinstance(_resolve_loss_function("MSELoss", nn), nn.MSELoss)
+
+    def test_callable_is_preserved(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        custom_loss = object()
+
+        assert _resolve_loss_function(custom_loss, self._fake_nn()) is custom_loss
+
+    def test_unknown_loss_name_is_rejected(self):
+        from nirs4all.controllers.models.torch_model import _resolve_loss_function
+
+        with pytest.raises(ValueError, match="Unknown PyTorch loss 'not_a_loss'"):
+            _resolve_loss_function("not_a_loss", self._fake_nn())
 
 
 @pytest.mark.xdist_group("gpu")
@@ -28,4 +79,3 @@ class TestPyTorchModels:
         x = torch.randn(1, 5)
         y = model(x)
         assert y.shape == (1, 1)
-

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -217,7 +217,7 @@ class TestPyTorchLossResolution:
             DagMLTrainingLossExecution(_loss_task(), _MismatchedRegistry())
 
 
-@pytest.mark.xdist_group("gpu")
+@pytest.mark.xdist_group("torch")
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch not available")
 class TestPyTorchModels:
     """Test suite for PyTorch models."""

--- a/tests/unit/operators/models/test_pytorch.py
+++ b/tests/unit/operators/models/test_pytorch.py
@@ -217,7 +217,8 @@ class TestPyTorchLossResolution:
             DagMLTrainingLossExecution(_loss_task(), _MismatchedRegistry())
 
 
-@pytest.mark.xdist_group("torch")
+@pytest.mark.xdist_group("gpu")
+@pytest.mark.torch
 @pytest.mark.skipif(not TORCH_AVAILABLE, reason="PyTorch not available")
 class TestPyTorchModels:
     """Test suite for PyTorch models."""

--- a/tests/unit/operators/models/test_tensorflow.py
+++ b/tests/unit/operators/models/test_tensorflow.py
@@ -43,7 +43,13 @@ class _RecordingLossRegistry:
 
 
 def _loss_task(phase: str = "FIT_CV") -> dict[str, Any]:
-    return {"phase": phase, "node_plan": {"training_losses": [{}]}}
+    return {
+        "phase": phase,
+        "node_plan": {"training_losses": [{}]},
+        "required_loss_attestations": [
+            {"phase": phase, "loss_id": "example.loss.tensorflow-squared@1"}
+        ],
+    }
 
 
 def _train_with_dagml_loss(

--- a/tests/unit/operators/models/test_tensorflow.py
+++ b/tests/unit/operators/models/test_tensorflow.py
@@ -1,0 +1,194 @@
+"""Tests for TensorFlow models."""
+
+import io
+import os
+import subprocess
+import sys
+import zipfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from nirs4all.utils.backend import TF_AVAILABLE
+
+
+class _RecordingLossRegistry:
+    def __init__(self, implementation: Callable[[Any, Any], Any]) -> None:
+        self.bind_calls: list[tuple[dict[str, Any], int]] = []
+        self.calls: list[tuple[dict[str, Any], Any, Any, int]] = []
+        self.implementation = implementation
+
+    def bind_training_loss(
+        self,
+        task: dict[str, Any],
+        *,
+        role_index: int,
+    ) -> dict[str, Any]:
+        self.bind_calls.append((task, role_index))
+
+        def invoke(target: Any, prediction: Any) -> Any:
+            self.calls.append((task, target, prediction, role_index))
+            return self.implementation(target, prediction)
+
+        return {
+            "invoke": invoke,
+            "required_attestation": {
+                "phase": task["phase"],
+                "loss_id": "example.loss.tensorflow-squared@1",
+            },
+        }
+
+
+def _loss_task(phase: str = "FIT_CV") -> dict[str, Any]:
+    return {"phase": phase, "node_plan": {"training_losses": [{}]}}
+
+
+def _train_with_dagml_loss(
+    phase: str,
+    *,
+    nested_compile: bool = False,
+) -> tuple[Any, _RecordingLossRegistry, Any]:
+    import tensorflow as tf
+
+    from nirs4all.controllers.models.tensorflow_model import TensorFlowModelController
+    from nirs4all.core.task_type import TaskType
+    from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+    model = tf.keras.Sequential(
+        [
+            tf.keras.Input(shape=(1,)),
+            tf.keras.layers.Dense(1, use_bias=False, kernel_initializer="zeros"),
+        ]
+    )
+    registry = _RecordingLossRegistry(
+        lambda target, prediction: tf.reduce_mean(tf.square(prediction - target))
+    )
+    execution = DagMLTrainingLossExecution(_loss_task(phase), registry)
+    train_params: dict[str, Any] = {
+        "task_type": TaskType.REGRESSION,
+        "epochs": 1,
+        "batch_size": 2,
+        "validation_split": 0.0,
+        "best_model_memory": False,
+        "verbose": 0,
+    }
+    compile_params = {
+        "optimizer": "sgd",
+        "learning_rate": 0.1,
+        "loss": execution,
+        "metrics": [],
+    }
+    if nested_compile:
+        compile_params["run_eagerly"] = True
+        train_params["compile"] = compile_params
+    else:
+        train_params.update(compile_params)
+
+    trained = TensorFlowModelController()._train_model(
+        model,
+        np.ones((4, 1), dtype=np.float32),
+        np.ones((4, 1), dtype=np.float32),
+        **train_params,
+    )
+    return trained, registry, execution
+
+
+def test_dagml_execution_preserves_keras_target_prediction_order():
+    from nirs4all.controllers.models.tensorflow_model import _resolve_loss_function
+    from nirs4all.pipeline.dagml import DagMLTrainingLossExecution
+
+    registry = _RecordingLossRegistry(
+        lambda target, prediction: (prediction - target) ** 2
+    )
+    execution = DagMLTrainingLossExecution(_loss_task(), registry)
+    loss_fn = _resolve_loss_function(execution)
+
+    assert loss_fn(1.0, 3.0) == 4.0
+    assert len(registry.bind_calls) == 1
+    assert registry.calls[0][1:] == (1.0, 3.0, 0)
+    assert execution.loss_attestations == [
+        {"phase": "FIT_CV", "loss_id": "example.loss.tensorflow-squared@1"}
+    ]
+
+
+def test_regular_keras_loss_is_preserved():
+    from nirs4all.controllers.models.tensorflow_model import _resolve_loss_function
+
+    custom_loss = object()
+
+    assert _resolve_loss_function(custom_loss) is custom_loss
+
+
+@pytest.mark.tensorflow
+@pytest.mark.xdist_group("tensorflow")
+@pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not available")
+@pytest.mark.parametrize("phase", ["FIT_CV", "REFIT"])
+@pytest.mark.parametrize("nested_compile", [False, True], ids=["graph", "nested-eager"])
+def test_training_loop_executes_dagml_loss_and_preserves_gradients(
+    phase: str,
+    nested_compile: bool,
+):
+    trained, registry, execution = _train_with_dagml_loss(
+        phase,
+        nested_compile=nested_compile,
+    )
+
+    assert trained.layers[-1].get_weights()[0].item() > 0.0
+    assert execution.invocation_count >= 1
+    assert len(registry.bind_calls) == 1
+    assert execution.loss_attestations == [
+        {"phase": phase, "loss_id": "example.loss.tensorflow-squared@1"}
+    ]
+
+
+@pytest.mark.tensorflow
+@pytest.mark.xdist_group("tensorflow")
+@pytest.mark.skipif(not TF_AVAILABLE, reason="TensorFlow not available")
+def test_production_persistence_reloads_without_process_local_loss(
+    tmp_path: Path,
+):
+    from nirs4all.pipeline.storage.artifacts.artifact_persistence import to_bytes
+
+    trained, _, _ = _train_with_dagml_loss("FIT_CV")
+
+    data, format_name = to_bytes(trained, format_hint="tensorflow")
+    assert format_name == "tensorflow_keras"
+    with zipfile.ZipFile(io.BytesIO(data)) as archive:
+        config = archive.read("config.json")
+    assert b"example.loss.tensorflow-squared@1" not in config
+    assert b"DagMLTrainingLossExecution" not in config
+
+    artifact_path = tmp_path / "model.keras"
+    artifact_path.write_bytes(data)
+    script = "\n".join(
+        [
+            "import sys",
+            "from pathlib import Path",
+            "import numpy as np",
+            "from nirs4all.pipeline.storage.artifacts.artifact_persistence import from_bytes",
+            "data = Path(sys.argv[1]).read_bytes()",
+            "model = from_bytes(data, 'tensorflow_keras')",
+            "prediction = model.predict(np.ones((1, 1), dtype=np.float32), verbose=0)",
+            "assert prediction.shape == (1, 1)",
+        ]
+    )
+    env = os.environ.copy()
+    env.update(
+        {
+            "TF_CPP_MIN_LOG_LEVEL": "2",
+            "TF_NUM_INTRAOP_THREADS": "1",
+            "TF_NUM_INTEROP_THREADS": "1",
+        }
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script, str(artifact_path)],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 import numpy as np
@@ -17,6 +18,42 @@ from nirs4all.pipeline.dagml.raw_training_lowerer import (
     lower_raw_array_training_contracts,
     raw_arrays_to_spectro_dataset,
 )
+
+with contextlib.suppress(ImportError):
+    import torch
+
+with contextlib.suppress(ImportError):
+    import tensorflow as tf
+
+
+if "torch" in globals():
+
+    class _TinyTorchRegressor(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.linear = torch.nn.Linear(2, 1, bias=False)
+            torch.nn.init.zeros_(self.linear.weight)
+
+        def forward(self, features: Any) -> Any:
+            return self.linear(features)
+
+
+if "tf" in globals():
+
+    @tf.keras.utils.register_keras_serializable(package="nirs4all_tests")
+    class _TinyTensorFlowRegressor(tf.keras.Model):
+        def __init__(self, **kwargs: Any) -> None:
+            kwargs.setdefault("name", "tiny_tensorflow_regressor")
+            super().__init__(**kwargs)
+            self.flatten = tf.keras.layers.Flatten()
+            self.dense = tf.keras.layers.Dense(
+                1,
+                use_bias=False,
+                kernel_initializer="zeros",
+            )
+
+        def call(self, features: Any) -> Any:
+            return self.dense(self.flatten(features))
 
 
 class _FakeTrainingResult:
@@ -146,6 +183,65 @@ def test_lower_raw_array_training_contracts_rejects_step_level_train_params_unti
         lower_raw_array_training_contracts(pipeline, X, y, identity_frame=frame)
 
 
+def test_model_controller_routing_uses_framework_mro_without_substring_false_positives() -> None:
+    from nirs4all.pipeline.dagml_bridge import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+        _model_controller_id,
+    )
+
+    class _SciKerasLike:
+        pass
+
+    _SciKerasLike.__module__ = "scikeras.wrappers"
+
+    assert _model_controller_id(_SciKerasLike()) is None
+    if "torch" in globals():
+        assert _model_controller_id(_TinyTorchRegressor()) == _PYTORCH_MODEL_CONTROLLER_ID
+    if "tf" in globals():
+        assert _model_controller_id(_TinyTensorFlowRegressor()) == _TENSORFLOW_MODEL_CONTROLLER_ID
+
+
+def test_differentiable_backend_seed_maps_wide_core_seed_deterministically() -> None:
+    from nirs4all.pipeline.dagml.node_runner import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+        _seed_differentiable_backend,
+    )
+
+    seed = 2**63 + 17
+    if "torch" in globals():
+        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+        first_torch = torch.rand(3)
+        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+        assert torch.equal(first_torch, torch.rand(3))
+    if "tf" in globals():
+        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+        first_tensorflow = tf.random.uniform((3,))
+        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+        np.testing.assert_array_equal(first_tensorflow.numpy(), tf.random.uniform((3,)).numpy())
+
+
+def test_node_runner_rejects_missing_registry_and_multiple_loss_requirements() -> None:
+    from nirs4all.pipeline.dagml.node_runner import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _bind_training_loss,
+    )
+
+    task = {
+        "phase": "FIT_CV",
+        "required_loss_attestations": [{"phase": "FIT_CV", "loss_id": "loss@1"}],
+    }
+    with pytest.raises(RuntimeError, match="process-local loss registry"):
+        _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, None)
+
+    task["required_loss_attestations"].append(
+        {"phase": "FIT_CV", "loss_id": "other-loss@1"}
+    )
+    with pytest.raises(NotImplementedError, match="one training loss per task"):
+        _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, object())
+
+
 def test_raw_array_training_compiler_integrates_with_estimator_fit() -> None:
     _require_recent_dag_ml()
     X = np.arange(20, dtype=float).reshape(5, 4)
@@ -193,6 +289,234 @@ def test_raw_array_training_compiler_executes_native_training_when_supported() -
     assert estimator.training_outcome_.to_dict()["refit"]["status"] == "completed"
     assert estimator.outputs_[0]["binding"]["binding_id"] == "output:prediction"
     assert estimator.predictor_package_.to_dict()["package_id"] == "outcome:nirs4all.raw_fit-predictor"
+
+
+@pytest.mark.torch
+@pytest.mark.xdist_group("torch")
+def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -> None:
+    _require_recent_dag_ml()
+    if "torch" not in globals():
+        pytest.skip("PyTorch not available")
+    import dag_ml
+
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+
+    calls: list[tuple[tuple[int, ...], tuple[int, ...], bool, bool]] = []
+
+    def squared_loss(target: Any, prediction: Any) -> Any:
+        calls.append(
+            (
+                tuple(target.shape),
+                tuple(prediction.shape),
+                bool(target.requires_grad),
+                bool(prediction.requires_grad),
+            )
+        )
+        return torch.mean(torch.square(prediction - target))
+
+    registry = dag_ml.LocalImplementationRegistry()
+    loss_reference = registry.register_local_loss(
+        {
+            "schema_version": 1,
+            "loss_id": "example.loss.nirs4all-torch-squared@1",
+            "kind": "custom",
+            "task_kinds": ["regression"],
+            "prediction_kinds": ["regression_point"],
+            "objective": "minimize",
+            "reduction": "mean",
+            "required_inputs": ["target", "prediction"],
+            "capabilities": ["differentiable"],
+            "parameters": {},
+        },
+        squared_loss,
+        registry_key="loss:nirs4all:test-torch-squared",
+        implementation_fingerprint="a" * 64,
+        capabilities=["differentiable"],
+    )
+    bind_calls: list[tuple[str, str | None, str | None, int]] = []
+
+    class _CountingRegistry:
+        def bind_training_loss(
+            self,
+            task: dict[str, Any],
+            *,
+            role_index: int,
+        ) -> Any:
+            bind_calls.append(
+                (
+                    task["phase"],
+                    task.get("fold_id"),
+                    task.get("variant_id"),
+                    role_index,
+                )
+            )
+            return registry.bind_training_loss(task, role_index=role_index)
+
+    role = {
+        "schema_version": 1,
+        "node_id": "model:compat.0",
+        "output_id": "oof",
+        "phases": ["FIT_CV", "REFIT"],
+        "loss": loss_reference,
+    }
+    estimator = DagMLPipelineEstimator(
+        pipeline=[
+            KFold(n_splits=2),
+            {
+                "model": _TinyTorchRegressor(),
+                "train_params": {
+                    "epochs": 1,
+                    "batch_size": 2,
+                    "optimizer": "SGD",
+                    "learning_rate": 0.1,
+                    "patience": 1,
+                    "verbose": 0,
+                },
+            },
+        ],
+        training_compiler=RawArrayDagMLTrainingCompiler(
+            dagml_module="dag_ml",
+            training_losses=(role,),
+            local_implementations=_CountingRegistry(),
+        ),
+        dagml_module="dag_ml",
+    )
+    X = np.ones((6, 2), dtype=np.float32)
+    y = np.ones(6, dtype=np.float32)
+
+    estimator.fit(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    assert calls
+    assert all(not target_requires_grad for _, _, target_requires_grad, _ in calls)
+    assert any(prediction_requires_grad for _, _, _, prediction_requires_grad in calls)
+    assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
+    assert all(role_index == 0 for _, _, _, role_index in bind_calls)
+    outcome = estimator.training_outcome_.to_dict()
+    model_lineage = [
+        record
+        for record in outcome["lineage"]
+        if record["node_id"] == "model:compat.0"
+        and record["phase"] in {"FIT_CV", "REFIT"}
+    ]
+    assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
+    assert all(
+        [attestation["loss_id"] for attestation in record["loss_attestations"]]
+        == ["example.loss.nirs4all-torch-squared@1"]
+        for record in model_lineage
+    )
+    assert outcome["execution_bundle"]["refit_artifacts"][0][
+        "training_loss_fingerprint"
+    ]
+
+
+@pytest.mark.tensorflow
+@pytest.mark.xdist_group("tensorflow")
+def test_raw_array_training_executes_local_tensorflow_loss_and_detaches_refit_artifact() -> None:
+    _require_recent_dag_ml()
+    if "tf" not in globals():
+        pytest.skip("TensorFlow not available")
+    import dag_ml
+
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+
+    calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+
+    def squared_loss(target: Any, prediction: Any) -> Any:
+        calls.append((tuple(target.shape), tuple(prediction.shape)))
+        return tf.reduce_mean(tf.square(prediction - target))
+
+    registry = dag_ml.LocalImplementationRegistry()
+    loss_reference = registry.register_local_loss(
+        {
+            "schema_version": 1,
+            "loss_id": "example.loss.nirs4all-tensorflow-squared@1",
+            "kind": "custom",
+            "task_kinds": ["regression"],
+            "prediction_kinds": ["regression_point"],
+            "objective": "minimize",
+            "reduction": "mean",
+            "required_inputs": ["target", "prediction"],
+            "capabilities": ["differentiable"],
+            "parameters": {},
+        },
+        squared_loss,
+        registry_key="loss:nirs4all:test-tensorflow-squared",
+        implementation_fingerprint="b" * 64,
+        capabilities=["differentiable"],
+    )
+    bind_calls: list[tuple[str, str | None, str | None, int]] = []
+
+    class _CountingRegistry:
+        def bind_training_loss(
+            self,
+            task: dict[str, Any],
+            *,
+            role_index: int,
+        ) -> Any:
+            bind_calls.append(
+                (
+                    task["phase"],
+                    task.get("fold_id"),
+                    task.get("variant_id"),
+                    role_index,
+                )
+            )
+            return registry.bind_training_loss(task, role_index=role_index)
+
+    estimator = DagMLPipelineEstimator(
+        pipeline=[
+            KFold(n_splits=2),
+            {
+                "model": _TinyTensorFlowRegressor(),
+                "train_params": {
+                    "epochs": 1,
+                    "batch_size": 2,
+                    "optimizer": "sgd",
+                    "learning_rate": 0.1,
+                    "patience": 1,
+                    "best_model_memory": False,
+                    "verbose": 0,
+                },
+            },
+        ],
+        training_compiler=RawArrayDagMLTrainingCompiler(
+            dagml_module="dag_ml",
+            training_losses=(
+                {
+                    "schema_version": 1,
+                    "node_id": "model:compat.0",
+                    "output_id": "oof",
+                    "phases": ["FIT_CV", "REFIT"],
+                    "loss": loss_reference,
+                },
+            ),
+            local_implementations=_CountingRegistry(),
+        ),
+        dagml_module="dag_ml",
+    )
+    X = np.ones((6, 2), dtype=np.float32)
+    y = np.ones(6, dtype=np.float32)
+
+    estimator.fit(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    assert calls
+    assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
+    assert all(role_index == 0 for _, _, _, role_index in bind_calls)
+    outcome = estimator.training_outcome_.to_dict()
+    model_lineage = [
+        record
+        for record in outcome["lineage"]
+        if record["node_id"] == "model:compat.0"
+        and record["phase"] in {"FIT_CV", "REFIT"}
+    ]
+    assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
+    assert all(
+        [attestation["loss_id"] for attestation in record["loss_attestations"]]
+        == ["example.loss.nirs4all-tensorflow-squared@1"]
+        for record in model_lineage
+    )
 
 
 def test_raw_array_training_compiler_executes_native_deterministic_finetune_when_supported() -> None:

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -32,6 +32,11 @@ def _tiny_torch_regressor() -> Any:
         def forward(self, features: Any) -> Any:
             return self.linear(features)
 
+    # dag-ml rebuilds local implementations by module-qualified class name.
+    # Publish this lazily-created class exactly as a module-level test fixture.
+    TinyTorchRegressor.__qualname__ = "TinyTorchRegressor"
+    TinyTorchRegressor.__module__ = __name__
+    globals()[TinyTorchRegressor.__name__] = TinyTorchRegressor
     return TinyTorchRegressor()
 
 
@@ -54,6 +59,9 @@ def _tiny_tensorflow_regressor() -> Any:
         def call(self, features: Any) -> Any:
             return self.dense(self.flatten(features))
 
+    TinyTensorFlowRegressor.__qualname__ = "TinyTensorFlowRegressor"
+    TinyTensorFlowRegressor.__module__ = __name__
+    globals()[TinyTensorFlowRegressor.__name__] = TinyTensorFlowRegressor
     return TinyTensorFlowRegressor()
 
 

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import contextlib
 from typing import Any
 
 import numpy as np
@@ -19,16 +18,12 @@ from nirs4all.pipeline.dagml.raw_training_lowerer import (
     raw_arrays_to_spectro_dataset,
 )
 
-with contextlib.suppress(ImportError):
+
+def _tiny_torch_regressor() -> Any:
+    """Build the native test model without initializing another runtime."""
     import torch
 
-with contextlib.suppress(ImportError):
-    import tensorflow as tf
-
-
-if "torch" in globals():
-
-    class _TinyTorchRegressor(torch.nn.Module):
+    class TinyTorchRegressor(torch.nn.Module):
         def __init__(self) -> None:
             super().__init__()
             self.linear = torch.nn.Linear(2, 1, bias=False)
@@ -37,11 +32,15 @@ if "torch" in globals():
         def forward(self, features: Any) -> Any:
             return self.linear(features)
 
+    return TinyTorchRegressor()
 
-if "tf" in globals():
+
+def _tiny_tensorflow_regressor() -> Any:
+    """Build the native test model without initializing another runtime."""
+    import tensorflow as tf
 
     @tf.keras.utils.register_keras_serializable(package="nirs4all_tests")
-    class _TinyTensorFlowRegressor(tf.keras.Model):
+    class TinyTensorFlowRegressor(tf.keras.Model):
         def __init__(self, **kwargs: Any) -> None:
             kwargs.setdefault("name", "tiny_tensorflow_regressor")
             super().__init__(**kwargs)
@@ -54,6 +53,8 @@ if "tf" in globals():
 
         def call(self, features: Any) -> Any:
             return self.dense(self.flatten(features))
+
+    return TinyTensorFlowRegressor()
 
 
 class _FakeTrainingResult:
@@ -185,8 +186,6 @@ def test_lower_raw_array_training_contracts_rejects_step_level_train_params_unti
 
 def test_model_controller_routing_uses_framework_mro_without_substring_false_positives() -> None:
     from nirs4all.pipeline.dagml_bridge import (
-        _PYTORCH_MODEL_CONTROLLER_ID,
-        _TENSORFLOW_MODEL_CONTROLLER_ID,
         _model_controller_id,
     )
 
@@ -196,30 +195,65 @@ def test_model_controller_routing_uses_framework_mro_without_substring_false_pos
     _SciKerasLike.__module__ = "scikeras.wrappers"
 
     assert _model_controller_id(_SciKerasLike()) is None
-    if "torch" in globals():
-        assert _model_controller_id(_TinyTorchRegressor()) == _PYTORCH_MODEL_CONTROLLER_ID
-    if "tf" in globals():
-        assert _model_controller_id(_TinyTensorFlowRegressor()) == _TENSORFLOW_MODEL_CONTROLLER_ID
 
 
-def test_differentiable_backend_seed_maps_wide_core_seed_deterministically() -> None:
+@pytest.mark.torch
+def test_model_controller_routing_accepts_pytorch_mro() -> None:
+    from nirs4all.pipeline.dagml_bridge import (
+        _PYTORCH_MODEL_CONTROLLER_ID,
+        _model_controller_id,
+    )
+
+    pytest.importorskip("torch")
+    assert _model_controller_id(_tiny_torch_regressor()) == _PYTORCH_MODEL_CONTROLLER_ID
+
+
+@pytest.mark.tensorflow
+def test_model_controller_routing_accepts_tensorflow_mro() -> None:
+    from nirs4all.pipeline.dagml_bridge import (
+        _TENSORFLOW_MODEL_CONTROLLER_ID,
+        _model_controller_id,
+    )
+
+    pytest.importorskip("tensorflow")
+    assert (
+        _model_controller_id(_tiny_tensorflow_regressor())
+        == _TENSORFLOW_MODEL_CONTROLLER_ID
+    )
+
+
+@pytest.mark.torch
+def test_pytorch_seed_maps_wide_core_seed_deterministically() -> None:
     from nirs4all.pipeline.dagml.node_runner import (
         _PYTORCH_MODEL_CONTROLLER_ID,
+        _seed_differentiable_backend,
+    )
+
+    torch = pytest.importorskip("torch")
+
+    seed = 2**63 + 17
+    _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+    first_torch = torch.rand(3)
+    _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
+    assert torch.equal(first_torch, torch.rand(3))
+
+
+@pytest.mark.tensorflow
+def test_tensorflow_seed_maps_wide_core_seed_deterministically() -> None:
+    from nirs4all.pipeline.dagml.node_runner import (
         _TENSORFLOW_MODEL_CONTROLLER_ID,
         _seed_differentiable_backend,
     )
 
+    tf = pytest.importorskip("tensorflow")
+
     seed = 2**63 + 17
-    if "torch" in globals():
-        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
-        first_torch = torch.rand(3)
-        _seed_differentiable_backend(_PYTORCH_MODEL_CONTROLLER_ID, seed)
-        assert torch.equal(first_torch, torch.rand(3))
-    if "tf" in globals():
-        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
-        first_tensorflow = tf.random.uniform((3,))
-        _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
-        np.testing.assert_array_equal(first_tensorflow.numpy(), tf.random.uniform((3,)).numpy())
+    _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+    first_tensorflow = tf.random.uniform((3,))
+    _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
+    np.testing.assert_array_equal(
+        first_tensorflow.numpy(), tf.random.uniform((3,)).numpy()
+    )
 
 
 def test_node_runner_rejects_missing_registry_and_multiple_loss_requirements() -> None:
@@ -295,8 +329,7 @@ def test_raw_array_training_compiler_executes_native_training_when_supported() -
 @pytest.mark.xdist_group("torch")
 def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -> None:
     _require_recent_dag_ml()
-    if "torch" not in globals():
-        pytest.skip("PyTorch not available")
+    torch = pytest.importorskip("torch")
     import dag_ml
 
     if not hasattr(dag_ml, "LocalImplementationRegistry"):
@@ -364,7 +397,7 @@ def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -
         pipeline=[
             KFold(n_splits=2),
             {
-                "model": _TinyTorchRegressor(),
+                "model": _tiny_torch_regressor(),
                 "train_params": {
                     "epochs": 1,
                     "batch_size": 2,
@@ -414,8 +447,7 @@ def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -
 @pytest.mark.xdist_group("tensorflow")
 def test_raw_array_training_executes_local_tensorflow_loss_and_detaches_refit_artifact() -> None:
     _require_recent_dag_ml()
-    if "tf" not in globals():
-        pytest.skip("TensorFlow not available")
+    tf = pytest.importorskip("tensorflow")
     import dag_ml
 
     if not hasattr(dag_ml, "LocalImplementationRegistry"):
@@ -469,7 +501,7 @@ def test_raw_array_training_executes_local_tensorflow_loss_and_detaches_refit_ar
         pipeline=[
             KFold(n_splits=2),
             {
-                "model": _TinyTensorFlowRegressor(),
+                "model": _tiny_tensorflow_regressor(),
                 "train_params": {
                     "epochs": 1,
                     "batch_size": 2,

--- a/tests/unit/pipeline/dagml/test_result_projection.py
+++ b/tests/unit/pipeline/dagml/test_result_projection.py
@@ -1,0 +1,83 @@
+"""Tests for DAG-ML ScoreSet to RunResult projection metadata."""
+
+from __future__ import annotations
+
+from nirs4all.pipeline.dagml.result import _scores_to_run_result
+
+
+def test_scores_to_run_result_carries_native_node_results_for_attestation_audit() -> None:
+    scores = {
+        "reports": [
+            {
+                "partition": "validation",
+                "fold_id": "fold0",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "metrics": {"rmse": 1.0},
+            }
+        ]
+    }
+    node_results = [
+        {
+            "lineage": {
+                "node_id": "model:compat.0",
+                "phase": "FIT_CV",
+                "loss_attestations": [{"loss_id": "example.loss@1"}],
+            }
+        }
+    ]
+
+    result = _scores_to_run_result(
+        scores,
+        "dataset:test",
+        "TinyModel",
+        results=node_results,
+    )
+
+    assert result._dagml_node_results == node_results  # noqa: SLF001
+
+
+def test_scores_to_run_result_carries_variant_node_results_for_attestation_audit() -> None:
+    scores = {
+        "reports": [
+            {
+                "partition": "validation",
+                "fold_id": "fold0",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "metrics": {"rmse": 1.0},
+            }
+        ]
+    }
+    variant_frames = {
+        "variant:base": [
+            {
+                "lineage": {
+                    "node_id": "model:compat.0",
+                    "phase": "FIT_CV",
+                    "loss_attestations": [{"loss_id": "example.loss@1"}],
+                }
+            }
+        ],
+        "variant:loser": [
+            {
+                "lineage": {
+                    "node_id": "model:compat.0",
+                    "phase": "FIT_CV",
+                    "loss_attestations": [],
+                }
+            }
+        ],
+    }
+
+    result = _scores_to_run_result(
+        scores,
+        "dataset:test",
+        "TinyModel",
+        results_by_variant=variant_frames,
+    )
+
+    assert result._dagml_node_results == [  # noqa: SLF001
+        *variant_frames["variant:base"],
+        *variant_frames["variant:loser"],
+    ]

--- a/tests/unit/pipeline/dagml/test_training_contracts.py
+++ b/tests/unit/pipeline/dagml/test_training_contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import pytest
@@ -17,8 +18,16 @@ from nirs4all.pipeline.dagml.training_contracts import (
 
 
 def _dagml_training_fixture() -> dict:
-    fixture_path = Path(__file__).resolve().parents[5] / "dag-ml" / "examples" / "fixtures" / "training" / "python_training_smoke.v1.json"
-    if not fixture_path.exists():
+    relative_path = Path("dag-ml/examples/fixtures/training/python_training_smoke.v1.json")
+    fixture_path = next(
+        (
+            parent / relative_path
+            for parent in Path(__file__).resolve().parents
+            if (parent / relative_path).exists()
+        ),
+        None,
+    )
+    if fixture_path is None:
         pytest.skip("sibling dag-ml training fixture is not available")
     return json.loads(fixture_path.read_text(encoding="utf-8"))
 
@@ -79,6 +88,134 @@ def test_assemble_training_request_reproduces_and_validates_native_fixture() -> 
     assert validated.to_dict() == source
 
 
+def test_assemble_training_request_transports_and_orders_loss_roles_without_fixture() -> None:
+    later_role = _custom_training_loss_role()
+    later_role["node_id"] = "model:z"
+    later_role["output_id"] = None
+    later_role["phases"] = ["REFIT", "FIT_CV"]
+    earlier_role = deepcopy(later_role)
+    earlier_role["node_id"] = "model:a"
+    request = assemble_training_request(
+        DagMLTrainingRequestSpec(
+            request_id="training:test.loss-order",
+            plan_id="plan:test.loss-order",
+            graph={},
+            campaign={},
+            controller_manifests=(),
+            data_identities=(),
+            training_losses=(later_role, earlier_role),
+            output_requests=(),
+        )
+    )
+
+    assert [role["node_id"] for role in request["training_losses"]] == [
+        "model:a",
+        "model:z",
+    ]
+    assert all(
+        role["phases"] == ["FIT_CV", "REFIT"]
+        for role in request["training_losses"]
+    )
+    assert request["request_fingerprint"] == tcv1_fingerprint_without(
+        request, "request_fingerprint"
+    )
+
+
+def test_assemble_training_request_validates_native_training_loss_role() -> None:
+    fixture = _dagml_training_fixture()
+    source = fixture["request"]
+    controller_manifests = deepcopy(source["controller_manifests"])
+    model_manifest = next(
+        manifest
+        for manifest in controller_manifests
+        if manifest["controller_id"] == "controller:model.mock"
+    )
+    model_manifest["capabilities"] = sorted(
+        {
+            *model_manifest["capabilities"],
+            "needs_python_gil",
+            "supports_configurable_loss",
+            "supports_custom_loss",
+            "supports_differentiable_loss",
+        }
+    )
+    training_loss = _custom_training_loss_role()
+    spec = DagMLTrainingRequestSpec(
+        request_id=source["request_id"],
+        plan_id=source["plan_id"],
+        graph=source["graph"],
+        campaign=source["campaign"],
+        controller_manifests=controller_manifests,
+        data_identities=source["data_identities"],
+        training_losses=(training_loss,),
+        selection_metric=source["options"]["selection"]["metric"]["name"],
+        selection_objective=source["options"]["selection"]["metric"]["objective"],
+        selection_output_id=source["options"]["selection_output_id"],
+        output_requests=source["options"]["outputs"],
+        seed=source["options"]["seed"],
+        refit=source["options"]["refit"],
+        scheduler_workers=source["options"]["scheduler"]["workers"],
+        cpu_threads=source["options"]["resources"]["cpu_threads"],
+        cv_artifacts=source["options"]["artifacts"]["cv_artifacts"],
+        prediction_caches=source["options"]["artifacts"]["prediction_caches"],
+        fitted_artifacts=source["options"]["artifacts"]["fitted_artifacts"],
+        selection_required_metric_level=source["options"]["selection"]["required_metric_level"],
+        selection_evaluation_scope=source["options"]["selection"]["evaluation_scope"],
+    )
+
+    assembled = assemble_training_request(spec)
+
+    assert assembled["training_losses"] == [training_loss]
+    assert assembled["request_fingerprint"] == tcv1_fingerprint_without(
+        assembled, "request_fingerprint"
+    )
+    dag_ml = pytest.importorskip("dag_ml")
+    if not hasattr(dag_ml, "LocalImplementationRegistry"):
+        pytest.skip("installed dag_ml does not expose local loss contracts yet")
+    validated = validate_training_request_with_dagml(assembled, dag_ml)
+    assert validated.to_dict()["training_losses"] == [training_loss]
+
+
 def test_tcv1_rejects_nonfinite_values() -> None:
     with pytest.raises(ValueError, match="NaN and infinity"):
         tcv1_fingerprint_without({"x": float("nan"), "fp": "0" * 64}, "fp")
+
+
+def _custom_training_loss_role() -> dict:
+    spec = {
+        "schema_version": 1,
+        "loss_id": "example.loss.asymmetric@1",
+        "kind": "custom",
+        "task_kinds": ["regression"],
+        "prediction_kinds": ["regression_point"],
+        "objective": "minimize",
+        "reduction": "mean",
+        "required_inputs": ["target", "prediction"],
+        "capabilities": ["differentiable"],
+        "parameters": {"over_weight": 1.0, "under_weight": 2.0},
+        "spec_fingerprint": "cf661225cc7137ab5ef9b87871ed5736a8479dd21587b7e17150c442b1e43eb0",
+    }
+    implementation = {
+        "schema_version": 1,
+        "semantic_kind": "loss",
+        "semantic_id": spec["loss_id"],
+        "semantic_fingerprint": spec["spec_fingerprint"],
+        "provider_id": "provider:python-local",
+        "binding_id": "binding:python",
+        "implementation_version": "1.0.0",
+        "implementation_fingerprint": "1f4c71b0b758c5ed25b4e38b132b9ad56fb2f5ff2cf490f7eb8786c4350a62f7",
+        "supported_controller_families": [],
+        "runtime_requirements": [],
+        "capabilities": ["deterministic", "differentiable", "needs_gil"],
+        "portability": "host_local",
+        "replayability": "registry_required",
+        "registry_key": "loss:run-123:asymmetric",
+        "descriptor_fingerprint": "031c7b120740620dade9ba14a5f2e142831ecb1be47ea7181f68511dfafdd807",
+    }
+    return {
+        "schema_version": 1,
+        "node_id": "model:base",
+        "output_id": "oof",
+        "phases": ["FIT_CV", "REFIT"],
+        "loss": {"spec": spec, "implementation": implementation},
+    }

--- a/tests/unit/pipeline/storage/test_workspace_store.py
+++ b/tests/unit/pipeline/storage/test_workspace_store.py
@@ -8,6 +8,7 @@ concurrent access.  Every test uses ``tmp_path`` for isolation.
 from __future__ import annotations
 
 import gc
+import hashlib
 import json
 import threading
 import weakref
@@ -50,6 +51,40 @@ class _SummingModel:
 def _make_store(tmp_path: Path) -> WorkspaceStore:
     """Create a WorkspaceStore rooted at *tmp_path*."""
     return WorkspaceStore(tmp_path / "workspace")
+
+
+def test_load_artifact_routes_framework_native_format_to_artifact_loader(tmp_path, monkeypatch):
+    """Workspace-registered Keras payloads must not be deserialized as pickle."""
+    from nirs4all.pipeline.storage.artifacts import artifact_persistence
+
+    store = _make_store(tmp_path)
+    payload = b"keras-native-payload"
+    relative_path = "tf/model.keras"
+    artifact_path = store._artifacts_dir / relative_path  # noqa: SLF001
+    artifact_path.parent.mkdir(parents=True)
+    artifact_path.write_bytes(payload)
+    artifact_id = "tensorflow-model"
+    store.register_existing_artifact(
+        artifact_id=artifact_id,
+        path=relative_path,
+        content_hash=hashlib.sha256(payload).hexdigest(),
+        operator_class="keras.Sequential",
+        artifact_type="model",
+        format="tensorflow_keras",
+        size_bytes=len(payload),
+    )
+
+    expected = object()
+    calls: list[tuple[bytes, str]] = []
+
+    def fake_from_bytes(data: bytes, fmt: str):
+        calls.append((data, fmt))
+        return expected
+
+    monkeypatch.setattr(artifact_persistence, "from_bytes", fake_from_bytes)
+
+    assert store.load_artifact(artifact_id) is expected
+    assert calls == [(payload, "tensorflow_keras")]
 
 
 def _create_full_run(store: WorkspaceStore, *, dataset_name: str = "wheat") -> dict:

--- a/tests/unit/pipeline/test_dagml_in_process_router.py
+++ b/tests/unit/pipeline/test_dagml_in_process_router.py
@@ -14,6 +14,9 @@ These pin the SELECTION/AVAILABILITY logic without running a real dag-ml campaig
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pytest
 
 from nirs4all.pipeline.dagml import in_process_runner
@@ -97,6 +100,63 @@ def test_router_threads_process_local_training_losses_to_in_process(monkeypatch:
     assert outcome["returncode"] == 0
     assert captured["training_losses"] == (role,)
     assert captured["local_implementations"] is registry
+
+
+def test_in_process_runner_prefers_public_dagml_facade_for_training_losses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """dag-ml owns the in-process scheduler surface; nirs4all should call the public facade when present."""
+    dsl = {"pipeline": "dsl"}
+    envelope = {"data": "envelope"}
+    manifests = [{"controller_id": "controller:nirs4all.test"}]
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV"], "loss": {"loss_id": "example.loss@1"}}
+    registry = object()
+    dataset = object()
+    captured: dict[str, object] = {}
+
+    def _fake_facade_runner(
+        received_dsl: object,
+        received_envelope: object,
+        received_manifests: object,
+        received_roles: object,
+        op_callback: object,
+        selection_metric: str,
+    ) -> dict[str, object]:
+        captured.update(
+            {
+                "dsl": received_dsl,
+                "envelope": received_envelope,
+                "manifests": received_manifests,
+                "roles": received_roles,
+                "op_callback": op_callback,
+                "selection_metric": selection_metric,
+            }
+        )
+        return {"node_results": [], "scores": {"reports": []}}
+
+    monkeypatch.setitem(sys.modules, "dag_ml", SimpleNamespace(run_cv_refit_in_process_with_training_losses=_fake_facade_runner))
+    monkeypatch.delitem(sys.modules, "dag_ml._dag_ml", raising=False)
+    monkeypatch.setattr(in_process_runner, "controller_manifests", lambda: manifests)
+    monkeypatch.setattr(in_process_runner, "mint_identity", lambda _dataset: "dataset:test")
+    monkeypatch.setattr(in_process_runner, "MaterializationResolver", lambda *_args, **_kwargs: object())
+
+    outcome = in_process_runner.run_cv_refit_bundle(
+        dsl=dsl,
+        envelope=envelope,
+        graph={"nodes": [], "edges": []},
+        dataset_path="unused",
+        selection_metric="rmse",
+        dataset=dataset,
+        training_losses=(role,),
+        local_implementations=registry,
+    )
+
+    assert outcome["returncode"] == 0
+    assert outcome["scores"] == {"reports": []}
+    assert captured["dsl"] is dsl
+    assert captured["envelope"] is envelope
+    assert captured["manifests"] == manifests
+    assert captured["roles"] == [role]
+    assert callable(captured["op_callback"])
+    assert captured["selection_metric"] == "rmse"
 
 
 def test_router_rejects_process_local_training_losses_on_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/pipeline/test_dagml_in_process_router.py
+++ b/tests/unit/pipeline/test_dagml_in_process_router.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import pytest
 
 from nirs4all.pipeline.dagml import in_process_runner
-from nirs4all.pipeline.dagml.errors import DagMlUnavailable
+from nirs4all.pipeline.dagml.errors import DagMlUnavailable, DagMlUnsupported
 from nirs4all.pipeline.dagml.in_process_runner import in_process_enabled, run_cv_refit_bundle_router
 
 
@@ -72,6 +72,52 @@ def test_router_picks_in_process_when_selected_and_extension_loads(monkeypatch: 
     outcome = run_cv_refit_bundle_router(**_router_kwargs())
     assert called["in_process"] is True
     assert outcome is sentinel
+
+
+def test_router_threads_process_local_training_losses_to_in_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The router keeps executable local losses on the in-process branch and passes only the registry
+    object to the Python callback side."""
+    monkeypatch.delenv("N4A_DAGML_INPROCESS", raising=False)
+    monkeypatch.setattr(in_process_runner, "_dagml_extension_loads", lambda: True)
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV"], "loss": {"loss_id": "example.loss@1"}}
+    registry = object()
+    captured: dict[str, object] = {}
+
+    def _fake_in_process(**kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {"scores": {"reports": []}, "results": [], "returncode": 0, "stdout": ""}
+
+    monkeypatch.setattr(in_process_runner, "run_cv_refit_bundle", _fake_in_process)
+    outcome = run_cv_refit_bundle_router(
+        **_router_kwargs(),
+        training_losses=(role,),
+        local_implementations=registry,
+    )
+
+    assert outcome["returncode"] == 0
+    assert captured["training_losses"] == (role,)
+    assert captured["local_implementations"] is registry
+
+
+def test_router_rejects_process_local_training_losses_on_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("N4A_DAGML_INPROCESS", "off")
+    monkeypatch.setattr(in_process_runner, "_dagml_extension_loads", lambda: True)
+    role = {"schema_version": 1, "node_id": "model:compat.0", "output_id": "oof", "phases": ["FIT_CV"], "loss": {"loss_id": "example.loss@1"}}
+
+    with pytest.raises(DagMlUnsupported, match="subprocess adapter cannot receive local callables"):
+        run_cv_refit_bundle_router(
+            **_router_kwargs(dagml_cli="/nonexistent/dag-ml-cli"),
+            training_losses=(role,),
+            local_implementations=object(),
+        )
+
+
+def test_router_rejects_registry_without_training_losses() -> None:
+    with pytest.raises(DagMlUnsupported, match="without DAG-ML training_losses"):
+        run_cv_refit_bundle_router(
+            **_router_kwargs(),
+            local_implementations=object(),
+        )
 
 
 def test_router_falls_through_to_subprocess_when_extension_missing(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- route `nirs4all.run(engine="dag-ml")` training-loss roles and the process-local registry through the public DAG-ML in-process scheduler facade
- keep native `NodeResult` frames on the public `RunResult` path so loss attestations are auditable without adding a parallel nirs4all registry API
- reject legacy/subprocess/tuning paths that would lose process-local callbacks
- require a local loss binding attestation to exactly match the `NodeTask` requirement before it can be published
- require every process-local loss execution to start from task-owned `required_loss_attestations`, rejecting missing or malformed attestations before registry binding
- reject non-finite Python scalar custom-loss values before publishing the task-owned attestation

## Validation
- `rtk python3.11 -m pytest tests/unit/operators/models/test_pytorch.py::TestPyTorchLossResolution -q` (18 passed)
- `rtk python3.11 -m pytest tests/unit/pipeline/dagml tests/unit/pipeline/test_dagml_in_process_router.py tests/unit/operators/models/test_pytorch.py::TestPyTorchLossResolution tests/unit/operators/models/test_tensorflow.py -q` (516 passed, 14 skipped)
- `rtk python3.11 -m compileall -q nirs4all/pipeline/dagml tests/unit/operators/models/test_pytorch.py`
- `rtk git diff --check`
- GitHub Actions: 4 passed, 0 failed on `16454b60`

## Architecture
DAG-ML remains the contract owner for loss roles, task requirements, descriptor validation, scheduling and attestations. nirs4all owns only the host-side execution point that has the model tensors/callables; it now refuses any route where the process-local callback, exact task-required attestation, task-owned attestation requirement, or finite scalar result invariant would be lost.