### PR TITLE
fix(dagml): reject nonportable native training results

### DIFF
--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -16,7 +16,7 @@ The public Python API runs that contract directly. The CLI currently validates a
 | Function/class | Purpose | Typical input | Typical output |
 | --- | --- | --- | --- |
 | `nirs4all.run(...)` | Train/evaluate one or many pipelines on one or many datasets | Pipeline spec + dataset spec | `RunResult` |
-| `nirs4all.fit_native_pipeline(...)` | Train the supported raw-array/single-splitter/single-model lane through DAG-ML and retain Package V2 | List pipeline + finite `X`, `y`, explicit sample ids | Fitted `DagMLPipelineEstimator`, with direct Archive V2 export |
+| `nirs4all.fit_native_pipeline(...)` | Train the supported raw-array/single-splitter/single-model lane through DAG-ML and retain a portable Methods Package V2 | List pipeline + finite `X`, `y`, explicit sample ids | Fitted `DagMLPipelineEstimator`, with direct Archive V2 export; refuses host-sidecar/joblib results |
 | `nirs4all.predict(...)` | Predict from a stored chain or exported bundle | `chain_id` or model bundle + data | `PredictResult` |
 | `nirs4all.calibrate(...)` | Fit split-conformal intervals from explicit calibration evidence | Replayed calibration predictions or selected calibration cohort + prediction ids | `CalibratedRunResult` or `PredictResult` |
 | `nirs4all.CONFORMAL_CALIBRATION_METHODS` / `CONFORMAL_CALIBRATION_UNITS` | Discover conformal method and exchangeability-unit vocabularies | None | Tuples aligned with runtime validation and registry schema |

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -15,7 +15,11 @@ import numpy as np
 
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
-from nirs4all.pipeline.dagml.raw_replay_lowerer import RawArrayMethodsReplayCompiler
+from nirs4all.pipeline.dagml.raw_replay_lowerer import (
+    RawArrayMethodsReplayCompiler,
+    RawArrayMethodsReplayError,
+    validate_native_methods_package,
+)
 from nirs4all.pipeline.dagml.raw_training_lowerer import RawArrayDagMLTrainingCompiler
 
 
@@ -43,10 +47,13 @@ def fit_native_pipeline(
     ``sample_ids`` are mandatory because the resulting Package V2 and Archive
     V2 require stable identities for every later PREDICT cohort.
 
-    The returned fitted estimator retains the exact native ``TrainingResult``,
-    ``TrainingOutcome`` and Package V2.  Its :meth:`export_native_archive`
-    method writes the native Archive V2 directly; it never invokes the legacy
-    runner or fits the model a second time.
+    The installed DAG-ML runtime must produce a ``portable_required`` Methods
+    Package V2 with one durable N4MM refit artifact.  Host-sidecar/joblib
+    results are refused before this function returns: they cannot be replayed
+    or exported as a native archive.  A successful estimator retains the exact
+    native ``TrainingResult``, ``TrainingOutcome`` and Package V2.  Its
+    :meth:`export_native_archive` method writes Archive V2 directly; it never
+    invokes the legacy runner or fits the model a second time.
     """
 
     if not isinstance(pipeline, list):
@@ -89,6 +96,12 @@ def fit_native_pipeline(
     estimator.fit(X, y, sample_ids=sample_ids, groups=groups, metadata=metadata)
     if estimator.predictor_package_ is None:
         raise DagMLNativeCoverageError("native DAG-ML training did not return an exportable Package V2")
+    try:
+        validate_native_methods_package(estimator.predictor_package_)
+    except RawArrayMethodsReplayError as error:
+        raise DagMLNativeCoverageError(
+            "native DAG-ML training did not return a replayable portable Methods Package V2"
+        ) from error
     estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
         estimator.predictor_package_,
         dagml_module=dagml_module,

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -432,12 +432,32 @@ class DagMLPipelineEstimator(BaseEstimator):
     def _select_output_binding(self, outputs: list[dict[str, Any]]) -> dict[str, Any]:
         if self.selection_output_id is not None:
             for output in outputs:
-                if output.get("output_id") == self.selection_output_id:
+                if self._output_binding_id(output) == self.selection_output_id:
                     return output
             raise DagMLNativeCoverageError(f"native training output '{self.selection_output_id}' was not produced")
         if len(outputs) == 1:
             return outputs[0]
         raise DagMLNativeCoverageError("native training produced ambiguous outputs; set selection_output_id explicitly")
+
+    @staticmethod
+    def _output_binding_id(output: dict[str, Any]) -> str | None:
+        """Read the output id from both legacy and Package V2 result shapes.
+
+        The native 0.3.4 binding returns an output wrapper with its stable id
+        at ``binding.binding_id``.  Test doubles and older bindings used the
+        flattened ``output_id`` form.  They express the same selected output;
+        accepting both avoids silently choosing by position.
+        """
+
+        output_id = output.get("output_id")
+        if isinstance(output_id, str):
+            return output_id
+        binding = output.get("binding")
+        if isinstance(binding, dict):
+            binding_id = binding.get("binding_id")
+            if isinstance(binding_id, str):
+                return binding_id
+        return None
 
     def _export_predictor_package(self, training_result: Any, execution: DagMLTrainingExecution) -> Any:
         export_package = getattr(training_result, "export_portable_predictor_package", None)

--- a/nirs4all/pipeline/dagml/raw_replay_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_replay_lowerer.py
@@ -164,6 +164,19 @@ def _package_document(package: Any) -> dict[str, Any]:
     return package
 
 
+def validate_native_methods_package(package: Any) -> dict[str, Any]:
+    """Return a package only when it carries replayable Methods evidence.
+
+    Training callers use this at their public boundary so a host-sidecar result
+    cannot masquerade as a native raw pipeline and fail only during prediction
+    or Archive V2 export.
+    """
+
+    document = _package_document(package)
+    _require_native_methods_package(document)
+    return document
+
+
 def _require_native_methods_package(package: Mapping[str, Any]) -> None:
     if package.get("schema_version") != 2:
         raise RawArrayMethodsReplayError("raw-array Methods replay requires Package V2")
@@ -285,4 +298,8 @@ def _object(container: Mapping[str, Any], name: str) -> dict[str, Any]:
     return value
 
 
-__all__ = ["RawArrayMethodsReplayCompiler", "RawArrayMethodsReplayError"]
+__all__ = [
+    "RawArrayMethodsReplayCompiler",
+    "RawArrayMethodsReplayError",
+    "validate_native_methods_package",
+]

--- a/tests/unit/api/test_native_training.py
+++ b/tests/unit/api/test_native_training.py
@@ -24,7 +24,16 @@ class _TrainingResult:
     ]
 
     def export_portable_predictor_package(self, package_id: str) -> dict[str, Any]:
-        return {"schema_version": 2, "package_id": package_id}
+        return {
+            "schema_version": 2,
+            "package_id": package_id,
+            "execution_bundle": {
+                "raw_artifact_payloads": {"artifact:model": [1, 2, 3]},
+                "refit_artifacts": [
+                    {"artifact_id": "artifact:model", "kind": "n4m_model"}
+                ],
+            },
+        }
 
 
 class _Client:
@@ -92,10 +101,9 @@ def test_fit_native_pipeline_is_a_public_strict_native_composition(
         {"records": []},
         {"entries": []},
     )
-    assert estimator.predictor_package_ == {
-        "schema_version": 2,
-        "package_id": "outcome:native-predictor",
-    }
+    assert estimator.predictor_package_ == _TrainingResult().export_portable_predictor_package(
+        "outcome:native-predictor"
+    )
     assert estimator.prediction_compiler is not None
     assert estimator.prediction_identity_decoder is not None
     assert nirs4all.fit_native_pipeline is fit_native_pipeline
@@ -151,6 +159,41 @@ def test_fit_native_pipeline_surfaces_missing_package_as_native_coverage_error(
             np.asarray([1.0]),
             sample_ids=["fit-a"],
             native_client=NoPackageClient(),
+        )
+
+
+def test_fit_native_pipeline_refuses_host_sidecar_package_before_returning(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class HostSidecar(_TrainingResult):
+        def export_portable_predictor_package(self, package_id: str) -> dict[str, Any]:
+            return {"schema_version": 2, "package_id": package_id, "execution_bundle": {}}
+
+    class HostSidecarClient(_Client):
+        def execute_training(self, *args: Any, **kwargs: Any) -> HostSidecar:
+            _ = (args, kwargs)
+            return HostSidecar()
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        lambda *_args, **_kwargs: __import__("nirs4all.pipeline.dagml.estimator", fromlist=["DagMLTrainingExecution"]).DagMLTrainingExecution(
+            request={},
+            data_envelopes={},
+            relations={},
+            training_influence={},
+            op_callback=lambda task: task,
+            outcome_id="o",
+            run_id="r",
+            bundle_id="b",
+        ),
+    )
+    with pytest.raises(DagMLNativeCoverageError, match="replayable portable Methods"):
+        fit_native_pipeline(
+            [{"split": "stub"}, {"model": "stub"}],
+            np.asarray([[1.0]]),
+            np.asarray([1.0]),
+            sample_ids=["fit-a"],
+            native_client=HostSidecarClient(),
         )
 
 

--- a/tests/unit/pipeline/dagml/test_estimator.py
+++ b/tests/unit/pipeline/dagml/test_estimator.py
@@ -273,6 +273,24 @@ def test_fit_refuses_ambiguous_outputs_without_selection_output_id() -> None:
         estimator.fit(np.ones((2, 2)), np.ones(2))
 
 
+def test_fit_selects_package_v2_nested_output_binding() -> None:
+    class PackageV2Result(_FakeTrainingResult):
+        def __init__(self) -> None:
+            super().__init__()
+            self.outputs = [{"binding": {"binding_id": "pred"}}]
+
+    client = _FakeNativeClient()
+    client.training_result = PackageV2Result()
+    estimator = DagMLPipelineEstimator(
+        pipeline=("model",),
+        selection_output_id="pred",
+        native_client=client,
+        training_compiler=lambda *args, **kwargs: _training_execution(),
+    ).fit(np.ones((2, 2)), np.ones(2))
+
+    assert estimator.output_binding_ == {"binding": {"binding_id": "pred"}}
+
+
 def test_predict_requires_replay_compiler_after_fit() -> None:
     estimator = DagMLPipelineEstimator(
         pipeline=("model",),


### PR DESCRIPTION
## Summary
- select the stable nested Package V2 output binding returned by DAG-ML 0.3.4
- require `fit_native_pipeline` to return a replayable Methods/N4MM Package V2
- refuse host-sidecar/joblib results before prediction or Archive V2 export

## Validation
- `ruff check nirs4all/api/native_training.py nirs4all/pipeline/dagml/estimator.py nirs4all/pipeline/dagml/raw_replay_lowerer.py tests/unit/api/test_native_training.py tests/unit/pipeline/dagml/test_estimator.py`
- `pytest -q tests/unit/api/test_native_training.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/pipeline/dagml/test_estimator.py tests/unit/pipeline/dagml/test_raw_training_lowerer.py` (39 passed, 6 skipped)
- `python3.11 -m sphinx -W -b html docs/source /tmp/nirs4all-native-session-docs`
- real wheel probe (`dag-ml==0.3.4` + `nirs4all-core==0.3.15`) confirms host-sidecar output is now refused at fit time

This intentionally does not add a fallback or retrain. A published Methods-portable DAG-ML runtime remains the next dependency for successful native raw fitting.