### PR TITLE
feat(dagml): run raw PLS through portable Methods

### DIFF
--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -37,11 +37,14 @@ and every training and prediction row has a stable identity.
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.model_selection import KFold
 
+methods_library = "/opt/nirs4all/lib/libn4m.so"
+
 estimator = nirs4all.fit_native_pipeline(
     [KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
     X_train,
     y_train,
     sample_ids=["train-0", "train-1", "train-2"],
+    methods_library_path=methods_library,
 )
 estimator.export_native_archive("model.n4a", archive_id="archive:demo.pls")
 prediction = estimator.predict_with_identity(
@@ -55,6 +58,8 @@ and Package V2. Export writes Archive V2 from those exact native objects; it
 does not invoke the compatibility `PipelineRunner` or refit. Unsupported
 pipeline shapes, implicit identities, non-finite arrays, absent native
 capabilities, and non-native probability decoding fail explicitly.
+``methods_library_path`` is explicit on purpose: the portable route never
+discovers or substitutes a Python backend.
 
 ### nirs4all.run()
 

--- a/docs/source/reference/api/session.md
+++ b/docs/source/reference/api/session.md
@@ -118,7 +118,11 @@ predictions = session.predict(X_new)
 
 **Native Archive V2 example:**
 ```python
-native = nirs4all.load_session("exports/methods_model.n4a", engine="native")
+native = nirs4all.load_session(
+    "exports/methods_model.n4a",
+    engine="native",
+    methods_library_path="/opt/nirs4all/lib/libn4m.so",
+)
 prediction = nirs4all.predict(
     data={"X": X_new, "sample_ids": sample_ids},
     session=native,

--- a/docs/source/user_guide/predictions/session_api.md
+++ b/docs/source/user_guide/predictions/session_api.md
@@ -127,7 +127,12 @@ sample ids:
 ```python
 import nirs4all
 
-with nirs4all.load_session("exports/methods_model.n4a", engine="native") as native:
+methods_library = "/opt/nirs4all/lib/libn4m.so"
+with nirs4all.load_session(
+    "exports/methods_model.n4a",
+    engine="native",
+    methods_library_path=methods_library,
+) as native:
     prediction = nirs4all.predict(
         data={"X": X_new, "sample_ids": sample_ids},
         session=native,
@@ -137,7 +142,8 @@ with nirs4all.load_session("exports/methods_model.n4a", engine="native") as nati
 
 This R2 migration surface supports portable **PREDICT** replay only.  Training,
 retraining and explanation remain separate capabilities and are never routed to
-the legacy runner implicitly.
+the legacy runner implicitly. The native Methods shared library is explicit for
+each session; a missing library path is refused rather than replaced by Python.
 
 ## Session Features
 

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -38,6 +38,7 @@ def fit_native_pipeline(
     native_client: Any = None,
     training_losses: tuple[Mapping[str, Any], ...] = (),
     local_implementations: Any = None,
+    methods_library_path: str | None = None,
     seed: int = 12345,
 ) -> DagMLPipelineEstimator:
     """Fit the supported raw-array pipeline entirely through DAG-ML.
@@ -89,6 +90,7 @@ def fit_native_pipeline(
             dagml_module=dagml_module,
             training_losses=training_losses,
             local_implementations=local_implementations,
+            methods_library_path=methods_library_path,
             seed=seed,
         ),
         require_explicit_sample_ids=True,
@@ -105,6 +107,7 @@ def fit_native_pipeline(
     estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
         estimator.predictor_package_,
         dagml_module=dagml_module,
+        methods_library_path=methods_library_path,
     )
     estimator.prediction_identity_decoder = _decode_raw_methods_prediction
     return estimator

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -78,6 +78,7 @@ def predict(
     save_to_workspace: bool = False,
     workspace_metadata: Mapping[str, Any] | None = None,
     workspace_result_metadata: Mapping[str, Any] | None = None,
+    methods_library_path: str | Path | None = None,
     **runner_kwargs: Any,
 ) -> PredictResult:
     """Make predictions with a trained model on new data.
@@ -163,6 +164,10 @@ def predict(
             ``engine="native"``.  Native sessions never construct a legacy
             runner.
 
+        methods_library_path: Required path to the compatible ``libn4m`` for
+            ``engine="native"`` Archive V2 Methods prediction. It is never
+            used to select a legacy execution path.
+
         verbose: Verbosity level (0=quiet, 1=info, 2=debug).
             Default: 0
 
@@ -235,6 +240,7 @@ def predict(
             all_predictions=all_predictions,
             coverage=coverage,
             session=session,
+            methods_library_path=methods_library_path,
         )
         if save_to_workspace:
             raise NotImplementedError(
@@ -397,6 +403,7 @@ def _predict_from_native_archive(
     all_predictions: bool,
     coverage: float | list[float] | tuple[float, ...] | None,
     session: Session | NativeArchiveSession | None,
+    methods_library_path: str | Path | None,
 ) -> PredictResult:
     """Execute the narrow, portable Archive V2 Methods PREDICT route.
 
@@ -455,6 +462,7 @@ def _predict_from_native_archive(
             sample_ids=data["sample_ids"],
             groups=data.get("groups"),
             metadata=data.get("metadata"),
+            methods_library_path=methods_library_path,
         )
         values = native_prediction.values
         prediction_sample_ids = native_prediction.sample_ids

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -39,8 +39,14 @@ class NativeArchiveSession:
     explanation remain explicit future capabilities rather than legacy fallbacks.
     """
 
-    def __init__(self, archive_path: str | Path) -> None:
+    def __init__(
+        self,
+        archive_path: str | Path,
+        *,
+        methods_library_path: str | Path | None = None,
+    ) -> None:
         self._archive_path = Path(archive_path)
+        self._methods_library_path = methods_library_path
         self._closed = False
 
     @property
@@ -76,6 +82,7 @@ class NativeArchiveSession:
             self._archive_path,
             X,
             sample_ids=sample_ids,
+            methods_library_path=self._methods_library_path,
             groups=groups,
             metadata=metadata,
         )
@@ -113,10 +120,18 @@ class NativeArchiveSession:
         self.close()
 
 
-def load_native_archive_session(path: str | Path) -> NativeArchiveSession:
-    """Open a portable Archive V2 PREDICT session without a legacy runner."""
+def load_native_archive_session(
+    path: str | Path,
+    *,
+    methods_library_path: str | Path | None = None,
+) -> NativeArchiveSession:
+    """Open a portable Archive V2 PREDICT session without a legacy runner.
 
-    return NativeArchiveSession(path)
+    ``methods_library_path`` identifies the compatible native Methods shared
+    library used for invocation-local N4MM hydration.
+    """
+
+    return NativeArchiveSession(path, methods_library_path=methods_library_path)
 
 
 class Session:
@@ -508,6 +523,7 @@ def load_session(
     path: str | Path,
     *,
     engine: str = "legacy",
+    methods_library_path: str | Path | None = None,
 ) -> Session | NativeArchiveSession:
     """Load a prediction session from a saved bundle or portable archive.
 
@@ -517,6 +533,8 @@ def load_session(
             session. ``"native"`` opens the fail-closed Core Archive V2
             Methods replay session; it never constructs a ``PipelineRunner``
             or falls back to the legacy loader.
+        methods_library_path: Required path to ``libn4m`` for an
+            ``engine="native"`` Archive V2 Methods session.
 
     Returns:
         A session ready for prediction. The concrete type is
@@ -536,7 +554,7 @@ def load_session(
     if engine == "native":
         if path.suffix.lower() != ".n4a":
             raise ValueError("engine='native' load_session requires a Core Archive V2 .n4a path")
-        return load_native_archive_session(path)
+        return load_native_archive_session(path, methods_library_path=methods_library_path)
     if engine != "legacy":
         from nirs4all.pipeline.engine import require_legacy_engine
 

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -44,6 +44,11 @@ class DagMLTrainingExecution:
     bundle_id: str
     warnings: Any = ()
     diagnostics: Any = None
+    # The native Methods lane owns its numeric provider in dag-ml.  Keeping
+    # this optional prevents the generic host-callback execution route from
+    # gaining a second, implicit meaning.
+    methods_inputs: Any = None
+    methods_library_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -60,6 +65,8 @@ class DagMLReplayExecution:
     cleanup: Any = None
     warnings: Any = ()
     diagnostics: Any = None
+    methods_inputs: Any = None
+    methods_library_path: str | None = None
 
 
 class DagMLTrainingCompiler(Protocol):
@@ -158,18 +165,37 @@ class DagMLPipelineEstimator(BaseEstimator):
             identity_frame=identity_frame,
         )
         client = self._client()
-        training_result = client.execute_training(
-            execution.request,
-            execution.data_envelopes,
-            execution.relations,
-            execution.training_influence,
-            execution.op_callback,
-            outcome_id=execution.outcome_id,
-            run_id=execution.run_id,
-            bundle_id=execution.bundle_id,
-            warnings=execution.warnings,
-            diagnostics=execution.diagnostics,
-        )
+        if execution.methods_inputs is not None or execution.methods_library_path is not None:
+            if execution.methods_inputs is None or execution.methods_library_path is None:
+                raise DagMLNativeCoverageError(
+                    "native Methods training requires both methods inputs and an explicit libn4m path"
+                )
+            training_result = client.execute_methods_training(
+                execution.request,
+                execution.data_envelopes,
+                execution.relations,
+                execution.training_influence,
+                execution.methods_inputs,
+                methods_library_path=execution.methods_library_path,
+                outcome_id=execution.outcome_id,
+                run_id=execution.run_id,
+                bundle_id=execution.bundle_id,
+                warnings=execution.warnings,
+                diagnostics=execution.diagnostics,
+            )
+        else:
+            training_result = client.execute_training(
+                execution.request,
+                execution.data_envelopes,
+                execution.relations,
+                execution.training_influence,
+                execution.op_callback,
+                outcome_id=execution.outcome_id,
+                run_id=execution.run_id,
+                bundle_id=execution.bundle_id,
+                warnings=execution.warnings,
+                diagnostics=execution.diagnostics,
+            )
 
         self.training_result_ = training_result
         self.training_outcome_ = getattr(training_result, "outcome", None)
@@ -386,18 +412,35 @@ class DagMLPipelineEstimator(BaseEstimator):
         )
         replay = self._compile_replay(X, mode=mode, identity_frame=identity_frame)
         try:
-            outcome = self._client().replay_loaded_predictor_package(
-                self.predictor_package_,
-                replay.request,
-                replay.data_envelopes,
-                replay.artifact_handles,
-                replay.op_callback,
-                outcome_id=replay.outcome_id,
-                run_id=replay.run_id,
-                artifact_callback=replay.artifact_callback,
-                warnings=replay.warnings,
-                diagnostics=replay.diagnostics,
-            )
+            if replay.methods_inputs is not None or replay.methods_library_path is not None:
+                if replay.methods_inputs is None or replay.methods_library_path is None:
+                    raise DagMLNativeCoverageError(
+                        "native Methods replay requires inputs and an explicit libn4m path"
+                    )
+                outcome = self._client().replay_loaded_methods_predictor_package(
+                    self.predictor_package_,
+                    replay.request,
+                    replay.data_envelopes,
+                    replay.methods_inputs,
+                    methods_library_path=replay.methods_library_path,
+                    outcome_id=replay.outcome_id,
+                    run_id=replay.run_id,
+                    warnings=replay.warnings,
+                    diagnostics=replay.diagnostics,
+                )
+            else:
+                outcome = self._client().replay_loaded_predictor_package(
+                    self.predictor_package_,
+                    replay.request,
+                    replay.data_envelopes,
+                    replay.artifact_handles,
+                    replay.op_callback,
+                    outcome_id=replay.outcome_id,
+                    run_id=replay.run_id,
+                    artifact_callback=replay.artifact_callback,
+                    warnings=replay.warnings,
+                    diagnostics=replay.diagnostics,
+                )
         finally:
             if replay.cleanup is not None:
                 replay.cleanup()
@@ -464,6 +507,12 @@ class DagMLPipelineEstimator(BaseEstimator):
         if not callable(export_package):
             return None
         package_id = self.package_id or f"{execution.outcome_id}-predictor"
+        if execution.methods_inputs is not None:
+            return export_package(
+                package_id,
+                fitted_artifact_mode="portable_required",
+                artifact_load_mode="native_portable",
+            )
         return export_package(package_id)
 
     @staticmethod

--- a/nirs4all/pipeline/dagml/native_archive_replay.py
+++ b/nirs4all/pipeline/dagml/native_archive_replay.py
@@ -159,6 +159,7 @@ def predict_methods_archive_v2_raw(
     X: Any,
     *,
     sample_ids: Any,
+    methods_library_path: str | Path | None = None,
     groups: Any = None,
     metadata: Any = None,
     outcome_id: str = "outcome:nirs4all.archive_predict",
@@ -176,6 +177,7 @@ def predict_methods_archive_v2_raw(
         archive_path,
         X,
         sample_ids=sample_ids,
+        methods_library_path=methods_library_path,
         groups=groups,
         metadata=metadata,
         outcome_id=outcome_id,
@@ -188,6 +190,7 @@ def predict_methods_archive_v2_raw_result(
     X: Any,
     *,
     sample_ids: Any,
+    methods_library_path: str | Path | None = None,
     groups: Any = None,
     metadata: Any = None,
     outcome_id: str = "outcome:nirs4all.archive_predict",
@@ -199,6 +202,16 @@ def predict_methods_archive_v2_raw_result(
     :func:`predict_methods_archive_v2_raw`.  It exposes only interval blocks
     already materialized and validated by DAG-ML; it never recalibrates.
     """
+
+    if methods_library_path is None:
+        raise NativeArchiveReplayError(
+            "native Archive V2 Methods replay requires an explicit methods_library_path"
+        )
+    library_path = str(methods_library_path)
+    if not library_path:
+        raise NativeArchiveReplayError(
+            "native Archive V2 Methods replay requires a non-empty methods_library_path"
+        )
 
     dag_ml, package, package_document = _load_methods_archive_package(archive_path)
     identity = normalize_predict_identity(
@@ -212,20 +225,20 @@ def predict_methods_archive_v2_raw_result(
         package,
         outcome_id=outcome_id,
         run_id=run_id,
+        methods_library_path=library_path,
     )
     try:
         replay = compiler.compile_replay(
             None, X, mode="predict", identity_frame=identity
         )
-        outcome = dag_ml.replay_loaded_predictor_package(
+        outcome = dag_ml.replay_loaded_methods_predictor_package(
             package,
             replay.request,
             replay.data_envelopes,
-            replay.artifact_handles,
-            replay.op_callback,
+            replay.methods_inputs,
+            methods_library_path=library_path,
             outcome_id=replay.outcome_id,
             run_id=replay.run_id,
-            artifact_callback=replay.artifact_callback,
         )
         return _decode_exact_raw_prediction(
             outcome,
@@ -234,9 +247,6 @@ def predict_methods_archive_v2_raw_result(
         )
     except (MethodsPortableReplayError, RawArrayMethodsReplayError) as error:
         raise NativeArchiveReplayError(str(error)) from error
-    finally:
-        if "replay" in locals() and replay.cleanup is not None:
-            replay.cleanup()
 
 
 def _load_methods_archive_package(

--- a/nirs4all/pipeline/dagml/native_client.py
+++ b/nirs4all/pipeline/dagml/native_client.py
@@ -50,6 +50,22 @@ class _DagMLFacade(Protocol):
         diagnostics: Any = None,
     ) -> Any: ...
 
+    def execute_methods_training(
+        self,
+        request: Any,
+        data_envelopes: Any,
+        relations: Any,
+        training_influence: Any,
+        methods_inputs: Any,
+        *,
+        methods_library_path: str,
+        outcome_id: str,
+        run_id: str,
+        bundle_id: str,
+        warnings: Any = (),
+        diagnostics: Any = None,
+    ) -> Any: ...
+
     def replay_loaded_predictor_package(
         self,
         package: Any,
@@ -61,6 +77,20 @@ class _DagMLFacade(Protocol):
         outcome_id: str,
         run_id: str,
         artifact_callback: Any = None,
+        warnings: Any = (),
+        diagnostics: Any = None,
+    ) -> Any: ...
+
+    def replay_loaded_methods_predictor_package(
+        self,
+        package: Any,
+        request: Any,
+        data_envelopes: Any,
+        methods_inputs: Any,
+        *,
+        methods_library_path: str,
+        outcome_id: str,
+        run_id: str,
         warnings: Any = (),
         diagnostics: Any = None,
     ) -> Any: ...
@@ -138,6 +168,43 @@ class DagMLNativeClient:
             diagnostics=diagnostics,
         )
 
+    def execute_methods_training(
+        self,
+        request: Any,
+        data_envelopes: Any,
+        relations: Any,
+        training_influence: Any,
+        methods_inputs: Any,
+        *,
+        methods_library_path: str,
+        outcome_id: str,
+        run_id: str,
+        bundle_id: str,
+        warnings: Any = (),
+        diagnostics: Any = None,
+    ) -> Any:
+        """Execute the no-callback portable Methods PLS lane.
+
+        This intentionally has a distinct facade method: routing a Methods
+        model through ``execute_training`` would install a Python callback and
+        silently turn a supposedly portable model into a host sidecar.
+        """
+
+        facade = self._require_callable("execute_methods_training")
+        return facade.execute_methods_training(
+            request,
+            data_envelopes,
+            relations,
+            training_influence,
+            methods_inputs,
+            methods_library_path=methods_library_path,
+            outcome_id=outcome_id,
+            run_id=run_id,
+            bundle_id=bundle_id,
+            warnings=warnings,
+            diagnostics=diagnostics,
+        )
+
     def replay_loaded_predictor_package(
         self,
         package: Any,
@@ -176,6 +243,34 @@ class DagMLNativeClient:
             artifact_handles,
             op_callback,
             **kwargs,
+        )
+
+    def replay_loaded_methods_predictor_package(
+        self,
+        package: Any,
+        request: Any,
+        data_envelopes: Any,
+        methods_inputs: Any,
+        *,
+        methods_library_path: str,
+        outcome_id: str,
+        run_id: str,
+        warnings: Any = (),
+        diagnostics: Any = None,
+    ) -> Any:
+        """Replay a native Methods package without callback or sidecar adapters."""
+
+        facade = self._require_callable("replay_loaded_methods_predictor_package")
+        return facade.replay_loaded_methods_predictor_package(
+            package,
+            request,
+            data_envelopes,
+            methods_inputs,
+            methods_library_path=methods_library_path,
+            outcome_id=outcome_id,
+            run_id=run_id,
+            warnings=warnings,
+            diagnostics=diagnostics,
         )
 
     def _load_facade(self) -> _DagMLFacade:

--- a/nirs4all/pipeline/dagml/raw_replay_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_replay_lowerer.py
@@ -69,6 +69,7 @@ class RawArrayMethodsReplayCompiler:
     request_id: str = "replay:nirs4all.raw_predict"
     dagml_module: str = "dag_ml"
     fallback: Any = None
+    methods_library_path: str | None = None
 
     def compile_replay(
         self,
@@ -131,23 +132,45 @@ class RawArrayMethodsReplayCompiler:
                 "installed dag_ml lacks native replay-request signing; upgrade DAG-ML"
             )
         request = signer(unsigned_request)
-        resolver = _ArrayReplayResolver(
-            dict(zip(identity_frame.sample_ids, values, strict=True))
-        )
-        callbacks = MethodsN4mmReplayCallbacks(
-            resolver,
-            target_names_by_node={binding["node_id"]: list(binding["target_names"])},
-            fallback=self.fallback,
-        )
+        methods_inputs = {
+            key: {
+                "sample_ids": list(identity_frame.sample_ids),
+                "x": values.tolist(),
+                "target_names": list(binding["target_names"]),
+            }
+            for key in requirements
+        }
+        if self.methods_library_path is None:
+            # Compatibility tests and pre-published bindings may still use the
+            # old explicit hydration callback.  The public fit path always
+            # supplies a library path and therefore never takes this branch.
+            resolver = _ArrayReplayResolver(
+                dict(zip(identity_frame.sample_ids, values, strict=True))
+            )
+            callbacks = MethodsN4mmReplayCallbacks(
+                resolver,
+                target_names_by_node={binding["node_id"]: list(binding["target_names"])},
+                fallback=self.fallback,
+            )
+            return DagMLReplayExecution(
+                request=request,
+                data_envelopes=envelopes,
+                artifact_handles={},
+                op_callback=callbacks.op_callback,
+                artifact_callback=callbacks.artifact_callback,
+                cleanup=callbacks.close,
+                outcome_id=self.outcome_id,
+                run_id=self.run_id,
+            )
         return DagMLReplayExecution(
             request=request,
             data_envelopes=envelopes,
             artifact_handles={},
-            op_callback=callbacks.op_callback,
-            artifact_callback=callbacks.artifact_callback,
-            cleanup=callbacks.close,
+            op_callback=None,
             outcome_id=self.outcome_id,
             run_id=self.run_id,
+            methods_inputs=methods_inputs,
+            methods_library_path=self.methods_library_path,
         )
 
 
@@ -192,20 +215,29 @@ def _require_native_methods_package(package: Mapping[str, Any]) -> None:
         for artifact_id, payload in raw.items()
         if isinstance(artifact_id, str) and isinstance(payload, (str, list, bytes, bytearray))
     }
+    # Package V2 serializes refit artifacts as records containing ``artifact``.
+    # Keep accepting the historical flattened test fixture while all public
+    # production paths use the nested record shape.
     methods = [
-        artifact
-        for artifact in artifacts
-        if isinstance(artifact, dict) and artifact.get("kind") == "n4m_model"
+        record
+        for record in artifacts
+        if isinstance(record, dict)
+        and _artifact_document(record).get("kind") == "n4m_model"
     ]
     if len(methods) != 1:
         raise RawArrayMethodsReplayError(
             "raw-array Methods replay requires exactly one n4m_model refit artifact"
         )
-    artifact_id = methods[0].get("artifact_id")
+    artifact_id = _artifact_document(methods[0]).get("id", methods[0].get("artifact_id"))
     if not isinstance(artifact_id, str) or artifact_id not in raw_ids:
         raise RawArrayMethodsReplayError(
             "Package V2 N4MM refit artifact has no matching durable raw payload"
         )
+
+
+def _artifact_document(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    artifact = record.get("artifact")
+    return artifact if isinstance(artifact, Mapping) else record
 
 
 def _requirements(bundle: Mapping[str, Any]) -> dict[str, dict[str, str]]:

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 import numpy as np
 
 from nirs4all.data.dataset import SpectroDataset
-from nirs4all.pipeline.dagml_bridge import _model_controller_id, controller_manifests
+from nirs4all.pipeline.dagml_bridge import _model_controller_id, _model_data_requirements, controller_manifests
 
 from .cli_runner import assemble_cv_refit_dsl
 from .envelope import build_envelope
@@ -55,6 +55,7 @@ class RawArrayDagMLTrainingCompiler:
     dagml_module: str = "dag_ml"
     training_losses: tuple[Mapping[str, Any], ...] = ()
     local_implementations: Any = None
+    methods_library_path: str | None = None
 
     def compile_fit(
         self,
@@ -86,6 +87,7 @@ class RawArrayDagMLTrainingCompiler:
             dagml_module=self.dagml_module,
             training_losses=self.training_losses,
             local_implementations=self.local_implementations,
+            methods_library_path=self.methods_library_path,
         )
         compiler = DagMLTrainingRequestCompiler(
             contracts,
@@ -120,10 +122,14 @@ def lower_raw_array_training_contracts(
     dagml_module: str = "dag_ml",
     training_losses: tuple[Mapping[str, Any], ...] = (),
     local_implementations: Any = None,
+    methods_library_path: str | None = None,
 ) -> DagMLTrainingRequestContracts:
     """Lower a linear raw-array pipeline into executable DAG-ML contracts."""
 
     steps, splitter, finetune_overrides = _supported_linear_steps(pipeline)
+    portable_methods = methods_library_path is not None
+    if portable_methods:
+        _validate_portable_methods_pipeline(steps)
     selection_metric = finetune_overrides.get("selection_metric", selection_metric)
     selection_objective = finetune_overrides.get("selection_objective", selection_objective)
     dataset = raw_arrays_to_spectro_dataset(X, y, identity_frame=identity_frame)
@@ -143,6 +149,9 @@ def lower_raw_array_training_contracts(
     envelope["target_content_fingerprint"] = _array_content_fingerprint("y", y)
     dsl = assemble_cv_refit_dsl(steps, identity, envelope, folds, dsl_id="nirs4all-raw-fit", n_splits=len(folds))
     manifests = controller_manifests()
+    if portable_methods:
+        _lower_portable_methods_pls_dsl(dsl)
+        manifests = [_portable_methods_pls_manifest()]
     artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, manifests)
     graph = artifact.graph.to_dict()
     campaign = artifact.campaign_template.to_dict()
@@ -166,6 +175,8 @@ def lower_raw_array_training_contracts(
         selection_required_metric_level="sample",
         selection_evaluation_scope="oof",
         cv_artifacts="discard",
+        prediction_caches="retain",
+        fitted_artifacts="portable_required" if portable_methods else "allow_host_sidecar",
     )
     training_influence = _training_influence_manifest(
         graph,
@@ -180,11 +191,17 @@ def lower_raw_array_training_contracts(
         data_envelopes=data_envelopes,
         relations=copy.deepcopy(envelope["coordinator_relations"]),
         training_influence=training_influence,
-        op_callback=_op_callback(dataset, identity, graph, local_implementations),
+        op_callback=None if portable_methods else _op_callback(dataset, identity, graph, local_implementations),
         outcome_id=outcome_id,
         run_id=run_id,
         bundle_id=bundle_id,
         diagnostics={"nirs4all_raw_array_samples": identity_frame.n_samples},
+        methods_inputs=(
+            _methods_inputs_from_arrays(X, y, identity_frame, next(iter(data_envelopes)))
+            if portable_methods
+            else None
+        ),
+        methods_library_path=methods_library_path,
     )
 
 
@@ -255,6 +272,99 @@ def _supported_linear_steps(pipeline: Any) -> tuple[list[Any], Any, dict[str, st
     _reject_multi_model(steps)
     _assert_supported_operators(steps)
     return steps, splitter, finetune_overrides
+
+
+def _validate_portable_methods_pipeline(steps: list[Any]) -> None:
+    """Refuse every raw fit shape the Methods PLS lane cannot represent exactly."""
+
+    if len(steps) != 1 or not isinstance(steps[0], Mapping) or set(steps[0]) - {"model"}:
+        raise ValueError(
+            "portable Methods training currently supports exactly one PLSRegression model step after the splitter"
+        )
+    model = steps[0].get("model")
+    cls = model if isinstance(model, type) else type(model)
+    if (
+        getattr(cls, "__name__", None) != "PLSRegression"
+        or not str(getattr(cls, "__module__", "")).startswith("sklearn.cross_decomposition")
+    ):
+        raise ValueError(
+            "portable Methods training currently supports sklearn.cross_decomposition.PLSRegression only"
+        )
+    components = getattr(model, "n_components", None)
+    if not isinstance(components, int) or isinstance(components, bool) or components < 1:
+        raise ValueError("portable Methods PLS requires a positive integer n_components")
+
+
+def _lower_portable_methods_pls_dsl(dsl: dict[str, Any]) -> None:
+    """Bind the single model node to the typed Methods controller, never Python."""
+
+    pipeline = dsl.get("pipeline")
+    if not isinstance(pipeline, list) or len(pipeline) != 1 or not isinstance(pipeline[0], dict):
+        raise ValueError("portable Methods DSL must contain exactly one model step")
+    step = pipeline[0]
+    params = step.get("params")
+    if not isinstance(params, Mapping) or not isinstance(params.get("n_components"), int):
+        raise ValueError("portable Methods DSL requires integer PLS n_components")
+    # `model` stays a transparent declaration for graph provenance; the
+    # controller id is explicit and scheduler-owned, so no Python import or
+    # sklearn callback can become executable at runtime.
+    step["metadata"] = {"controller_id": "controller:methods.pls"}
+
+
+def _portable_methods_pls_manifest() -> dict[str, Any]:
+    """The public controller declaration matching DAG-ML's Methods PLS runtime."""
+
+    return {
+        "controller_id": "controller:methods.pls",
+        "controller_version": "n4m-abi-2.2",
+        "operator_kind": "model",
+        "priority": 100,
+        "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
+        "input_ports": [
+            {"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}
+        ],
+        "output_ports": [
+            {"name": "oof", "kind": "prediction", "representation": None, "cardinality": "one"},
+            {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
+        ],
+        "data_requirements": _model_data_requirements(),
+        "capabilities": [
+            "deterministic",
+            "thread_safe",
+            "process_safe",
+            "emits_predictions",
+            "emits_artifacts",
+            "stateful",
+        ],
+        "operator_selectors": [{"refs": ["sklearn.cross_decomposition._pls.PLSRegression"]}],
+        "fit_scope": "fold_train",
+        "rng_policy": "uses_core_seed",
+        "artifact_policy": "serializable",
+    }
+
+
+def _methods_inputs_from_arrays(
+    X: Any,
+    y: Any,
+    identity_frame: DagMLFitIdentityFrame,
+    binding_key: str,
+) -> dict[str, Any]:
+    """Create the host-owned full numeric input keyed by the one model binding."""
+
+    features = np.asarray(X, dtype=float)
+    targets = np.asarray(y, dtype=float)
+    if targets.ndim == 1:
+        targets = targets.reshape(-1, 1)
+    if targets.ndim != 2 or targets.shape[1] != 1:
+        raise ValueError("portable Methods PLS currently supports exactly one numeric target")
+    return {
+        binding_key: {
+            "sample_ids": list(identity_frame.sample_ids),
+            "x": features.tolist(),
+            "y": targets.tolist(),
+            "target_names": ["y"],
+        }
+    }
 
 
 def _data_contracts_from_campaign(

--- a/nirs4all/pipeline/dagml/training_compiler.py
+++ b/nirs4all/pipeline/dagml/training_compiler.py
@@ -37,12 +37,14 @@ class DagMLPreparedTrainingContracts:
     data_envelopes: Mapping[str, Any]
     relations: Any
     training_influence: Any
-    op_callback: Callable[[Any], Any]
+    op_callback: Callable[[Any], Any] | None
     outcome_id: str
     run_id: str
     bundle_id: str
     warnings: Sequence[str] = ()
     diagnostics: Mapping[str, Any] | None = None
+    methods_inputs: Mapping[str, Any] | None = None
+    methods_library_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -53,12 +55,14 @@ class DagMLTrainingRequestContracts:
     data_envelopes: Mapping[str, Any]
     relations: Any
     training_influence: Any
-    op_callback: Callable[[Any], Any]
+    op_callback: Callable[[Any], Any] | None
     outcome_id: str
     run_id: str
     bundle_id: str
     warnings: Sequence[str] = ()
     diagnostics: Mapping[str, Any] | None = None
+    methods_inputs: Mapping[str, Any] | None = None
+    methods_library_path: str | None = None
 
     def to_prepared(self) -> DagMLPreparedTrainingContracts:
         """Assemble the signed request and return prepared execution contracts."""
@@ -74,6 +78,8 @@ class DagMLTrainingRequestContracts:
             bundle_id=self.bundle_id,
             warnings=self.warnings,
             diagnostics=self.diagnostics,
+            methods_inputs=self.methods_inputs,
+            methods_library_path=self.methods_library_path,
         )
 
 
@@ -213,6 +219,8 @@ def compile_prepared_training_contracts(
         bundle_id=contracts.bundle_id,
         warnings=warnings,
         diagnostics=diagnostics,
+        methods_inputs=(dict(contracts.methods_inputs) if contracts.methods_inputs is not None else None),
+        methods_library_path=contracts.methods_library_path,
     )
 
 
@@ -224,7 +232,13 @@ def _validate_prepared_contracts(contracts: DagMLPreparedTrainingContracts) -> N
     for key in contracts.data_envelopes:
         if not isinstance(key, str) or not key:
             raise ValueError("data_envelopes keys must be non-empty strings")
-    if not callable(contracts.op_callback):
+    uses_methods = contracts.methods_inputs is not None or contracts.methods_library_path is not None
+    if uses_methods:
+        if contracts.methods_inputs is None or not isinstance(contracts.methods_library_path, str) or not contracts.methods_library_path:
+            raise ValueError("Methods contracts require inputs and an explicit libn4m path")
+        if contracts.op_callback is not None:
+            raise ValueError("Methods contracts forbid a Python operator callback")
+    elif not callable(contracts.op_callback):
         raise TypeError("op_callback must be callable")
     _require_non_empty_text("outcome_id", contracts.outcome_id)
     _require_non_empty_text("run_id", contracts.run_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.4",
+    "dag-ml>=0.3.5",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.4",
+    "dag-ml>=0.3.5",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
 ]

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.4
+dag-ml>=0.3.5
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.4
+dag-ml>=0.3.5
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.4
+dag-ml>=0.3.5
 dag-ml-data>=0.2.8

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -77,9 +77,9 @@ def test_predict_native_archive_is_explicit_and_never_constructs_a_legacy_runner
 ) -> None:
     observed: dict[str, object] = {}
 
-    def native_predict(path, X, *, sample_ids, groups, metadata):  # noqa: ANN001
+    def native_predict(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
         observed.update(
-            path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), groups=groups, metadata=metadata
+            path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), methods_library_path=methods_library_path, groups=groups, metadata=metadata
         )
         return NativeArchivePrediction(
             values=np.asarray([[2.0], [3.0]]),

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -13,8 +13,8 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
 ) -> None:
     observed: dict[str, object] = {}
 
-    def replay(path, X, *, sample_ids, groups, metadata):  # noqa: ANN001
-        observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), groups=groups, metadata=metadata)
+    def replay(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
+        observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), methods_library_path=methods_library_path, groups=groups, metadata=metadata)
         return NativeArchivePrediction(
             values=np.asarray([[4.0], [5.0]]),
             sample_ids=("p1", "p2"),
@@ -26,7 +26,7 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
         "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
         replay,
     )
-    with load_native_archive_session("portable.n4a") as session:
+    with load_native_archive_session("portable.n4a", methods_library_path="/native/libn4m.so") as session:
         assert isinstance(session, NativeArchiveSession)
         result = session.predict(
             np.asarray([[1.0], [2.0]]),
@@ -37,6 +37,7 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
         assert result.metadata["engine"] == "native"
     assert session.closed
     assert observed["sample_ids"] == ["p1", "p2"]
+    assert observed["methods_library_path"] == "/native/libn4m.so"
     with pytest.raises(RuntimeError, match="closed"):
         session.predict(np.asarray([[1.0]]), sample_ids=["p3"])
 
@@ -66,7 +67,7 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
 ) -> None:
     observed: dict[str, object] = {}
 
-    def replay(path, X, *, sample_ids, groups, metadata):  # noqa: ANN001
+    def replay(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
         observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids))
         return NativeArchivePrediction(
             values=np.asarray([[7.0], [8.0]]),
@@ -79,7 +80,9 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
         "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
         replay,
     )
-    native_session = load_native_archive_session("portable.n4a")
+    native_session = load_native_archive_session(
+        "portable.n4a", methods_library_path="/native/libn4m.so"
+    )
 
     result = predict(
         data={"X": np.asarray([[1.0], [2.0]]), "sample_ids": ["p1", "p2"]},

--- a/tests/unit/pipeline/dagml/test_native_client.py
+++ b/tests/unit/pipeline/dagml/test_native_client.py
@@ -145,6 +145,57 @@ def test_execute_training_forwards_to_facade_without_contract_reimplementation(
     ]
 
 
+def test_execute_methods_training_forwards_without_a_python_operator_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module_name = "_n4a_fake_dag_ml_methods_training"
+    calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+    sentinel = object()
+
+    def execute_methods_training(*args: Any, **kwargs: Any) -> object:
+        calls.append((args, kwargs))
+        return sentinel
+
+    monkeypatch.setitem(
+        sys.modules,
+        module_name,
+        _fake_module(module_name, execute_methods_training=execute_methods_training),
+    )
+
+    result = DagMLNativeClient(module_name).execute_methods_training(
+        {"request": True},
+        {"model:base.x": {"envelope": True}},
+        {"relations": True},
+        {"influence": True},
+        {"model:base.x": {"x": [[1.0]], "y": [[2.0]]}},
+        methods_library_path="/absolute/libn4m.so",
+        outcome_id="outcome-1",
+        run_id="run-1",
+        bundle_id="bundle-1",
+    )
+
+    assert result is sentinel
+    assert calls == [
+        (
+            (
+                {"request": True},
+                {"model:base.x": {"envelope": True}},
+                {"relations": True},
+                {"influence": True},
+                {"model:base.x": {"x": [[1.0]], "y": [[2.0]]}},
+            ),
+            {
+                "methods_library_path": "/absolute/libn4m.so",
+                "outcome_id": "outcome-1",
+                "run_id": "run-1",
+                "bundle_id": "bundle-1",
+                "warnings": (),
+                "diagnostics": None,
+            },
+        )
+    ]
+
+
 def test_replay_loaded_predictor_package_forwards_to_facade(monkeypatch: pytest.MonkeyPatch) -> None:
     module_name = "_n4a_fake_dag_ml_replay"
     calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []

--- a/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
@@ -169,25 +169,13 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
         package: _Package,
         request: dict[str, object],
         envelopes: dict[str, object],
-        handles: dict[str, object],
-        op_callback: object,
+        methods_inputs: dict[str, object],
         *,
+        methods_library_path: str,
         outcome_id: str,
         run_id: str,
-        artifact_callback: object,
     ) -> dict[str, object]:
-        _ = (package, request, envelopes, handles, op_callback, outcome_id, run_id)
-        handle = artifact_callback(
-            {
-                "operation": "hydrate",
-                "request": {
-                    "artifact": {"kind": "n4m_model"},
-                    "controller_id": "methods.pls",
-                },
-                "payload": [1, 2, 3],
-            }
-        )
-        artifact_callback({"operation": "release", "handle": handle})
+        _ = (package, request, envelopes, methods_inputs, methods_library_path, outcome_id, run_id)
         return {
             "outputs": [
                 {
@@ -202,7 +190,7 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
         }
 
     runtime.PortablePredictorPackage = _Package
-    runtime.replay_loaded_predictor_package = replay
+    runtime.replay_loaded_methods_predictor_package = replay
     monkeypatch.setitem(sys.modules, "dag_ml", runtime)
     monkeypatch.setitem(
         sys.modules,
@@ -211,7 +199,7 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
     )
 
     values = predict_methods_archive_v2_raw(
-        "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"]
+        "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"], methods_library_path="/native/libn4m.so"
     )
 
     assert values.tolist() == [[1.5], [2.5]]
@@ -220,10 +208,19 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
     def mismatched_replay(*args: object, **kwargs: object) -> dict[str, object]:
         return {"outputs": [{"predictions": [{"sample_ids": ["sample.two"], "values": [[1.0]]}]}]}
 
-    runtime.replay_loaded_predictor_package = mismatched_replay
+    runtime.replay_loaded_methods_predictor_package = mismatched_replay
     with pytest.raises(NativeArchiveReplayError, match="identities do not exactly match"):
         predict_methods_archive_v2_raw(
-            "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"]
+            "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"], methods_library_path="/native/libn4m.so"
+        )
+
+
+def test_raw_archive_predict_refuses_an_implicit_methods_library() -> None:
+    with pytest.raises(NativeArchiveReplayError, match="explicit methods_library_path"):
+        predict_methods_archive_v2_raw(
+            "portable.n4a",
+            np.asarray([[1.0]]),
+            sample_ids=["sample.one"],
         )
 
 
@@ -283,7 +280,7 @@ def test_raw_archive_predict_projects_exact_native_conformal_intervals(
         }
 
     runtime.PortablePredictorPackage = _Package
-    runtime.replay_loaded_predictor_package = replay
+    runtime.replay_loaded_methods_predictor_package = replay
     monkeypatch.setitem(sys.modules, "dag_ml", runtime)
     monkeypatch.setitem(
         sys.modules,
@@ -297,6 +294,7 @@ def test_raw_archive_predict_projects_exact_native_conformal_intervals(
         "portable.n4a",
         np.asarray([[1.0], [2.0]]),
         sample_ids=["sample.one", "sample.two"],
+        methods_library_path="/native/libn4m.so",
     )
 
     assert result.values.tolist() == [[1.5], [2.5]]
@@ -320,12 +318,13 @@ def test_raw_archive_predict_projects_exact_native_conformal_intervals(
         payload["conformal_intervals"][0]["intervals"][0]["cells"][0][0] = {"status": "unbounded"}
         return payload
 
-    runtime.replay_loaded_predictor_package = unbounded
+    runtime.replay_loaded_methods_predictor_package = unbounded
     with pytest.raises(NativeArchiveReplayError, match="unbounded conformal interval"):
         predict_methods_archive_v2_raw_result(
             "portable.n4a",
             np.asarray([[1.0], [2.0]]),
             sample_ids=["sample.one", "sample.two"],
+            methods_library_path="/native/libn4m.so",
         )
 
 

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import numpy as np
 import pytest
+from sklearn.cross_decomposition import PLSRegression
 from sklearn.model_selection import KFold
 from sklearn.neighbors import KNeighborsRegressor
 
@@ -128,6 +129,55 @@ def test_lower_raw_array_training_contracts_builds_request_envelopes_and_influen
     assert envelope["target_content_fingerprint"] == request["data_identities"][0]["target_content_fingerprint"]
     assert {row["observation_id"] for row in contracts.relations["records"]} == {f"s{index}" for index in range(5)}
     assert {entry["kind"] for entry in contracts.training_influence["entries"]} == {"model_fit", "hpo_selection"}
+
+
+def test_portable_methods_lowering_uses_only_the_native_controller_and_identity_keyed_rows() -> None:
+    _require_recent_dag_ml()
+    X = np.arange(12, dtype=float).reshape(6, 2)
+    y = np.arange(6, dtype=float)
+    frame = normalize_fit_identity(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    contracts = lower_raw_array_training_contracts(
+        [KFold(n_splits=2), {"model": PLSRegression(n_components=1)}],
+        X,
+        y,
+        identity_frame=frame,
+        methods_library_path="/absolute/libn4m.so",
+    )
+    prepared = contracts.to_prepared()
+
+    assert contracts.op_callback is None
+    assert prepared.methods_library_path == "/absolute/libn4m.so"
+    assert prepared.request["options"]["artifacts"] == {
+        "cv_artifacts": "discard",
+        "prediction_caches": "retain",
+        "fitted_artifacts": "portable_required",
+    }
+    assert [manifest["controller_id"] for manifest in prepared.request["controller_manifests"]] == [
+        "controller:methods.pls"
+    ]
+    node = prepared.request["graph"]["nodes"][0]
+    assert node["metadata"]["controller_id"] == "controller:methods.pls"
+    assert prepared.methods_inputs == {
+        "model:compat.0.x": {
+            "sample_ids": [f"s{index}" for index in range(6)],
+            "x": X.tolist(),
+            "y": y.reshape(-1, 1).tolist(),
+            "target_names": ["y"],
+        }
+    }
+
+
+def test_portable_methods_lowering_refuses_non_pls_or_transform_pipelines() -> None:
+    _require_recent_dag_ml()
+    X = np.arange(12, dtype=float).reshape(6, 2)
+    y = np.arange(6, dtype=float)
+    frame = normalize_fit_identity(X, y, sample_ids=[f"s{index}" for index in range(6)])
+
+    with pytest.raises(ValueError, match="PLSRegression only"):
+        lower_raw_array_training_contracts(
+            _pipeline(), X, y, identity_frame=frame, methods_library_path="/absolute/libn4m.so"
+        )
 
 
 def test_lower_raw_array_training_contracts_maps_deterministic_finetune_grid() -> None:


### PR DESCRIPTION
## Summary
- lower the explicit raw-array PLS API to `controller:methods.pls` with `portable_required` artifacts
- send full host matrices under signed binding keys; scheduler controls FIT_CV/REFIT row views
- use the distinct callback-free DAG-ML Methods FIT and loaded PREDICT APIs
- retain generic host-callback routes only for their existing compatibility callers

Depends on GBeurier/dag-ml#45.

## Validation
- `ruff check` for the changed native DAG-ML modules/tests
- `pytest -q` targeted native client, estimator, raw lowerer/replay and API tests: 62 passed, 6 skipped
- real local N4M: raw PLS fit → Package V2 with raw N4MM/native_portable → loaded PREDICT replay with an explicit current cohort