### PR TITLE
fix(api): require explicit legacy export compatibility

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,7 +16,7 @@ The same YAML/JSON contract is the stable user surface across Python and languag
 | R | Portable wrapper pattern | Yes | Through `reticulate` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | Julia | Portable wrapper pattern | Yes | Through `PythonCall` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | JavaScript/TypeScript | Portable process/runtime wrapper pattern | Yes | No native JS API in this repo | Calls a Python/runtime process today | Calls a Python/runtime process today | {doc}`getting_started/hello_world` |
-| dag-ml runtime | Selectable from Python | Yes, for covered shapes | No Python object construction | `engine="dag-ml"` with legacy fallback | Native results optional; bundle export is bridged | {doc}`reference/public_interfaces` |
+| dag-ml runtime | Selectable from Python | Yes, for covered shapes | No Python object construction | `engine="dag-ml"` with legacy fallback | Native result artifacts export directly when supported; legacy refit is explicit-only | {doc}`reference/public_interfaces` |
 
 :::{note}
 The language-independent contract is the pair of config files. Native R, Julia, or JavaScript package APIs can wrap that contract without changing user pipelines.

--- a/docs/source/reference/predictions_api.md
+++ b/docs/source/reference/predictions_api.md
@@ -137,8 +137,8 @@ Returned by `nirs4all.run()` and `nirs4all.retrain()`.
 | `filter(**kwargs)` | list[dict] | Filter predictions by criteria |
 | `get_datasets()` | list[str] | Unique dataset names |
 | `get_models()` | list[str] | Unique model names |
-| `export(output_path, format="n4a", source=None, chain_id=None)` | Path | Export model to bundle |
-| `export_model(output_path, source=None, format=None, fold=None)` | Path | Export model artifact only |
+| `export(output_path, format="n4a", source=None, chain_id=None, *, compatibility=None)` | Path | Export a legacy-workspace bundle; DAG-ML refuses by default rather than re-training, and accepts only `compatibility="legacy-refit"` as an explicit transitional opt-in |
+| `export_model(output_path, source=None, format=None, fold=None, *, compatibility=None)` | Path | Export a captured DAG-ML native model artifact when available; otherwise refuses unless the explicit `legacy-refit` compatibility opt-in is used |
 | `summary()` | str | Multi-line summary string |
 | `validate(...)` | dict | Check for common issues |
 

--- a/nirs4all/api/result.py
+++ b/nirs4all/api/result.py
@@ -497,6 +497,7 @@ def _lineage_by_feature(feature_lineage: Mapping[str, Any], feature: str | int) 
 # ``.keras`` → tensorflow_keras, ``.pt``/``.pth`` → pytorch_state_dict) are the ones that MUST route through
 # the legacy ``to_bytes`` path instead of the joblib-only native helper.
 _NON_JOBLIB_EXTENSIONS = frozenset({".pkl", ".pickle", ".h5", ".hdf5", ".keras", ".pt", ".pth"})
+_DAGML_LEGACY_REFIT_COMPATIBILITY = "legacy-refit"
 
 
 def _request_is_joblib(output_path: str | Path, format: str | None) -> bool:
@@ -1389,18 +1390,30 @@ class RunResult:
     def _no_workspace_export_error(self) -> Exception:
         """The right fail-loud error when an export has no workspace path.
 
-        A dag-ml result WITHOUT an export spec → a CATCHABLE :class:`NotImplementedError` (so the cutover
-        fallback redirects export to the legacy engine); a genuinely detached/misused legacy result → the
-        original :class:`RuntimeError` (a real misuse, not a fall-back-able dag-ml gap). A dag-ml result
-        WITH a spec never reaches here — :meth:`_dagml_export_delegate` materializes a legacy workspace first.
+        A dag-ml result with no native export material raises a stable refusal; a genuinely detached/misused
+        legacy result keeps the original :class:`RuntimeError`.
         """
         if self._is_dagml_engine():
-            return NotImplementedError(
-                "engine='dag-ml' does not support .n4a export for this run: the dag-ml backend returns native "
-                "scores with no workspace artifacts to bundle, and no export spec was captured to re-run the "
-                "pipeline on the legacy engine; run the export-bound pipeline on the legacy engine."
-            )
+            return self._dagml_export_refusal("export", "no replayable native artifacts were captured")
         return RuntimeError("Cannot export: no workspace path available (result was not created from a workspace run)")
+
+    def _dagml_export_refusal(self, operation: str, reason: str) -> Exception:
+        """Build the fail-closed result-level native export refusal."""
+        from nirs4all.pipeline.dagml.errors import DagMlExportRefusal
+
+        return DagMlExportRefusal(
+            operation,
+            reason,
+            mitigation=(f"Export a run that captured a supported native artifact, or pass compatibility='{_DAGML_LEGACY_REFIT_COMPATIBILITY}' to explicitly request a legacy refit."),
+        )
+
+    def _legacy_refit_compatibility_requested(self, compatibility: str | None) -> bool:
+        """Validate the only opt-in that permits a legacy export refit."""
+        if compatibility is None:
+            return False
+        if compatibility == _DAGML_LEGACY_REFIT_COMPATIBILITY:
+            return True
+        raise ValueError(f"unsupported dag-ml export compatibility opt-in {compatibility!r}; expected {_DAGML_LEGACY_REFIT_COMPATIBILITY!r}")
 
     def _dagml_export_delegate(self) -> RunResult | None:
         """Materialize (once) a LEGACY RunResult to back .n4a export of a dag-ml run; ``None`` if N/A.
@@ -1491,6 +1504,8 @@ class RunResult:
         format: str = "n4a",
         source: dict[str, Any] | None = None,
         chain_id: str | None = None,
+        *,
+        compatibility: str | None = None,
     ) -> Path:
         """Export a model to bundle.
 
@@ -1509,13 +1524,10 @@ class RunResult:
         In detached mode, a temporary store is opened for the export
         and closed immediately after.
 
-        **dag-ml runs (P1c, transitional):** the dag-ml backend keeps no workspace/artifacts, so this
-        re-fits the pipeline via the legacy engine to produce the bundle. For an EXACT export, set
-        ``run(random_state=...)`` AND seed every stochastic component's ``random_state``; otherwise
-        (``sample_augmentation``, an unseeded run, or any unseeded-stochastic component such as
-        ``RandomForest`` / ``MLP`` / ``CARS``) the exported model may differ from the dag-ml-scored model.
-        ``source`` / ``chain_id`` are not supported for a dag-ml run (they reference its non-existent
-        workspace); the run's best model is exported. P3 will capture the fitted model natively.
+        **dag-ml runs:** this legacy ``.n4a`` bundle format is not synthesized by re-training. The default
+        path refuses rather than silently running the legacy engine. To deliberately request the transitional
+        behavior, pass ``compatibility="legacy-refit"``; it re-runs the frozen pipeline and is best-effort
+        for stochastic pipelines.
 
         Args:
             output_path: Path for the exported bundle file.
@@ -1524,6 +1536,8 @@ class RunResult:
             chain_id: Chain identifier for store-based export.
                 When provided, ``source`` is ignored and the chain is
                 exported directly from the workspace store.
+            compatibility: The sole DAG-ML compatibility opt-in. ``"legacy-refit"`` deliberately re-runs
+                the frozen pipeline through the legacy engine; it is never the default.
 
         Returns:
             Path to the exported bundle file.
@@ -1533,23 +1547,26 @@ class RunResult:
             ValueError: If no predictions available and source not provided.
             NotImplementedError: For a dag-ml run, if ``source``/``chain_id`` is given.
         """
-        # dag-ml export bridge (P1c): the dag-ml backend has no workspace, so delegate to a legacy re-run of
-        # the same pipeline (materialized on demand, cached). FAIL-FAST FIRST: an EXPLICIT non-default
-        # ``source`` / ``chain_id`` references the (non-existent) dag-ml workspace, so it cannot be honored
-        # — raise the CATCHABLE NotImplementedError BEFORE materializing the delegate (no wasted refit, no
-        # spurious stochastic warning). The predicate is the cheap spec flag, NOT the delegate (which would
-        # trigger the refit). Otherwise materialize the delegate and export its OWN best/final (the
-        # single-winner the dag-ml run scored).
-        if self._dagml_export_spec is not None:
+        legacy_refit_compatibility = self._legacy_refit_compatibility_requested(compatibility)
+        if self._is_dagml_engine():
             if source is not None or chain_id is not None:
                 raise NotImplementedError(
                     "engine='dag-ml' export does not support an explicit source=/chain_id= (they reference "
                     "the dag-ml run's non-existent workspace); export the run's best model with "
                     "result.export(path) (no source/chain_id)."
                 )
-            delegate = self._dagml_export_delegate()
-            assert delegate is not None  # spec present ⇒ delegate materializes
-            return delegate.export(output_path, format=format)
+            if legacy_refit_compatibility:
+                delegate = self._dagml_export_delegate()
+                if delegate is None:
+                    raise self._dagml_export_refusal("export", "no frozen inputs are available for the requested compatibility refit")
+                return delegate.export(output_path, format=format)
+            raise self._dagml_export_refusal(
+                "export",
+                "the legacy .n4a writer cannot represent this native result without re-training",
+            )
+
+        if legacy_refit_compatibility:
+            raise ValueError("compatibility='legacy-refit' is only valid for engine='dag-ml' results")
 
         # Store-based export path
         if chain_id is not None:
@@ -1648,7 +1665,15 @@ class RunResult:
         joblib.dump(model, output_path, compress=3)
         return output_path
 
-    def export_model(self, output_path: str | Path, source: dict[str, Any] | None = None, format: str | None = None, fold: int | None = None) -> Path:
+    def export_model(
+        self,
+        output_path: str | Path,
+        source: dict[str, Any] | None = None,
+        format: str | None = None,
+        fold: int | None = None,
+        *,
+        compatibility: str | None = None,
+    ) -> Path:
         """Export only the model artifact (lightweight).
 
         Unlike export() which creates a full bundle, this exports just the model.
@@ -1661,20 +1686,16 @@ class RunResult:
         when a ``y_transform`` was captured) — with NO legacy refit and NO stochastic warning. The exported
         model's ``predict`` reproduces the dag-ml run's scored REFIT model EXACTLY (it IS that model).
 
-        **dag-ml runs (P1c bridge — fallback):** without a native dir, or for a multi-model / branch /
-        stacking run (≠1 captured artifact), or when ``fold`` is given, the model is produced by a legacy
-        re-fit. For an EXACT bridge export, set ``run(random_state=...)`` AND seed every stochastic
-        component's ``random_state``; otherwise (``sample_augmentation``, an unseeded run, or any
-        unseeded-stochastic component such as ``RandomForest`` / ``MLP`` / ``CARS``) the bridge-exported
-        model may differ from the dag-ml-scored model. ``source`` is not supported for a dag-ml run (it
-        references its non-existent workspace); ``fold`` is honored by the bridge (it selects a fold's model
-        from the legacy re-fit's workspace) and routes around the native single-artifact path.
+        **dag-ml runs:** a captured single native artifact is exported directly. Unsupported shapes refuse
+        by default and never re-train through the legacy engine. ``compatibility="legacy-refit"`` is the
+        explicit transitional opt-in for that old behavior.
 
         Args:
             output_path: Path for the output model file.
             source: Prediction dict to export. If None, exports best model.
             format: Model format (inferred from extension if None).
             fold: Fold index to export (default: fold 0).
+            compatibility: Optional ``"legacy-refit"`` opt-in for an otherwise refused DAG-ML export.
 
         Returns:
             Path to the exported model file.
@@ -1682,31 +1703,37 @@ class RunResult:
         Raises:
             RuntimeError: If no workspace path available.
         """
-        # dag-ml export bridge (P1c): same as export() — FAIL-FAST on an explicit ``source`` BEFORE
-        # materializing the delegate (no wasted refit / no spurious stochastic warning), using the cheap
-        # spec flag (not the delegate, which would trigger the refit). ``fold`` is FORWARDED (it selects a
-        # fold's model from the delegate's REAL legacy workspace, which does have per-fold artifacts).
-        if self._dagml_export_spec is not None:
+        legacy_refit_compatibility = self._legacy_refit_compatibility_requested(compatibility)
+        if self._is_dagml_engine():
             if source is not None:
                 raise NotImplementedError(
                     "engine='dag-ml' export_model does not support an explicit source= (it references the "
                     "dag-ml run's non-existent workspace); export the run's best model with "
                     "result.export_model(path[, fold=...]) (no source)."
                 )
+            if legacy_refit_compatibility:
+                delegate = self._dagml_export_delegate()
+                if delegate is None:
+                    raise self._dagml_export_refusal("export_model", "no frozen inputs are available for the requested compatibility refit")
+                return delegate.export_model(output_path, format=format, fold=fold)
             # NATIVE export (P3 Slice 2c-ii): when this dag-ml run captured EXACTLY ONE concrete model
             # artifact in its native results dir AND the request is joblib-compatible, export that captured
             # (verify-then-load) REFIT model DIRECTLY — no legacy refit, no stochastic warning. ``fold`` is
             # incompatible with the native single-artifact export (it would select a fold's model, which
             # lives only in the legacy workspace), so the native path is attempted only for the default
             # whole-model export. A ``None`` return means not applicable (no native dir / non-joblib format /
-            # ≠1 artifact / unloadable artifact) → fall through to the legacy bridge below.
+            # ≠1 artifact / unloadable artifact) → refuse without a legacy refit.
             if fold is None:
                 native = self._dagml_native_export_model(output_path, format)
                 if native is not None:
                     return native
-            delegate = self._dagml_export_delegate()
-            assert delegate is not None  # spec present ⇒ delegate materializes
-            return delegate.export_model(output_path, format=format, fold=fold)
+            raise self._dagml_export_refusal(
+                "export_model",
+                "no single replayable native model artifact matches the requested format and fold selector",
+            )
+
+        if legacy_refit_compatibility:
+            raise ValueError("compatibility='legacy-refit' is only valid for engine='dag-ml' results")
 
         if source is None:
             source = self.best

--- a/nirs4all/pipeline/dagml/errors.py
+++ b/nirs4all/pipeline/dagml/errors.py
@@ -74,6 +74,22 @@ class DagMlUnavailable(RuntimeError):
     """
 
 
+class DagMlExportRefusal(RuntimeError):
+    """A completed native run cannot satisfy a requested export capability.
+
+    This error deliberately is not a ``DagMlUnsupported``: export occurs after
+    training, beyond ``run()``'s compatibility fallback boundary.  Re-running
+    the pipeline through the legacy engine is available only through the
+    explicit ``compatibility=\"legacy-refit\"`` export opt-in.
+    """
+
+    def __init__(self, operation: str, reason: str, *, mitigation: str) -> None:
+        self.operation = operation
+        self.reason = reason
+        self.mitigation = mitigation
+        super().__init__(f"engine='dag-ml' {operation} cannot proceed: {reason}. {mitigation}")
+
+
 def _cli_child_error(stdout: str) -> str:
     """The child adapter's actual error line(s) from a dag-ml-cli failure, for an informative message.
 

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -424,9 +424,9 @@ def run_via_dagml(
         # the legacy store" property.
         if native_results_enabled(results_path):
             # Record the written run dir on the RunResult so a NATIVE export_model (P3 Slice 2c-ii) can
-            # locate the captured fitted REFIT artifact(s) + rehydrate them directly — retiring the P1c
-            # legacy-refit bridge for the single-model case (the bridge stays the fallback when no native
-            # dir exists or the run captured ≠1 loadable artifact).
+            # locate the captured fitted REFIT artifact(s) + rehydrate them directly. Unsupported native
+            # export shapes refuse at the public boundary unless callers explicitly opt into legacy-refit
+            # compatibility.
             result._dagml_results_dir = write_native_results(result, result._dagml_score_set, results_path)  # noqa: SLF001
         return result
     finally:
@@ -435,10 +435,11 @@ def run_via_dagml(
 
 
 def _attach_export_spec(result: RunResult, pipeline: Any, dataset: Any, name: str, random_state: int | None) -> None:
-    """FREEZE the run inputs on the dag-ml RunResult so .n4a export can re-fit the SAME run on legacy (P1c).
+    """Freeze inputs solely for an explicit ``compatibility=\"legacy-refit\"`` export request.
 
-    The dag-ml backend has no workspace/artifacts to bundle, so ``RunResult.export()`` re-runs this exact
-    pipeline through the legacy engine on demand. The replay inputs are FROZEN here, at run time, so a later
+    The dag-ml backend has no legacy workspace/artifacts. The default export path therefore refuses rather
+    than re-training. The compatibility path uses these frozen inputs only after an explicit caller opt-in,
+    so a later
     mutation of the live ``pipeline`` / in-memory ``dataset`` (arrays, SpectroDataset) cannot make the
     export represent a different run than the one scored:
 

--- a/tests/integration/parity/test_conformance_export_roundtrip.py
+++ b/tests/integration/parity/test_conformance_export_roundtrip.py
@@ -37,6 +37,7 @@ import nirs4all
 from nirs4all.api.result import RunResult
 from nirs4all.data import DatasetConfigs
 from nirs4all.data.predictions import Predictions
+from nirs4all.pipeline.dagml.errors import DagMlExportRefusal
 
 from . import _conformance_helpers as H
 from ._datasets import dataset_path
@@ -117,12 +118,13 @@ def test_dagml_n4a_export_rejects_workspace_selectors_before_legacy_refit(
     assert result._dagml_legacy_result is None  # noqa: SLF001
 
 
-def test_dagml_n4a_export_without_workspace_or_spec_is_catchable(tmp_path: Path) -> None:
-    """A dag-ml result with no export spec raises ``NotImplementedError``, not a legacy misuse error."""
+def test_dagml_n4a_export_without_workspace_or_spec_refuses_native_export() -> None:
+    """A dag-ml result without native export material has a stable, non-legacy refusal."""
     result = _minimal_dagml_result()
 
-    with pytest.raises(NotImplementedError, match="engine='dag-ml'.*no workspace artifacts"):
-        result.export(tmp_path / "model.n4a", source={"prediction_id": "p0"})
+    error = result._no_workspace_export_error()  # noqa: SLF001
+    assert isinstance(error, DagMlExportRefusal)
+    assert "no replayable native artifacts" in str(error)
 
 
 @pytest.mark.parametrize("case_name", _EXACT_CASES)

--- a/tests/unit/api/test_dagml_export_refusal.py
+++ b/tests/unit/api/test_dagml_export_refusal.py
@@ -1,0 +1,73 @@
+"""Result-level exports must never retrain a DAG-ML result implicitly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nirs4all.api.result import RunResult
+from nirs4all.data.predictions import Predictions
+from nirs4all.pipeline.dagml.errors import DagMlExportRefusal
+
+
+def _native_result() -> RunResult:
+    return RunResult(
+        predictions=Predictions(),
+        per_dataset={"fixture": {"engine": "dag-ml"}},
+        _dagml_export_spec={"pipeline": [], "dataset": object()},
+    )
+
+
+def test_default_dagml_bundle_export_refuses_without_materializing_legacy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _native_result()
+
+    def _unexpected_delegate() -> object:
+        raise AssertionError("default export must not retrain through the legacy engine")
+
+    monkeypatch.setattr(result, "_dagml_export_delegate", _unexpected_delegate)
+
+    with pytest.raises(DagMlExportRefusal, match="legacy .n4a writer"):
+        result.export(tmp_path / "model.n4a")
+
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+
+def test_default_dagml_model_export_refuses_without_materializing_legacy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _native_result()
+
+    def _unexpected_delegate() -> object:
+        raise AssertionError("default export_model must not retrain through the legacy engine")
+
+    monkeypatch.setattr(result, "_dagml_export_delegate", _unexpected_delegate)
+
+    with pytest.raises(DagMlExportRefusal, match="single replayable native model"):
+        result.export_model(tmp_path / "model.joblib")
+
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+
+def test_legacy_refit_requires_the_named_compatibility_opt_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    result = _native_result()
+    bundle = tmp_path / "compat.n4a"
+    model = tmp_path / "compat.joblib"
+
+    class _Delegate:
+        def export(self, output_path: Path, *, format: str) -> Path:
+            assert format == "n4a"
+            return output_path
+
+        def export_model(self, output_path: Path, *, format: str | None, fold: int | None) -> Path:
+            assert format == "joblib"
+            assert fold == 2
+            return output_path
+
+    monkeypatch.setattr(result, "_dagml_export_delegate", lambda: _Delegate())
+
+    assert result.export(bundle, compatibility="legacy-refit") == bundle
+    assert result.export_model(model, format="joblib", fold=2, compatibility="legacy-refit") == model
+
+
+def test_invalid_compatibility_is_rejected_before_any_export(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="unsupported dag-ml export compatibility"):
+        _native_result().export(tmp_path / "model.n4a", compatibility="legacy")


### PR DESCRIPTION
## Summary
- prevent `RunResult.export()` and unsupported `export_model()` DAG-ML paths from silently rerunning training through the legacy engine
- retain the old bridge only behind explicit `compatibility="legacy-refit"`
- document the boundary and cover refusal/opt-in behavior

## Validation
- `ruff check nirs4all/api/result.py nirs4all/pipeline/dagml/errors.py nirs4all/pipeline/dagml/run_backend.py tests/unit/api/test_dagml_export_refusal.py`
- `python3.11 -m pytest -q tests/unit/api/test_dagml_export_refusal.py tests/unit/api/test_native_archive_session.py tests/unit/pipeline/dagml/test_estimator.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/pipeline/dagml/test_training_compiler.py tests/unit/pipeline/dagml/test_raw_training_lowerer.py`
- `python3.11 -m sphinx -W -b html docs/source /tmp/nirs4all-native-runresult-docs`
- `git diff --check`