### PR TITLE
feat(api): expose native raw pipeline fitting

### DIFF
--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -27,6 +27,35 @@ with nirs4all.session(verbose=1) as s:
 
 ## Functions
 
+### nirs4all.fit_native_pipeline()
+
+Run the deliberately narrow, fully-native raw-array training lane. This is the
+portable alternative when the pipeline is one splitter plus one supported model
+and every training and prediction row has a stable identity.
+
+```python
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold
+
+estimator = nirs4all.fit_native_pipeline(
+    [KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+    X_train,
+    y_train,
+    sample_ids=["train-0", "train-1", "train-2"],
+)
+estimator.export_native_archive("model.n4a", archive_id="archive:demo.pls")
+prediction = estimator.predict_with_identity(
+    X_predict,
+    sample_ids=["predict-0", "predict-1"],
+)
+```
+
+The fit result retains the actual DAG-ML `TrainingResult`, `TrainingOutcome`,
+and Package V2. Export writes Archive V2 from those exact native objects; it
+does not invoke the compatibility `PipelineRunner` or refit. Unsupported
+pipeline shapes, implicit identities, non-finite arrays, absent native
+capabilities, and non-native probability decoding fail explicitly.
+
 ### nirs4all.run()
 
 Execute a training pipeline on a dataset.

--- a/docs/source/reference/pipeline_keywords.md
+++ b/docs/source/reference/pipeline_keywords.md
@@ -802,11 +802,18 @@ surface. It reports native training/replay capability and forwards already-built
 contracts to DAG-ML, but it deliberately does not parse pipeline keywords,
 materialize patches, run Optuna/n4m, or choose fallback behavior.
 
-The next internal seam is `nirs4all.pipeline.dagml.estimator.DagMLPipelineEstimator`.
-It is sklearn-cloneable and can call native training/replay when supplied with
-compiled DAG-ML contracts, but it is not exported as a public user API yet. In
-the current state, missing compilers or decoders raise typed coverage errors;
-`predict_proba()` never fabricates one-hot pseudo-probabilities.
+`nirs4all.fit_native_pipeline(...)` exposes the first public native training
+lane. It accepts only a raw finite `(X, y)` cohort, explicit stable
+`sample_ids`, and a linear list pipeline with one splitter and one supported
+model. It returns the sklearn-cloneable internal
+`nirs4all.pipeline.dagml.estimator.DagMLPipelineEstimator`, retaining the exact
+native `TrainingResult`, `TrainingOutcome`, and Package V2. Its
+`export_native_archive(...)` method writes Archive V2 directly from those
+objects: it does not construct a `PipelineRunner` or refit the model. Prediction
+requires explicit current sample ids and is decoded only after the native replay
+returns the exact same ordered ids. Unsupported syntax remains fail-closed;
+this narrow API is not a synonym for the broader compatibility `run(...)`
+surface. `predict_proba()` never fabricates one-hot pseudo-probabilities.
 
 The shared objective seam is
 `nirs4all.pipeline.dagml.pipeline_objective.PipelineObjective`. It evaluates one
@@ -1249,6 +1256,23 @@ and `dag_ml.sample_relation_set_fingerprint_json()`, this lowerer can execute
 the native `dag_ml.execute_training()` path for that minimal raw-array shape.
 The second helper is required so the Python-built data envelope uses the same
 relation fingerprint as `dag-ml-core`.
+
+The public wrapper is:
+
+```python
+estimator = nirs4all.fit_native_pipeline(
+    [KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+    X_train,
+    y_train,
+    sample_ids=train_ids,
+)
+estimator.export_native_archive("pls.n4a", archive_id="archive:demo.pls")
+prediction = estimator.predict_with_identity(X_predict, sample_ids=predict_ids)
+```
+
+`sample_ids` are required at fit and prediction time. The archive-writing step
+requires the installed Core/DAG-ML native archive capabilities; a missing
+capability is a typed native coverage error, not a legacy export fallback.
 
 For the same internal raw-array seam, the deterministic subset of
 `finetune_params` is lowerable natively by the same shared helper used by public

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -16,6 +16,7 @@ The public Python API runs that contract directly. The CLI currently validates a
 | Function/class | Purpose | Typical input | Typical output |
 | --- | --- | --- | --- |
 | `nirs4all.run(...)` | Train/evaluate one or many pipelines on one or many datasets | Pipeline spec + dataset spec | `RunResult` |
+| `nirs4all.fit_native_pipeline(...)` | Train the supported raw-array/single-splitter/single-model lane through DAG-ML and retain Package V2 | List pipeline + finite `X`, `y`, explicit sample ids | Fitted `DagMLPipelineEstimator`, with direct Archive V2 export |
 | `nirs4all.predict(...)` | Predict from a stored chain or exported bundle | `chain_id` or model bundle + data | `PredictResult` |
 | `nirs4all.calibrate(...)` | Fit split-conformal intervals from explicit calibration evidence | Replayed calibration predictions or selected calibration cohort + prediction ids | `CalibratedRunResult` or `PredictResult` |
 | `nirs4all.CONFORMAL_CALIBRATION_METHODS` / `CONFORMAL_CALIBRATION_UNITS` | Discover conformal method and exchangeability-unit vocabularies | None | Tuples aligned with runtime validation and registry schema |

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -139,6 +139,7 @@ from .api import (
     conformal_metrics,
     explain,
     export_calibrated_result,
+    fit_native_pipeline,
     generate,
     get_keyword_registry,
     get_keyword_registry_schema,
@@ -197,6 +198,7 @@ from .utils import (
 __all__ = [
     # Module-level API (primary interface)
     "run",
+    "fit_native_pipeline",
     "DualRunUnsupported",
     "DualRunMismatchError",
     "calibrate",

--- a/nirs4all/api/__init__.py
+++ b/nirs4all/api/__init__.py
@@ -72,6 +72,7 @@ from .explain import explain
 
 # Synthetic data generation
 from .generate import generate_namespace as generate
+from .native_training import fit_native_pipeline
 from .predict import predict
 from .result import (
     ExplainResult,
@@ -167,6 +168,7 @@ from .tuning import (
 __all__ = [
     # Module-level API functions
     "run",
+    "fit_native_pipeline",
     "DualRunUnsupported",
     "DualRunMismatchError",
     "calibrate",

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -1,0 +1,124 @@
+"""Explicit public entry point for the first fully-native training lane.
+
+The broad :func:`nirs4all.run` compatibility surface still contains legacy
+workflow features that are not expressible by the portable runtime.  This
+module deliberately exposes only the proven raw-array lane instead of silently
+re-running that workflow through :class:`PipelineRunner` during export.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+import numpy as np
+
+from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+from nirs4all.pipeline.dagml.raw_replay_lowerer import RawArrayMethodsReplayCompiler
+from nirs4all.pipeline.dagml.raw_training_lowerer import RawArrayDagMLTrainingCompiler
+
+
+def fit_native_pipeline(
+    pipeline: list[Any],
+    X: Any,
+    y: Any,
+    *,
+    sample_ids: Sequence[str],
+    groups: Sequence[Any] | None = None,
+    metadata: Mapping[str, Sequence[Any]] | None = None,
+    selection_metric: str = "rmse",
+    selection_objective: str = "minimize",
+    package_id: str | None = None,
+    dagml_module: str = "dag_ml",
+    native_client: Any = None,
+    training_losses: tuple[Mapping[str, Any], ...] = (),
+    local_implementations: Any = None,
+    seed: int = 12345,
+) -> DagMLPipelineEstimator:
+    """Fit the supported raw-array pipeline entirely through DAG-ML.
+
+    This is an intentionally narrow native API: a linear list pipeline with
+    one splitter and one supported model, finite 2-D ``X``, and finite targets.
+    ``sample_ids`` are mandatory because the resulting Package V2 and Archive
+    V2 require stable identities for every later PREDICT cohort.
+
+    The returned fitted estimator retains the exact native ``TrainingResult``,
+    ``TrainingOutcome`` and Package V2.  Its :meth:`export_native_archive`
+    method writes the native Archive V2 directly; it never invokes the legacy
+    runner or fits the model a second time.
+    """
+
+    if not isinstance(pipeline, list):
+        raise TypeError("fit_native_pipeline requires a list pipeline")
+    if sample_ids is None:
+        raise ValueError("fit_native_pipeline requires explicit sample_ids")
+    if not isinstance(dagml_module, str) or not dagml_module:
+        raise ValueError("dagml_module must be a non-empty string")
+
+    # Fail before assembling the bridge when a caller passed an obviously
+    # non-portable matrix.  The lowerer repeats contract-level checks and
+    # DAG-ML remains authoritative for execution semantics.
+    features = np.asarray(X)
+    targets = np.asarray(y)
+    if features.ndim != 2 or targets.ndim not in (1, 2):
+        raise ValueError("fit_native_pipeline requires 2-D X and 1-D or 2-D y")
+    if features.shape[0] == 0 or features.shape[0] != targets.shape[0]:
+        raise ValueError("fit_native_pipeline requires aligned non-empty X and y")
+    if not np.issubdtype(features.dtype, np.number) or not np.issubdtype(targets.dtype, np.number):
+        raise TypeError("fit_native_pipeline requires numeric X and y")
+    if not np.isfinite(features).all() or not np.isfinite(targets).all():
+        raise ValueError("fit_native_pipeline requires finite X and y")
+
+    estimator = DagMLPipelineEstimator(
+        pipeline=pipeline,
+        selection_output_id="output:prediction",
+        package_id=package_id,
+        dagml_module=dagml_module,
+        native_client=native_client,
+        training_compiler=RawArrayDagMLTrainingCompiler(
+            selection_metric=selection_metric,
+            selection_objective=selection_objective,
+            dagml_module=dagml_module,
+            training_losses=training_losses,
+            local_implementations=local_implementations,
+            seed=seed,
+        ),
+        require_explicit_sample_ids=True,
+    )
+    estimator.fit(X, y, sample_ids=sample_ids, groups=groups, metadata=metadata)
+    if estimator.predictor_package_ is None:
+        raise DagMLNativeCoverageError("native DAG-ML training did not return an exportable Package V2")
+    estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
+        estimator.predictor_package_,
+        dagml_module=dagml_module,
+    )
+    estimator.prediction_identity_decoder = _decode_raw_methods_prediction
+    return estimator
+
+
+def _decode_raw_methods_prediction(outcome: Any, identity_frame: Any) -> np.ndarray:
+    """Decode a replay only after checking its exact current sample ordering."""
+
+    document = outcome.to_dict() if hasattr(outcome, "to_dict") else outcome
+    if not isinstance(document, Mapping):
+        raise DagMLNativeCoverageError("native replay did not return an outcome object")
+    outputs = document.get("outputs")
+    if not isinstance(outputs, list) or len(outputs) != 1 or not isinstance(outputs[0], Mapping):
+        raise DagMLNativeCoverageError("native raw replay requires exactly one output")
+    blocks = outputs[0].get("predictions")
+    if not isinstance(blocks, list) or len(blocks) != 1 or not isinstance(blocks[0], Mapping):
+        raise DagMLNativeCoverageError("native raw replay requires exactly one prediction block")
+    block = blocks[0]
+    if block.get("sample_ids") != list(identity_frame.sample_ids):
+        raise DagMLNativeCoverageError("native replay prediction identities do not exactly match the current cohort")
+    try:
+        values = np.asarray(block.get("values"), dtype=float)
+    except (TypeError, ValueError) as error:
+        raise DagMLNativeCoverageError("native replay prediction values are not numeric") from error
+    if values.ndim != 2 or values.shape[0] != identity_frame.n_samples or not np.isfinite(values).all():
+        raise DagMLNativeCoverageError("native replay prediction values are not a finite aligned matrix")
+    return cast(np.ndarray, values)
+
+
+__all__ = ["fit_native_pipeline"]

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 import numpy as np
 from sklearn.base import BaseEstimator
@@ -113,6 +113,7 @@ class DagMLPipelineEstimator(BaseEstimator):
         training_compiler: Any = None,
         prediction_compiler: Any = None,
         prediction_decoder: Any = None,
+        prediction_identity_decoder: Any = None,
         probability_decoder: Any = None,
         require_explicit_sample_ids: bool = False,
     ) -> None:
@@ -125,6 +126,7 @@ class DagMLPipelineEstimator(BaseEstimator):
         self.training_compiler = training_compiler
         self.prediction_compiler = prediction_compiler
         self.prediction_decoder = prediction_decoder
+        self.prediction_identity_decoder = prediction_identity_decoder
         self.probability_decoder = probability_decoder
         self.require_explicit_sample_ids = require_explicit_sample_ids
 
@@ -189,10 +191,18 @@ class DagMLPipelineEstimator(BaseEstimator):
         """
 
         check_is_fitted(self, attributes=["training_result_", "output_binding_"])
-        replay_outcome = self._execute_replay_with_identity(X, mode="predict")
+        replay_outcome, identity_frame = self._execute_replay_with_identity_frame(
+            X,
+            mode="predict",
+        )
+        if self.prediction_identity_decoder is not None:
+            return cast(
+                np.ndarray,
+                np.asarray(self.prediction_identity_decoder(replay_outcome, identity_frame)),
+            )
         if self.prediction_decoder is None:
             raise DagMLNativeCoverageError("DagMLPipelineEstimator.predict() requires a native prediction decoder; P1 does not synthesize Python predictions from replay JSON")
-        return np.asarray(self.prediction_decoder(replay_outcome))
+        return cast(np.ndarray, np.asarray(self.prediction_decoder(replay_outcome)))
 
     def predict_proba(self, X: Any) -> np.ndarray:
         """Predict class probabilities via native loaded-package replay.
@@ -205,7 +215,7 @@ class DagMLPipelineEstimator(BaseEstimator):
         replay_outcome = self._execute_replay_with_identity(X, mode="predict_proba")
         if self.probability_decoder is None:
             raise DagMLNativeCoverageError("DagMLPipelineEstimator.predict_proba() requires an explicit native probability decoder; pseudo-probabilities are forbidden")
-        return np.asarray(self.probability_decoder(replay_outcome))
+        return cast(np.ndarray, np.asarray(self.probability_decoder(replay_outcome)))
 
     def _compile_fit(
         self,
@@ -263,7 +273,7 @@ class DagMLPipelineEstimator(BaseEstimator):
         """
 
         check_is_fitted(self, attributes=["training_result_", "output_binding_"])
-        replay_outcome = self._execute_replay_with_identity(
+        replay_outcome, identity_frame = self._execute_replay_with_identity_frame(
             X,
             mode="predict",
             sample_ids=sample_ids,
@@ -271,11 +281,14 @@ class DagMLPipelineEstimator(BaseEstimator):
             metadata=metadata,
             require_explicit_sample_ids=True,
         )
-        if self.prediction_decoder is None:
-            raise DagMLNativeCoverageError(
-                "DagMLPipelineEstimator.predict_with_identity() requires a native prediction decoder; P1 does not synthesize Python predictions from replay JSON"
+        if self.prediction_identity_decoder is not None:
+            return cast(
+                np.ndarray,
+                np.asarray(self.prediction_identity_decoder(replay_outcome, identity_frame)),
             )
-        return np.asarray(self.prediction_decoder(replay_outcome))
+        if self.prediction_decoder is None:
+            raise DagMLNativeCoverageError("DagMLPipelineEstimator.predict_with_identity() requires a native prediction decoder; P1 does not synthesize Python predictions from replay JSON")
+        return cast(np.ndarray, np.asarray(self.prediction_decoder(replay_outcome)))
 
     def export_native_archive(
         self,
@@ -307,16 +320,17 @@ class DagMLPipelineEstimator(BaseEstimator):
         if not isinstance(archive_id, str) or not archive_id.strip():
             raise ValueError("archive_id must be a non-empty string")
         if self.predictor_package_ is None:
-            raise DagMLNativeCoverageError(
-                "native training did not retain a portable predictor package for Archive V2 export"
-            )
+            raise DagMLNativeCoverageError("native training did not retain a portable predictor package for Archive V2 export")
         from .native_archive_replay import write_methods_archive_v2
 
-        return write_methods_archive_v2(
-            archive_path,
-            archive_id=archive_id,
-            outcome=self.training_outcome_,
-            package=self.predictor_package_,
+        return cast(
+            dict[str, str],
+            write_methods_archive_v2(
+                archive_path,
+                archive_id=archive_id,
+                outcome=self.training_outcome_,
+                package=self.predictor_package_,
+            ),
         )
 
     def _execute_replay_with_identity(
@@ -329,6 +343,35 @@ class DagMLPipelineEstimator(BaseEstimator):
         metadata: Any = None,
         require_explicit_sample_ids: bool | None = None,
     ) -> Any:
+        """Run replay and return its native outcome (legacy private helper)."""
+
+        outcome, _identity_frame = self._execute_replay_with_identity_frame(
+            X,
+            mode=mode,
+            sample_ids=sample_ids,
+            groups=groups,
+            metadata=metadata,
+            require_explicit_sample_ids=require_explicit_sample_ids,
+        )
+        return outcome
+
+    def _execute_replay_with_identity_frame(
+        self,
+        X: Any,
+        *,
+        mode: str,
+        sample_ids: Any = None,
+        groups: Any = None,
+        metadata: Any = None,
+        require_explicit_sample_ids: bool | None = None,
+    ) -> tuple[Any, DagMLPredictIdentityFrame]:
+        """Run replay and retain the exact current identity frame for decoding.
+
+        A decoder that needs to verify output ordering (for example the raw
+        Methods path) receives this frame rather than reconstructing identities
+        from replay JSON.  The older outcome-only helper remains above for
+        existing decoders.
+        """
         if self.prediction_compiler is None:
             raise DagMLNativeCoverageError(f"DagMLPipelineEstimator.{mode}() requires the nirs4all→DAG-ML loaded-package replay compiler")
         if self.predictor_package_ is None:
@@ -339,15 +382,11 @@ class DagMLPipelineEstimator(BaseEstimator):
             sample_ids=sample_ids,
             groups=groups,
             metadata=metadata,
-            require_explicit_sample_ids=(
-                self.require_explicit_sample_ids
-                if require_explicit_sample_ids is None
-                else require_explicit_sample_ids
-            ),
+            require_explicit_sample_ids=(self.require_explicit_sample_ids if require_explicit_sample_ids is None else require_explicit_sample_ids),
         )
         replay = self._compile_replay(X, mode=mode, identity_frame=identity_frame)
         try:
-            return self._client().replay_loaded_predictor_package(
+            outcome = self._client().replay_loaded_predictor_package(
                 self.predictor_package_,
                 replay.request,
                 replay.data_envelopes,
@@ -362,6 +401,7 @@ class DagMLPipelineEstimator(BaseEstimator):
         finally:
             if replay.cleanup is not None:
                 replay.cleanup()
+        return outcome, identity_frame
 
     def _compile_replay(
         self,

--- a/tests/unit/api/test_native_training.py
+++ b/tests/unit/api/test_native_training.py
@@ -1,0 +1,210 @@
+"""Public native raw-array training entry point tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import nirs4all
+from nirs4all.api.native_training import fit_native_pipeline
+from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+
+class _TrainingResult:
+    outcome = {"native": True}
+    outputs = [
+        {
+            "output_id": "output:prediction",
+            "node_id": "model:compat.0",
+            "port_name": "oof",
+        }
+    ]
+
+    def export_portable_predictor_package(self, package_id: str) -> dict[str, Any]:
+        return {"schema_version": 2, "package_id": package_id}
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+    def execute_training(self, *args: Any, **kwargs: Any) -> _TrainingResult:
+        self.calls.append((args, kwargs))
+        return _TrainingResult()
+
+    def replay_loaded_predictor_package(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        _ = (args, kwargs)
+        return {
+            "outputs": [
+                {
+                    "predictions": [
+                        {
+                            "sample_ids": ["predict-a"],
+                            "values": [[3.5]],
+                        }
+                    ]
+                }
+            ]
+        }
+
+
+def test_fit_native_pipeline_is_a_public_strict_native_composition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def compile_fit(self, estimator, X, y, **kwargs):  # noqa: ANN001
+        captured.update(estimator=estimator, X=X, y=y, kwargs=kwargs)
+        from nirs4all.pipeline.dagml.estimator import DagMLTrainingExecution
+
+        return DagMLTrainingExecution(
+            request={"request": "native"},
+            data_envelopes={"model.x": {}},
+            relations={"records": []},
+            training_influence={"entries": []},
+            op_callback=lambda task: task,
+            outcome_id="outcome:native",
+            run_id="run:native",
+            bundle_id="bundle:native",
+        )
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        compile_fit,
+    )
+    client = _Client()
+    estimator = fit_native_pipeline(
+        [{"split": "stub"}, {"model": "stub"}],
+        np.asarray([[1.0], [2.0]]),
+        np.asarray([1.0, 2.0]),
+        sample_ids=["fit-a", "fit-b"],
+        native_client=client,
+    )
+
+    assert isinstance(estimator, DagMLPipelineEstimator)
+    assert captured["kwargs"]["sample_ids"] == ("fit-a", "fit-b")
+    assert client.calls[0][0][:4] == (
+        {"request": "native"},
+        {"model.x": {}},
+        {"records": []},
+        {"entries": []},
+    )
+    assert estimator.predictor_package_ == {
+        "schema_version": 2,
+        "package_id": "outcome:native-predictor",
+    }
+    assert estimator.prediction_compiler is not None
+    assert estimator.prediction_identity_decoder is not None
+    assert nirs4all.fit_native_pipeline is fit_native_pipeline
+
+
+@pytest.mark.parametrize(
+    "sample_ids, message",
+    [(None, "explicit sample_ids"), ([], "sample_ids length")],
+)
+def test_fit_native_pipeline_refuses_unportable_inputs_before_training(
+    sample_ids: Any,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        fit_native_pipeline(
+            [],
+            np.asarray([[1.0]]),
+            np.asarray([1.0]),
+            sample_ids=sample_ids,
+        )
+
+
+def test_fit_native_pipeline_surfaces_missing_package_as_native_coverage_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class NoPackage(_TrainingResult):
+        def export_portable_predictor_package(self, package_id: str) -> None:
+            _ = package_id
+            return None
+
+    class NoPackageClient(_Client):
+        def execute_training(self, *args: Any, **kwargs: Any) -> NoPackage:
+            _ = (args, kwargs)
+            return NoPackage()
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        lambda *_args, **_kwargs: __import__("nirs4all.pipeline.dagml.estimator", fromlist=["DagMLTrainingExecution"]).DagMLTrainingExecution(
+            request={},
+            data_envelopes={},
+            relations={},
+            training_influence={},
+            op_callback=lambda task: task,
+            outcome_id="o",
+            run_id="r",
+            bundle_id="b",
+        ),
+    )
+    with pytest.raises(DagMLNativeCoverageError, match="exportable Package V2"):
+        fit_native_pipeline(
+            [{"split": "stub"}, {"model": "stub"}],
+            np.asarray([[1.0]]),
+            np.asarray([1.0]),
+            sample_ids=["fit-a"],
+            native_client=NoPackageClient(),
+        )
+
+
+def test_fit_native_pipeline_predicts_only_through_identified_native_replay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def compile_fit(self, estimator, X, y, **kwargs):  # noqa: ANN001
+        _ = (self, estimator, X, y, kwargs)
+        from nirs4all.pipeline.dagml.estimator import DagMLTrainingExecution
+
+        return DagMLTrainingExecution(
+            request={},
+            data_envelopes={},
+            relations={},
+            training_influence={},
+            op_callback=lambda task: task,
+            outcome_id="o",
+            run_id="r",
+            bundle_id="b",
+        )
+
+    def compile_replay(self, estimator, X, *, mode, identity_frame):  # noqa: ANN001
+        _ = (self, estimator, X, mode)
+        from nirs4all.pipeline.dagml.estimator import DagMLReplayExecution
+
+        assert identity_frame.sample_ids == ("predict-a",)
+        return DagMLReplayExecution(
+            request={"phase": "PREDICT"},
+            data_envelopes={},
+            artifact_handles={},
+            op_callback=lambda task: task,
+            outcome_id="predict:o",
+            run_id="predict:r",
+        )
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        compile_fit,
+    )
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayMethodsReplayCompiler.compile_replay",
+        compile_replay,
+    )
+    estimator = fit_native_pipeline(
+        [{"split": "stub"}, {"model": "stub"}],
+        np.asarray([[1.0]]),
+        np.asarray([1.0]),
+        sample_ids=["fit-a"],
+        native_client=_Client(),
+    )
+
+    prediction = estimator.predict_with_identity(
+        np.asarray([[2.0]]),
+        sample_ids=["predict-a"],
+    )
+
+    assert prediction.tolist() == [[3.5]]


### PR DESCRIPTION
## Summary
- adds `nirs4all.fit_native_pipeline(...)` for the proven raw-array DAG-ML lane
- retains the native TrainingResult/Outcome/Package V2 and exports Archive V2 without a legacy refit
- verifies replay output against caller-provided sample identities

## Validation
- `python3.11 -m pytest -q tests/unit/api/test_native_training.py tests/unit/api/test_native_archive_session.py tests/unit/pipeline/dagml/test_estimator.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/pipeline/dagml/test_training_compiler.py tests/unit/pipeline/dagml/test_raw_training_lowerer.py`
- `ruff check ...`
- `python3.11 -m sphinx -W -b html docs/source /tmp/nirs4all-native-docs`
- `git diff --check`

The public compatibility `run()` path is intentionally unchanged: unsupported shapes continue to be explicit rather than silently re-run through legacy export.