### PR TITLE
feat(api): load native archive sessions explicitly

### DIFF
--- a/docs/source/reference/api/session.md
+++ b/docs/source/reference/api/session.md
@@ -77,18 +77,26 @@ with nirs4all.session(pipeline=my_pipeline, name="Demo", verbose=1) as sess:
    :no-index:
 ```
 
-Load a session from a saved `.n4a` bundle file.
+Load a legacy bundle session or an explicit portable Archive V2 prediction
+session.
 
 **Signature:**
 ```python
-nirs4all.load_session(path: Union[str, Path]) -> Session
+nirs4all.load_session(
+    path: Union[str, Path], *, engine: str = "legacy"
+) -> Union[Session, NativeArchiveSession]
 ```
 
 **Parameters:**
 - `path` (str|Path): Path to the `.n4a` bundle file to load
+- `engine`: `"legacy"` (default) preserves the existing `BundleLoader` session.
+  `"native"` opens a fail-closed Core Archive V2 Methods PREDICT session and
+  accepts no legacy fallback.
 
 **Returns:**
-- Session object ready for prediction, with status set to `"trained"`
+- `Session` for `engine="legacy"`, ready for legacy prediction.
+- `NativeArchiveSession` for `engine="native"`, ready for identity-bound
+  native PREDICT replay.
 
 **Raises:**
 - `FileNotFoundError`: If the bundle file does not exist
@@ -108,9 +116,22 @@ print(f"Is trained: {session.is_trained}")  # True
 predictions = session.predict(X_new)
 ```
 
+**Native Archive V2 example:**
+```python
+native = nirs4all.load_session("exports/methods_model.n4a", engine="native")
+prediction = nirs4all.predict(
+    data={"X": X_new, "sample_ids": sample_ids},
+    session=native,
+    engine="native",
+)
+native.close()
+```
+
 **Notes:**
-- The loaded session maintains a reference to the bundle file for predictions
-- The session can predict, retrain, or be saved to a new location
+- A legacy `Session` maintains a reference to its bundle and can use the
+  legacy prediction, retraining, and save APIs.
+- `NativeArchiveSession` is deliberately PREDICT-only: it owns no legacy
+  runner and cannot be repurposed for retraining or export.
 - The original bundle file is not modified by the loaded session
 
 ## Session Methods

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -60,7 +60,8 @@ The public Python API runs that contract directly. The CLI currently validates a
 | `nirs4all.explain(...)` | Generate SHAP explanations | Model/bundle + data | `ExplainResult` |
 | `nirs4all.retrain(...)` | Retrain from an existing result or bundle | Source + new data | `RunResult` |
 | `nirs4all.session(...)` | Share runner/workspace resources across calls | Optional pipeline and runner kwargs | `Session` |
-| `nirs4all.load_session(...)` | Load an exported `.n4a` bundle for prediction | Bundle path | `Session` |
+| `nirs4all.load_session(..., engine="legacy")` | Load an exported legacy `.n4a` bundle for prediction | Bundle path | `Session` |
+| `nirs4all.load_session(..., engine="native")` | Open a portable Archive V2 Methods PREDICT session without a legacy fallback | Archive path | `NativeArchiveSession` |
 | `nirs4all.generate(...)` | Generate synthetic NIRS data | Synthetic parameters | `SpectroDataset` or arrays |
 | `result.export(...)` | Export a trained pipeline bundle | Output path | `.n4a` path |
 

--- a/docs/source/user_guide/predictions/session_api.md
+++ b/docs/source/user_guide/predictions/session_api.md
@@ -117,6 +117,28 @@ print(f"Ready for prediction: {loaded_session.is_trained}")  # True
 predictions = loaded_session.predict(X_new)
 ```
 
+### Native Archive V2 prediction sessions
+
+For a portable Methods Archive V2, choose the native path explicitly.  It
+does not construct a `PipelineRunner`, invoke the legacy bundle loader, or
+fall back to Python execution.  Every prediction cohort must carry stable
+sample ids:
+
+```python
+import nirs4all
+
+with nirs4all.load_session("exports/methods_model.n4a", engine="native") as native:
+    prediction = nirs4all.predict(
+        data={"X": X_new, "sample_ids": sample_ids},
+        session=native,
+        engine="native",
+    )
+```
+
+This R2 migration surface supports portable **PREDICT** replay only.  Training,
+retraining and explanation remain separate capabilities and are never routed to
+the legacy runner implicitly.
+
 ## Session Features
 
 ### Stateful Pipeline Management

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -44,7 +44,7 @@ from nirs4all.pipeline import PipelineRunner
 from nirs4all.pipeline.engine import require_legacy_engine
 
 from .result import PredictResult
-from .session import Session
+from .session import NativeArchiveSession, Session
 
 # Type aliases for clarity
 ModelSpec: TypeAlias = (
@@ -72,7 +72,7 @@ def predict(
     workspace_path: str | Path | None = None,
     name: str = "prediction_dataset",
     all_predictions: bool = False,
-    session: Session | None = None,
+    session: Session | NativeArchiveSession | None = None,
     verbose: int = 0,
     coverage: float | list[float] | tuple[float, ...] | None = None,
     save_to_workspace: bool = False,
@@ -158,8 +158,10 @@ def predict(
         workspace_result_metadata: Optional result-level metadata merged over
             ``result.metadata`` when publishing the workspace prediction row.
 
-        session: Optional Session for resource reuse.
-            If provided, uses the session's runner.
+        session: Optional legacy :class:`Session` for runner reuse, or an
+            explicitly loaded :class:`NativeArchiveSession` with
+            ``engine="native"``.  Native sessions never construct a legacy
+            runner.
 
         verbose: Verbosity level (0=quiet, 1=info, 2=debug).
             Default: 0
@@ -210,15 +212,20 @@ def predict(
         - :func:`nirs4all.explain`: Generate SHAP explanations
         - :class:`nirs4all.api.result.PredictResult`: Result class
     """
+    engine = runner_kwargs.pop("engine", None)
+
+    if isinstance(session, NativeArchiveSession) and engine != "native":
+        raise ValueError(
+            "NativeArchiveSession requires engine='native'; it never falls back to legacy prediction"
+        )
+
     # ---- Validate mutually exclusive arguments ----
     if model is not None and chain_id is not None:
         raise ValueError("Provide either 'model' or 'chain_id', not both.")
-    if model is None and chain_id is None:
+    if model is None and chain_id is None and not isinstance(session, NativeArchiveSession):
         raise ValueError("Provide either 'model' or 'chain_id'.")
     if data is None:
         raise ValueError("'data' is required.")
-
-    engine = runner_kwargs.pop("engine", None)
 
     if engine == "native":
         result = _predict_from_native_archive(
@@ -394,15 +401,16 @@ def _predict_from_native_archive(
     materialized by DAG-ML are exposed as views; this path never recalibrates.
     """
 
-    if chain_id is not None or session is not None:
+    if chain_id is not None:
         raise NotImplementedError(
-            "engine='native' predict accepts an Archive V2 model path, not a legacy chain or Session"
+            "engine='native' predict accepts an Archive V2 model path or NativeArchiveSession, not a legacy chain"
         )
-    if not isinstance(model, (str, Path)):
-        raise TypeError("engine='native' predict requires a Core Archive V2 model path")
-    archive_path = Path(model)
-    if archive_path.suffix.lower() != ".n4a":
-        raise ValueError("engine='native' predict requires an Archive V2 .n4a path")
+    if session is not None and not isinstance(session, NativeArchiveSession):
+        raise NotImplementedError(
+            "engine='native' predict accepts a NativeArchiveSession, not a legacy Session"
+        )
+    if session is not None and model is not None:
+        raise ValueError("engine='native' predict accepts either model or NativeArchiveSession, not both")
     if all_predictions:
         raise NotImplementedError(
             "engine='native' Archive V2 prediction exposes one selected final output"
@@ -411,33 +419,52 @@ def _predict_from_native_archive(
         raise TypeError(
             "engine='native' predict requires data={'X': matrix, 'sample_ids': explicit_ids}"
         )
-    from nirs4all.pipeline.dagml.native_archive_replay import (
-        predict_methods_archive_v2_raw_result,
-    )
+    if session is not None:
+        session_result = session.predict(
+            data["X"],
+            sample_ids=data["sample_ids"],
+            groups=data.get("groups"),
+            metadata=data.get("metadata"),
+        )
+        values = session_result.y_pred
+        sample_ids = tuple(session_result.metadata["sample_ids"])
+        intervals = dict(session_result.intervals)
+        metadata = dict(session_result.metadata)
+        conformal_guarantee_status = metadata.get("conformal_guarantee_status")
+    else:
+        if not isinstance(model, (str, Path)):
+            raise TypeError("engine='native' predict requires a Core Archive V2 model path")
+        archive_path = Path(model)
+        if archive_path.suffix.lower() != ".n4a":
+            raise ValueError("engine='native' predict requires an Archive V2 .n4a path")
+        from nirs4all.pipeline.dagml.native_archive_replay import (
+            predict_methods_archive_v2_raw_result,
+        )
 
-    native_prediction = predict_methods_archive_v2_raw_result(
-        archive_path,
-        data["X"],
-        sample_ids=data["sample_ids"],
-        groups=data.get("groups"),
-        metadata=data.get("metadata"),
-    )
-    intervals = dict(native_prediction.intervals)
+        native_prediction = predict_methods_archive_v2_raw_result(
+            archive_path,
+            data["X"],
+            sample_ids=data["sample_ids"],
+            groups=data.get("groups"),
+            metadata=data.get("metadata"),
+        )
+        values = native_prediction.values
+        sample_ids = native_prediction.sample_ids
+        intervals = dict(native_prediction.intervals)
+        conformal_guarantee_status = native_prediction.conformal_guarantee_status
+        metadata = {
+            "engine": "native",
+            "archive_path": str(archive_path),
+            "sample_ids": list(sample_ids),
+        }
     selected_coverages = _normalize_requested_coverages(coverage)
     if selected_coverages is not None:
         intervals = _select_native_archive_intervals(intervals, selected_coverages)
-    metadata: dict[str, Any] = {
-        "engine": "native",
-        "archive_path": str(archive_path),
-        "sample_ids": list(native_prediction.sample_ids),
-    }
-    if native_prediction.conformal_guarantee_status is not None:
-        metadata["conformal_guarantee_status"] = dict(
-            native_prediction.conformal_guarantee_status
-        )
+    if conformal_guarantee_status is not None:
+        metadata["conformal_guarantee_status"] = dict(conformal_guarantee_status)
         metadata["selected_interval_coverages"] = sorted(intervals)
     return PredictResult(
-        y_pred=native_prediction.values,
+        y_pred=values,
         metadata=metadata,
         model_name="MethodsN4MM",
         preprocessing_steps=[],

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -242,6 +242,11 @@ def predict(
             )
         return result
 
+    # The explicit native branch above consumes every NativeArchiveSession.
+    # Narrow the remaining legacy paths for both runtime safety and static
+    # checking; none may receive a portable native session.
+    assert not isinstance(session, NativeArchiveSession)
+
     if _is_calibrated_replayed_prediction_request(model, data):
         result = _predict_from_calibrated_replayed_arrays(
             model=model,
@@ -391,14 +396,15 @@ def _predict_from_native_archive(
     chain_id: str | None,
     all_predictions: bool,
     coverage: float | list[float] | tuple[float, ...] | None,
-    session: Session | None,
+    session: Session | NativeArchiveSession | None,
 ) -> PredictResult:
     """Execute the narrow, portable Archive V2 Methods PREDICT route.
 
     This route is explicit while R2 is being qualified.  It owns no legacy
-    runner and therefore refuses store/session requests, sidecars and implicit
-    row identities before data execution. Native split-conformal blocks already
-    materialized by DAG-ML are exposed as views; this path never recalibrates.
+    runner and accepts only a model path or a NativeArchiveSession, never a
+    store/legacy session, sidecar or implicit row identities. Native
+    split-conformal blocks already materialized by DAG-ML are exposed as views;
+    this path never recalibrates.
     """
 
     if chain_id is not None:
@@ -419,6 +425,8 @@ def _predict_from_native_archive(
         raise TypeError(
             "engine='native' predict requires data={'X': matrix, 'sample_ids': explicit_ids}"
         )
+    metadata: dict[str, Any]
+    prediction_sample_ids: tuple[str, ...]
     if session is not None:
         session_result = session.predict(
             data["X"],
@@ -427,7 +435,7 @@ def _predict_from_native_archive(
             metadata=data.get("metadata"),
         )
         values = session_result.y_pred
-        sample_ids = tuple(session_result.metadata["sample_ids"])
+        prediction_sample_ids = tuple(session_result.metadata["sample_ids"])
         intervals = dict(session_result.intervals)
         metadata = dict(session_result.metadata)
         conformal_guarantee_status = metadata.get("conformal_guarantee_status")
@@ -449,13 +457,13 @@ def _predict_from_native_archive(
             metadata=data.get("metadata"),
         )
         values = native_prediction.values
-        sample_ids = native_prediction.sample_ids
+        prediction_sample_ids = native_prediction.sample_ids
         intervals = dict(native_prediction.intervals)
         conformal_guarantee_status = native_prediction.conformal_guarantee_status
         metadata = {
             "engine": "native",
             "archive_path": str(archive_path),
-            "sample_ids": list(sample_ids),
+            "sample_ids": list(prediction_sample_ids),
         }
     selected_coverages = _normalize_requested_coverages(coverage)
     if selected_coverages is not None:

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -504,14 +504,23 @@ class Session:
             status = "active" if self._runner is not None else "idle"
             return f"Session({status}, kwargs={list(self._runner_kwargs.keys())})"
 
-def load_session(path: str | Path) -> Session:
-    """Load a session from a saved bundle file.
+def load_session(
+    path: str | Path,
+    *,
+    engine: str = "legacy",
+) -> Session | NativeArchiveSession:
+    """Load a prediction session from a saved bundle or portable archive.
 
     Args:
-        path: Path to .n4a bundle file.
+        path: Path to a ``.n4a`` bundle or archive file.
+        engine: ``"legacy"`` (default) retains the existing BundleLoader
+            session. ``"native"`` opens the fail-closed Core Archive V2
+            Methods replay session; it never constructs a ``PipelineRunner``
+            or falls back to the legacy loader.
 
     Returns:
-        Session ready for prediction.
+        A session ready for prediction. The concrete type is
+        :class:`NativeArchiveSession` for ``engine="native"``.
 
     Example:
         >>> session = nirs4all.load_session("exports/model.n4a")
@@ -523,6 +532,16 @@ def load_session(path: str | Path) -> Session:
     path = Path(path)
     if not path.exists():
         raise FileNotFoundError(f"Bundle not found: {path}")
+
+    if engine == "native":
+        if path.suffix.lower() != ".n4a":
+            raise ValueError("engine='native' load_session requires a Core Archive V2 .n4a path")
+        return load_native_archive_session(path)
+    if engine != "legacy":
+        from nirs4all.pipeline.engine import require_legacy_engine
+
+        require_legacy_engine("load_session", engine)
+        raise AssertionError("require_legacy_engine unexpectedly accepted a non-legacy engine")
 
     # Load the bundle to get pipeline info
     loader = BundleLoader(path)

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -9,6 +9,7 @@ replay once the nirs4all→DAG-ML contract compiler is supplied.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol
 
 import numpy as np
@@ -275,6 +276,48 @@ class DagMLPipelineEstimator(BaseEstimator):
                 "DagMLPipelineEstimator.predict_with_identity() requires a native prediction decoder; P1 does not synthesize Python predictions from replay JSON"
             )
         return np.asarray(self.prediction_decoder(replay_outcome))
+
+    def export_native_archive(
+        self,
+        archive_path: str | Path,
+        *,
+        archive_id: str,
+    ) -> dict[str, str]:
+        """Write this fitted native predictor as a portable Archive V2.
+
+        The archive consists solely of the exact native ``TrainingOutcome``
+        and Package V2 emitted by DAG-ML.  Assembly remains owned by DAG-ML
+        and ZIP persistence by Core; this method neither serializes a Python
+        estimator nor retrains through :class:`PipelineRunner`.
+
+        Args:
+            archive_path: New ``.n4a`` Archive V2 destination.
+            archive_id: Explicit stable archive identity for the closed
+                DAG-ML/Core archive contract.
+
+        Returns:
+            The Core-issued archive id and SHA-256 reference.
+
+        Raises:
+            DagMLNativeCoverageError: If fit did not retain an exportable
+                portable predictor package.
+        """
+
+        check_is_fitted(self, attributes=["training_outcome_", "predictor_package_"])
+        if not isinstance(archive_id, str) or not archive_id.strip():
+            raise ValueError("archive_id must be a non-empty string")
+        if self.predictor_package_ is None:
+            raise DagMLNativeCoverageError(
+                "native training did not retain a portable predictor package for Archive V2 export"
+            )
+        from .native_archive_replay import write_methods_archive_v2
+
+        return write_methods_archive_v2(
+            archive_path,
+            archive_id=archive_id,
+            outcome=self.training_outcome_,
+            package=self.predictor_package_,
+        )
 
     def _execute_replay_with_identity(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.0",
+    "dag-ml>=0.3.3",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.1",
+    "dag-ml>=0.3.3",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
 ]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -48,6 +48,7 @@ ikpls>=1.1.0
 pyopls>=20.0
 trendfitter>=0.0.6
 
-# dag-ml execution core — the DEFAULT engine since the ADR-17 cutover (a hard dependency).
-dag-ml>=0.2.7
+# dag-ml execution core — a hard dependency; the public default remains legacy
+# until the ADR-17 cutover gate is explicitly satisfied.
+dag-ml>=0.3.3
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -60,6 +60,7 @@ ikpls>=1.1.0
 pyopls>=20.0
 trendfitter>=0.0.6
 
-# dag-ml execution core — the DEFAULT engine since the ADR-17 cutover (a hard dependency).
-dag-ml>=0.2.7
+# dag-ml execution core — a hard dependency; the public default remains legacy
+# until the ADR-17 cutover gate is explicitly satisfied.
+dag-ml>=0.3.3
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,8 +32,7 @@ ikpls>=1.1.0
 pyopls>=20.0
 trendfitter>=0.0.6
 
-# dag-ml execution core — the DEFAULT engine since the ADR-17 cutover (a hard
-# dependency, not an extra). run() falls back to legacy with a warning only when
-# the native backend is unavailable.
-dag-ml>=0.2.7
+# dag-ml execution core — a hard dependency, not an extra. The public default
+# remains legacy until the ADR-17 cutover gate is explicitly satisfied.
+dag-ml>=0.3.3
 dag-ml-data>=0.2.8

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from nirs4all.api.session import NativeArchiveSession, load_native_archive_session
+from nirs4all.api.session import NativeArchiveSession, load_native_archive_session, load_session
 from nirs4all.pipeline.dagml.native_archive_replay import NativeArchivePrediction
 
 
@@ -38,3 +38,42 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
     assert observed["sample_ids"] == ["p1", "p2"]
     with pytest.raises(RuntimeError, match="closed"):
         session.predict(np.asarray([[1.0]]), sample_ids=["p3"])
+
+
+def test_load_session_native_uses_the_portable_session_without_bundle_loader(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    archive = tmp_path / "portable.n4a"
+    archive.write_bytes(b"opaque-archive")
+
+    class UnexpectedBundleLoader:
+        def __init__(self, *_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+            raise AssertionError("native load_session constructed a legacy BundleLoader")
+
+    monkeypatch.setattr("nirs4all.pipeline.bundle.BundleLoader", UnexpectedBundleLoader)
+
+    loaded = load_session(archive, engine="native")
+
+    assert isinstance(loaded, NativeArchiveSession)
+    assert loaded.archive_path == archive
+    loaded.close()
+
+
+@pytest.mark.parametrize("engine", ["dag-ml", "dual", "invalid"])
+def test_load_session_rejects_non_native_nonlegacy_engines_before_bundle_loading(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    engine: str,
+) -> None:
+    bundle = tmp_path / "portable.n4a"
+    bundle.write_bytes(b"opaque-archive")
+
+    class UnexpectedBundleLoader:
+        def __init__(self, *_args, **_kwargs) -> None:  # noqa: ANN002, ANN003
+            raise AssertionError("unsupported load_session engine constructed a legacy BundleLoader")
+
+    monkeypatch.setattr("nirs4all.pipeline.bundle.BundleLoader", UnexpectedBundleLoader)
+
+    with pytest.raises((NotImplementedError, ValueError), match="load_session|unknown nirs4all engine"):
+        load_session(bundle, engine=engine)

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from nirs4all.api.predict import predict
 from nirs4all.api.session import NativeArchiveSession, load_native_archive_session, load_session
 from nirs4all.pipeline.dagml.native_archive_replay import NativeArchivePrediction
 
@@ -58,6 +59,46 @@ def test_load_session_native_uses_the_portable_session_without_bundle_loader(
     assert isinstance(loaded, NativeArchiveSession)
     assert loaded.archive_path == archive
     loaded.close()
+
+
+def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    def replay(path, X, *, sample_ids, groups, metadata):  # noqa: ANN001
+        observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids))
+        return NativeArchivePrediction(
+            values=np.asarray([[7.0], [8.0]]),
+            sample_ids=("p1", "p2"),
+            intervals={},
+            conformal_guarantee_status=None,
+        )
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
+        replay,
+    )
+    native_session = load_native_archive_session("portable.n4a")
+
+    result = predict(
+        data={"X": np.asarray([[1.0], [2.0]]), "sample_ids": ["p1", "p2"]},
+        session=native_session,
+        engine="native",
+    )
+
+    assert result.y_pred.tolist() == [[7.0], [8.0]]
+    assert result.metadata["engine"] == "native"
+    assert observed["path"] == "portable.n4a"
+    assert observed["sample_ids"] == ["p1", "p2"]
+
+
+def test_predict_native_session_requires_explicit_native_engine() -> None:
+    with pytest.raises(ValueError, match="requires engine='native'"):
+        predict(
+            data={"X": np.asarray([[1.0]]), "sample_ids": ["p1"]},
+            session=load_native_archive_session("portable.n4a"),
+        )
 
 
 @pytest.mark.parametrize("engine", ["dag-ml", "dual", "invalid"])

--- a/tests/unit/pipeline/dagml/test_estimator.py
+++ b/tests/unit/pipeline/dagml/test_estimator.py
@@ -190,6 +190,55 @@ def test_fit_forwards_compiled_training_contracts_and_sets_fitted_attrs() -> Non
     assert estimator.n_features_in_ == 4
 
 
+def test_fitted_native_estimator_exports_the_exact_native_outcome_and_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    client = _FakeNativeClient()
+    estimator = DagMLPipelineEstimator(
+        pipeline=("model",),
+        selection_output_id="pred",
+        native_client=client,
+        training_compiler=lambda *args, **kwargs: _training_execution(),
+    ).fit(np.ones((2, 2)), np.ones(2))
+    observed: dict[str, object] = {}
+
+    def write(path, *, archive_id, outcome, package):  # noqa: ANN001
+        observed.update(path=path, archive_id=archive_id, outcome=outcome, package=package)
+        return {"archive_id": archive_id, "archive_sha256": "a" * 64}
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.write_methods_archive_v2",
+        write,
+    )
+
+    reference = estimator.export_native_archive(
+        tmp_path / "native.n4a",
+        archive_id="archive:native.test",
+    )
+
+    assert reference == {"archive_id": "archive:native.test", "archive_sha256": "a" * 64}
+    assert observed == {
+        "path": tmp_path / "native.n4a",
+        "archive_id": "archive:native.test",
+        "outcome": client.training_result.outcome,
+        "package": {"package_id": "outcome-1-predictor"},
+    }
+
+
+def test_native_archive_export_requires_an_exportable_native_package() -> None:
+    estimator = DagMLPipelineEstimator(
+        pipeline=("model",),
+        selection_output_id="pred",
+        native_client=_FakeNativeClient(),
+        training_compiler=lambda *args, **kwargs: _training_execution(),
+    ).fit(np.ones((2, 2)), np.ones(2))
+    estimator.predictor_package_ = None
+
+    with pytest.raises(DagMLNativeCoverageError, match="portable predictor package"):
+        estimator.export_native_archive("native.n4a", archive_id="archive:native.test")
+
+
 def test_fit_can_require_explicit_sample_ids() -> None:
     estimator = DagMLPipelineEstimator(
         pipeline=("model",),


### PR DESCRIPTION
## Summary
- add an explicit native engine branch to load_session
- return the portable Archive V2 session without BundleLoader or PipelineRunner
- allow predict(..., session=native_session, engine="native") without a duplicate model path
- export a fitted native DAG-ML estimator directly as Archive V2 without Python model serialization or retraining
- reject unsupported engines and legacy sessions before legacy loading
- document the PREDICT-only native session boundary

## Validation
- python3.11 -m sphinx -W -b html docs/source /tmp/nirs4all-native-session-docs
- pytest tests/unit/api/test_native_archive_session.py tests/unit/api/test_engine_transition.py tests/unit/pipeline/dagml/test_estimator.py -q (37 passed)
- ruff check on changed files
- git diff --check
- mypy nirs4all: no diagnostics in changed API files; 22 pre-existing diagnostics remain in 13 unrelated modules
