### PR TITLE
[codex] Resolve bundled Methods runtime for native training

### DIFF
--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -14,6 +14,7 @@ from typing import Any, cast
 import numpy as np
 
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
+from nirs4all.pipeline.dagml.methods_runtime import resolve_methods_library_path
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
 from nirs4all.pipeline.dagml.raw_replay_lowerer import (
     RawArrayMethodsReplayCompiler,
@@ -54,7 +55,10 @@ def fit_native_pipeline(
     or exported as a native archive.  A successful estimator retains the exact
     native ``TrainingResult``, ``TrainingOutcome`` and Package V2.  Its
     :meth:`export_native_archive` method writes Archive V2 directly; it never
-    invokes the legacy runner or fits the model a second time.
+    invokes the legacy runner or fits the model a second time.  With
+    ``nirs4all[native]``, the bundled ``nirs4all-methods`` runtime is discovered
+    automatically; ``methods_library_path`` remains an explicit deployment
+    override.
     """
 
     if not isinstance(pipeline, list):
@@ -73,10 +77,13 @@ def fit_native_pipeline(
         raise ValueError("fit_native_pipeline requires 2-D X and 1-D or 2-D y")
     if features.shape[0] == 0 or features.shape[0] != targets.shape[0]:
         raise ValueError("fit_native_pipeline requires aligned non-empty X and y")
+    if len(sample_ids) != features.shape[0]:
+        raise ValueError("fit_native_pipeline requires sample_ids length to match X")
     if not np.issubdtype(features.dtype, np.number) or not np.issubdtype(targets.dtype, np.number):
         raise TypeError("fit_native_pipeline requires numeric X and y")
     if not np.isfinite(features).all() or not np.isfinite(targets).all():
         raise ValueError("fit_native_pipeline requires finite X and y")
+    resolved_methods_library_path = resolve_methods_library_path(methods_library_path)
 
     estimator = DagMLPipelineEstimator(
         pipeline=pipeline,
@@ -90,7 +97,7 @@ def fit_native_pipeline(
             dagml_module=dagml_module,
             training_losses=training_losses,
             local_implementations=local_implementations,
-            methods_library_path=methods_library_path,
+            methods_library_path=resolved_methods_library_path,
             seed=seed,
         ),
         require_explicit_sample_ids=True,
@@ -107,7 +114,7 @@ def fit_native_pipeline(
     estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
         estimator.predictor_package_,
         dagml_module=dagml_module,
-        methods_library_path=methods_library_path,
+        methods_library_path=resolved_methods_library_path,
     )
     estimator.prediction_identity_decoder = _decode_raw_methods_prediction
     return estimator

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -164,9 +164,10 @@ def predict(
             ``engine="native"``.  Native sessions never construct a legacy
             runner.
 
-        methods_library_path: Required path to the compatible ``libn4m`` for
-            ``engine="native"`` Archive V2 Methods prediction. It is never
-            used to select a legacy execution path.
+        methods_library_path: Optional explicit path to the compatible
+            ``libn4m`` for ``engine="native"`` Archive V2 Methods prediction.
+            When omitted, the bundled ``nirs4all-methods`` runtime is used. It
+            is never used to select a legacy execution path.
 
         verbose: Verbosity level (0=quiet, 1=info, 2=debug).
             Default: 0

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -127,8 +127,10 @@ def load_native_archive_session(
 ) -> NativeArchiveSession:
     """Open a portable Archive V2 PREDICT session without a legacy runner.
 
-    ``methods_library_path`` identifies the compatible native Methods shared
-    library used for invocation-local N4MM hydration.
+    With ``nirs4all[native]``, the compatible Methods shared library is
+    discovered from the installed ``nirs4all-methods`` wheel for each
+    invocation. ``methods_library_path`` remains an explicit deployment
+    override for invocation-local N4MM hydration.
     """
 
     return NativeArchiveSession(path, methods_library_path=methods_library_path)
@@ -533,8 +535,9 @@ def load_session(
             session. ``"native"`` opens the fail-closed Core Archive V2
             Methods replay session; it never constructs a ``PipelineRunner``
             or falls back to the legacy loader.
-        methods_library_path: Required path to ``libn4m`` for an
-            ``engine="native"`` Archive V2 Methods session.
+        methods_library_path: Optional explicit path to ``libn4m`` for an
+            ``engine="native"`` Archive V2 Methods session. When omitted,
+            the bundled ``nirs4all-methods`` runtime is used.
 
     Returns:
         A session ready for prediction. The concrete type is

--- a/nirs4all/pipeline/dagml/methods_runtime.py
+++ b/nirs4all/pipeline/dagml/methods_runtime.py
@@ -1,0 +1,87 @@
+"""Resolve the installed portable Methods runtime without a worktree path."""
+
+from __future__ import annotations
+
+import importlib
+from os import fspath
+from pathlib import Path
+from typing import Any
+
+from .native_client import DagMLNativeCoverageError
+
+
+def resolve_methods_library_path(path: str | Path | None = None) -> str:
+    """Return one absolute regular ``libn4m`` path for native DAG-ML calls.
+
+    A caller may explicitly select a library, which is useful for an audited
+    deployment.  Otherwise the resolver uses the bundled library exposed by
+    the official ``nirs4all-methods`` distribution (import package ``n4m``).
+    The resolved path is passed explicitly to DAG-ML; no sibling checkout or
+    loader search path becomes part of the portable training contract.
+    """
+
+    if path is not None:
+        return _validated_library_path(path, source="methods_library_path")
+
+    try:
+        module = importlib.import_module("n4m")
+    except Exception as error:  # pragma: no cover - exact import errors vary by platform
+        raise DagMLNativeCoverageError(
+            "native Methods execution requires the bundled n4m runtime; install "
+            "nirs4all[native] or provide an explicit absolute methods_library_path"
+        ) from error
+
+    library_path = getattr(module, "library_path", None)
+    if not callable(library_path):
+        raise DagMLNativeCoverageError(
+            "installed n4m runtime does not expose library_path(); upgrade nirs4all-methods "
+            "or provide an explicit absolute methods_library_path"
+        )
+    _require_optimizer_abi(module)
+    try:
+        return _validated_library_path(library_path(), source="nirs4all-methods")
+    except (OSError, TypeError, ValueError) as error:
+        raise DagMLNativeCoverageError(
+            "installed n4m runtime did not resolve a usable bundled libn4m; provide an "
+            "explicit absolute methods_library_path"
+        ) from error
+
+
+def _require_optimizer_abi(module: Any) -> None:
+    abi_version = getattr(module, "abi_version", None)
+    if not callable(abi_version):
+        raise DagMLNativeCoverageError(
+            "installed n4m runtime does not expose ABI metadata; upgrade nirs4all-methods "
+            "or provide an explicit absolute methods_library_path"
+        )
+    try:
+        abi = tuple(abi_version())
+    except Exception as error:  # pragma: no cover - runtime-specific loader failure
+        raise DagMLNativeCoverageError(
+            "installed n4m runtime could not report its ABI; upgrade nirs4all-methods"
+        ) from error
+    if len(abi) != 3 or abi[0:2] != (2, 2):
+        raise DagMLNativeCoverageError(
+            "installed n4m runtime ABI is incompatible with native DAG-ML Methods execution; "
+            "install nirs4all-methods>=1.0.10 or provide a compatible explicit "
+            "methods_library_path"
+        )
+
+
+def _validated_library_path(value: str | Path | Any, *, source: str) -> str:
+    try:
+        candidate = Path(fspath(value))
+    except TypeError as error:
+        raise TypeError(f"{source} must identify an absolute libn4m file") from error
+    if not candidate.is_absolute():
+        raise ValueError(f"{source} must identify an absolute libn4m file")
+    try:
+        resolved = candidate.resolve(strict=True)
+    except OSError as error:
+        raise ValueError(f"{source} does not identify an existing libn4m file") from error
+    if not resolved.is_file():
+        raise ValueError(f"{source} must identify a regular libn4m file")
+    return str(resolved)
+
+
+__all__ = ["resolve_methods_library_path"]

--- a/nirs4all/pipeline/dagml/native_archive_replay.py
+++ b/nirs4all/pipeline/dagml/native_archive_replay.py
@@ -20,6 +20,8 @@ import numpy as np
 
 from .fit_identity import normalize_predict_identity
 from .methods_replay import MethodsN4mmReplayCallbacks, MethodsPortableReplayError
+from .methods_runtime import resolve_methods_library_path
+from .native_client import DagMLNativeCoverageError
 from .raw_replay_lowerer import RawArrayMethodsReplayCompiler, RawArrayMethodsReplayError
 
 if TYPE_CHECKING:
@@ -203,15 +205,12 @@ def predict_methods_archive_v2_raw_result(
     already materialized and validated by DAG-ML; it never recalibrates.
     """
 
-    if methods_library_path is None:
+    try:
+        library_path = resolve_methods_library_path(methods_library_path)
+    except (DagMLNativeCoverageError, OSError, TypeError, ValueError, RuntimeError) as error:
         raise NativeArchiveReplayError(
-            "native Archive V2 Methods replay requires an explicit methods_library_path"
-        )
-    library_path = str(methods_library_path)
-    if not library_path:
-        raise NativeArchiveReplayError(
-            "native Archive V2 Methods replay requires a non-empty methods_library_path"
-        )
+            "native Archive V2 Methods replay could not resolve a compatible Methods runtime"
+        ) from error
 
     dag_ml, package, package_document = _load_methods_archive_package(archive_path)
     identity = normalize_predict_identity(

--- a/nirs4all/pipeline/dagml/result.py
+++ b/nirs4all/pipeline/dagml/result.py
@@ -498,10 +498,12 @@ def _scores_to_run_result(
     cv_partitions = _CV_PARTITIONS if run_has_test else ("train", "val")
 
     # Order the CV variants WINNER-first (the variant owning the refit `(final, None)`; its cross-fold
-    # avg is the native `None`-tagged row), then the losers in the order dag-ml emitted them. A single
-    # (non-sweep) pipeline has exactly one CV variant — `variant:base`, which is also the winner — so the
-    # loop runs once and reproduces the pre-#55 winner-only shape. The winner's avg key is the `None`
-    # variant_id; each loser's avg key is its own variant_id.
+    # avg is normally the native `None`-tagged row), then the losers in the order dag-ml emitted them. A
+    # single (non-sweep) pipeline has exactly one CV variant — `variant:base`, which is also the winner —
+    # so the loop runs once and reproduces the pre-#55 winner-only shape. The generic DAG-ML route tags
+    # the winner's avg with `None`; the portable Methods controller keeps the sole concrete
+    # `variant:base` identity instead. Both are the same single-producer OOF evidence, so the lookup
+    # below accepts the latter only when the former is absent.
     cv_variant_ids = list(dict.fromkeys(variant_id for (variant_id, partition, fold_id) in by_key if partition == "validation" and fold_id != "avg"))
     if final_variant_id is not _MISSING and final_variant_id in cv_variant_ids:
         cv_variant_ids = [final_variant_id] + [variant_id for variant_id in cv_variant_ids if variant_id != final_variant_id]
@@ -520,13 +522,16 @@ def _scores_to_run_result(
         fold_keys = [fold_id for (other_variant_id, partition, fold_id) in by_key if other_variant_id == variant_id and partition == "validation" and fold_id != "avg"]
         # The cross-fold OOF average for THIS variant. dag-ml emits the avg with `variant_id = None` for
         # the SOLE producer (a single concrete pipeline or a merge node) and for the SWEEP WINNER; a sweep
-        # LOSER's avg carries its own variant_id. So the `None`-tagged avg belongs to the winner, or to the
-        # lone variant when there is only one. A single-fold splitter (KennardStone/SPXY, n_splits=1) emits
-        # NO "avg" — just the one validation fold — so there is no ensemble block (the legacy 5-row
+        # LOSER's avg carries its own variant_id. The portable Methods controller retains `variant:base`
+        # for its sole producer instead of rewriting it to `None`, so we accept that exact fallback only
+        # when there is no `None` row. A single-fold splitter (KennardStone/SPXY, n_splits=1) emits NO
+        # "avg" — just the one validation fold — so there is no ensemble block (the legacy 5-row
         # single-split shape) and the lone fold's OOF is the CV score.
         avg_variant_id = None if (is_winner or len(cv_variant_ids) == 1) else variant_id
-        has_avg = by_key.get((avg_variant_id, "validation", "avg")) is not None
         avg = by_key.get((avg_variant_id, "validation", "avg"))
+        if avg is None and avg_variant_id is None:
+            avg = by_key.get((variant_id, "validation", "avg"))
+        has_avg = avg is not None
         if avg is None and len(fold_keys) == 1:
             avg = by_key[(variant_id, "validation", fold_keys[0])]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ native = [
     "dag-ml>=0.3.5",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
+    # ABI 2.2 carries the optimizer symbols required by DAG-ML Methods training.
+    "nirs4all-methods>=1.0.10",
 ]
 
 # Transition-release workspace converter wrapper. The runtime detects legacy

--- a/tests/unit/api/test_native_training.py
+++ b/tests/unit/api/test_native_training.py
@@ -13,6 +13,15 @@ from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
 
 
+@pytest.fixture
+def native_library(tmp_path) -> str:
+    """A path-shaped runtime is sufficient for client-boundary unit tests."""
+
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"native")
+    return str(library)
+
+
 class _TrainingResult:
     outcome = {"native": True}
     outputs = [
@@ -61,7 +70,7 @@ class _Client:
 
 
 def test_fit_native_pipeline_is_a_public_strict_native_composition(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, native_library: str
 ) -> None:
     captured: dict[str, Any] = {}
 
@@ -91,6 +100,7 @@ def test_fit_native_pipeline_is_a_public_strict_native_composition(
         np.asarray([1.0, 2.0]),
         sample_ids=["fit-a", "fit-b"],
         native_client=client,
+        methods_library_path=native_library,
     )
 
     assert isinstance(estimator, DagMLPipelineEstimator)
@@ -127,7 +137,7 @@ def test_fit_native_pipeline_refuses_unportable_inputs_before_training(
 
 
 def test_fit_native_pipeline_surfaces_missing_package_as_native_coverage_error(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, native_library: str
 ) -> None:
     class NoPackage(_TrainingResult):
         def export_portable_predictor_package(self, package_id: str) -> None:
@@ -159,11 +169,12 @@ def test_fit_native_pipeline_surfaces_missing_package_as_native_coverage_error(
             np.asarray([1.0]),
             sample_ids=["fit-a"],
             native_client=NoPackageClient(),
+            methods_library_path=native_library,
         )
 
 
 def test_fit_native_pipeline_refuses_host_sidecar_package_before_returning(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, native_library: str
 ) -> None:
     class HostSidecar(_TrainingResult):
         def export_portable_predictor_package(self, package_id: str) -> dict[str, Any]:
@@ -194,11 +205,12 @@ def test_fit_native_pipeline_refuses_host_sidecar_package_before_returning(
             np.asarray([1.0]),
             sample_ids=["fit-a"],
             native_client=HostSidecarClient(),
+            methods_library_path=native_library,
         )
 
 
 def test_fit_native_pipeline_predicts_only_through_identified_native_replay(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, native_library: str
 ) -> None:
     def compile_fit(self, estimator, X, y, **kwargs):  # noqa: ANN001
         _ = (self, estimator, X, y, kwargs)
@@ -243,6 +255,7 @@ def test_fit_native_pipeline_predicts_only_through_identified_native_replay(
         np.asarray([1.0]),
         sample_ids=["fit-a"],
         native_client=_Client(),
+        methods_library_path=native_library,
     )
 
     prediction = estimator.predict_with_identity(

--- a/tests/unit/pipeline/dagml/test_methods_runtime.py
+++ b/tests/unit/pipeline/dagml/test_methods_runtime.py
@@ -1,0 +1,59 @@
+"""Resolution coverage for the wheel-bundled Methods runtime."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nirs4all.pipeline.dagml.methods_runtime import resolve_methods_library_path
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+
+def test_explicit_methods_runtime_path_must_be_absolute_regular_file(tmp_path) -> None:
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"native")
+
+    assert resolve_methods_library_path(library) == str(library.resolve())
+
+    with pytest.raises(ValueError, match="absolute libn4m file"):
+        resolve_methods_library_path("libn4m.so")
+
+
+def test_bundled_methods_runtime_is_resolved_from_official_python_package(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"native")
+    module = SimpleNamespace(library_path=lambda: str(library), abi_version=lambda: (2, 2, 0))
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.methods_runtime.importlib.import_module",
+        lambda name: module if name == "n4m" else None,
+    )
+
+    assert resolve_methods_library_path() == str(library.resolve())
+
+
+def test_bundled_methods_runtime_refuses_the_pre_optimizer_abi(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"native")
+    module = SimpleNamespace(library_path=lambda: str(library), abi_version=lambda: (2, 0, 0))
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.methods_runtime.importlib.import_module",
+        lambda name: module if name == "n4m" else None,
+    )
+
+    with pytest.raises(DagMLNativeCoverageError, match="nirs4all-methods>=1.0.10"):
+        resolve_methods_library_path()
+
+
+def test_missing_bundled_methods_runtime_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    def missing(_name: str):
+        raise ModuleNotFoundError("n4m")
+
+    monkeypatch.setattr("nirs4all.pipeline.dagml.methods_runtime.importlib.import_module", missing)
+
+    with pytest.raises(DagMLNativeCoverageError, match=r"install nirs4all\[native\]"):
+        resolve_methods_library_path()

--- a/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
@@ -155,6 +155,10 @@ def test_raw_replay_resolver_refuses_unknown_or_duplicated_ids(
 def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.resolve_methods_library_path",
+        lambda path: str(path),
+    )
     runtime = _install_fake_runtime(monkeypatch)
     package_json = json.dumps(_package())
 
@@ -215,18 +219,56 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
         )
 
 
-def test_raw_archive_predict_refuses_an_implicit_methods_library() -> None:
-    with pytest.raises(NativeArchiveReplayError, match="explicit methods_library_path"):
-        predict_methods_archive_v2_raw(
-            "portable.n4a",
-            np.asarray([[1.0]]),
-            sample_ids=["sample.one"],
-        )
+def test_raw_archive_predict_resolves_the_bundled_methods_library(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runtime = _install_fake_runtime(monkeypatch)
+    package_json = json.dumps(_package())
+
+    class _Package:
+        def __init__(self, raw: str) -> None:
+            self._document = json.loads(raw)
+
+        def to_dict(self) -> dict[str, object]:
+            return self._document
+
+    runtime.PortablePredictorPackage = _Package
+    runtime.replay_loaded_methods_predictor_package = lambda *_args, **_kwargs: {
+        "outputs": [
+            {
+                "predictions": [
+                    {"sample_ids": ["sample.one"], "values": [[1.5]]}
+                ]
+            }
+        ]
+    }
+    monkeypatch.setitem(sys.modules, "dag_ml", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "nirs4all_core",
+        types.SimpleNamespace(
+            read_portable_predictor_package_v2=lambda _path: package_json.encode()
+        ),
+    )
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.resolve_methods_library_path",
+        lambda _path=None: "/wheel/libn4m.so",
+    )
+
+    values = predict_methods_archive_v2_raw(
+        "portable.n4a", np.asarray([[1.0]]), sample_ids=["sample.one"]
+    )
+
+    assert values.tolist() == [[1.5]]
 
 
 def test_raw_archive_predict_projects_exact_native_conformal_intervals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.resolve_methods_library_path",
+        lambda path: str(path),
+    )
     runtime = _install_fake_runtime(monkeypatch)
     package = _package()
     package["conformal_calibration"] = {

--- a/tests/unit/pipeline/dagml/test_result_projection.py
+++ b/tests/unit/pipeline/dagml/test_result_projection.py
@@ -81,3 +81,44 @@ def test_scores_to_run_result_carries_variant_node_results_for_attestation_audit
         *variant_frames["variant:base"],
         *variant_frames["variant:loser"],
     ]
+
+
+def test_scores_to_run_result_preserves_portable_methods_single_variant_oof_average() -> None:
+    """Methods keeps its sole concrete variant id on the terminal avg report."""
+
+    scores = {
+        "reports": [
+            {
+                "partition": "validation",
+                "fold_id": "fold0",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "metrics": {"rmse": 1.0},
+            },
+            {
+                "partition": "validation",
+                "fold_id": "fold1",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "metrics": {"rmse": 3.0},
+            },
+            {
+                "partition": "validation",
+                "fold_id": "avg",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "metrics": {"rmse": 2.0},
+            },
+        ]
+    }
+
+    result = _scores_to_run_result(scores, "dataset:test", "MethodsPLS")
+
+    avg_rows = [
+        row
+        for row in result.filter(load_arrays=False)
+        if row.get("fold_id") in {"avg", "w_avg"} and row.get("partition") == "val"
+    ]
+    assert len(avg_rows) == 2
+    assert {row["val_score"] for row in avg_rows} == {2.0}
+    assert result.cv_best_score == 2.0


### PR DESCRIPTION
## Summary

Makes native DAG-ML training resolve the libn4m bundled in the official `nirs4all-methods` wheel by default.

## Why

Native users must not need a sibling Methods checkout or loader-path configuration. The resolver requires ABI 2.2, which contains the optimizer symbols used by DAG-ML, and fails closed on older wheels.

## Scope

- adds `nirs4all-methods>=1.0.10` to the native extra
- preserves an explicit absolute `methods_library_path` deployment override
- validates sample identity alignment before native work starts
- adds resolver and boundary tests

## Validation

- `pytest tests/unit/pipeline/dagml/test_methods_runtime.py tests/unit/api/test_native_training.py -q`
- `ruff check` on touched modules/tests
- `python -m build --wheel`

Depends on nirs4all-methods#18 / tag `v1.0.10` before a public install can resolve the required ABI.