### PR TITLE
feat(native): expose strict Methods HPO via dag-ml

### DIFF
--- a/nirs4all/api/native_result.py
+++ b/nirs4all/api/native_result.py
@@ -32,10 +32,7 @@ class NativeMethodsRunResult(RunResult):
             raise ValueError("native archive_id must be a non-empty string")
         super().__init__(
             predictions=projected.predictions,
-            per_dataset={
-                dataset_name: {**info, "engine": "native"}
-                for dataset_name, info in projected.per_dataset.items()
-            },
+            per_dataset={dataset_name: {**info, "engine": "native"} for dataset_name, info in projected.per_dataset.items()},
         )
         self._dagml_score_set = projected._dagml_score_set  # noqa: SLF001
         self._dagml_node_results = projected._dagml_node_results  # noqa: SLF001
@@ -82,6 +79,38 @@ class NativeMethodsRunResult(RunResult):
         """The exact Core-issued reference from the last successful export."""
 
         return None if self._native_archive_reference is None else dict(self._native_archive_reference)
+
+    @property
+    def native_methods_hpo_resume_state(self) -> dict[str, Any] | None:
+        """Return the attested native HPO checkpoint/evidence, when present.
+
+        The value is the exact DAG-ML durable state (including the opaque
+        N4MOPT checkpoint and completed terminal trial ledger), copied only at
+        the outer mapping boundary so callers cannot mutate the retained
+        training outcome.  Native public resume is intentionally not exposed
+        yet: accepting an arbitrary checkpoint here would bypass the package
+        binding and provenance validation owned by DAG-ML.
+        """
+
+        outcome = _outcome_document(self._native_estimator)
+        state = outcome.get("methods_hpo_resume_state")
+        if state is None:
+            return None
+        if not isinstance(state, Mapping):
+            raise DagMLNativeCoverageError("native Methods HPO state is not a structured mapping")
+        return dict(state)
+
+    @property
+    def native_selected_variant_id(self) -> str | None:
+        """Return the scheduler-selected native variant identity, if any."""
+
+        outcome = _outcome_document(self._native_estimator)
+        value = outcome.get("selected_variant_id")
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value:
+            raise DagMLNativeCoverageError("native selected variant id is malformed")
+        return value
 
     def export(
         self,

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -42,6 +42,7 @@ def fit_native_pipeline(
     training_losses: tuple[Mapping[str, Any], ...] = (),
     local_implementations: Any = None,
     methods_library_path: str | None = None,
+    methods_hpo_operation: Mapping[str, Any] | None = None,
     seed: int = 12345,
 ) -> DagMLPipelineEstimator:
     """Fit the supported raw-array pipeline entirely through DAG-ML.
@@ -100,6 +101,7 @@ def fit_native_pipeline(
             training_losses=training_losses,
             local_implementations=local_implementations,
             methods_library_path=resolved_methods_library_path,
+            methods_hpo_operation=methods_hpo_operation,
             seed=seed,
         ),
         require_explicit_sample_ids=True,
@@ -110,9 +112,7 @@ def fit_native_pipeline(
     try:
         validate_native_methods_package(estimator.predictor_package_)
     except RawArrayMethodsReplayError as error:
-        raise DagMLNativeCoverageError(
-            "native DAG-ML training did not return a replayable portable Methods Package V2"
-        ) from error
+        raise DagMLNativeCoverageError("native DAG-ML training did not return a replayable portable Methods Package V2") from error
     estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
         estimator.predictor_package_,
         dagml_module=dagml_module,
@@ -138,6 +138,7 @@ def run_native_methods(
     report_naming: str = "nirs",
     results_path: Any = None,
     runner_kwargs: Mapping[str, Any] | None = None,
+    tuning: Any = None,
 ) -> NativeMethodsRunResult:
     """Run the verified public Methods training subset without a legacy runner.
 
@@ -145,6 +146,12 @@ def run_native_methods(
     ``groups`` and ``metadata``.  Charts, workspaces, sessions, cache, tuning,
     and non-native refit policies remain explicit capability refusals rather
     than becoming ignored legacy arguments.
+
+    ``tuning`` is deliberately a separate, strict native operation rather
+    than the older Python objective adapter.  Its only accepted V1 shape is
+    ``{"engine": "methods-hpo", "trials": N}`` with the fixed V1
+    random/no-pruner policy.  DAG-ML owns all trial execution, SELECT, native
+    incumbent attestation, and the single selected rerun/refit.
     """
 
     if not isinstance(dataset, Mapping):
@@ -173,21 +180,93 @@ def run_native_methods(
         raise NotImplementedError(f"engine='native' does not accept legacy runner kwargs: {sorted(runner_kwargs)}")
     if random_state is not None and (isinstance(random_state, bool) or not isinstance(random_state, int)):
         raise TypeError("engine='native' random_state must be an integer or None")
-
-    estimator = fit_native_pipeline(
-        pipeline,
-        dataset["X"],
-        dataset["y"],
-        sample_ids=dataset["sample_ids"],
-        groups=dataset.get("groups"),
-        metadata=dataset.get("metadata"),
+    methods_hpo_operation = _native_methods_hpo_operation(
+        tuning,
         seed=12345 if random_state is None else random_state,
     )
+
+    fit_kwargs: dict[str, Any] = {
+        "sample_ids": dataset["sample_ids"],
+        "groups": dataset.get("groups"),
+        "metadata": dataset.get("metadata"),
+        "seed": 12345 if random_state is None else random_state,
+    }
+    if methods_hpo_operation is not None:
+        fit_kwargs["methods_hpo_operation"] = methods_hpo_operation
+    estimator = fit_native_pipeline(pipeline, dataset["X"], dataset["y"], **fit_kwargs)
     return NativeMethodsRunResult.from_estimator(
         estimator,
         dataset_name=name or "native",
         model_name=_native_model_name(pipeline),
     )
+
+
+_NATIVE_METHODS_HPO_SAMPLERS = frozenset({"random"})
+_NATIVE_METHODS_HPO_PRUNERS = frozenset({"none"})
+
+
+def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] | None:
+    """Parse the public, deliberately narrow Methods scheduler operation.
+
+    This parser does not accept generic nirs4all tuning settings such as
+    ``space``, ``score_data``, callbacks, or workspace resume fields: those
+    belong to the historical Python objective path.  The V1 native search
+    space is attested by DAG-ML and intentionally fixes PLS ``n_components``
+    to the portable 1..=3 integer domain.
+    """
+
+    if tuning is None:
+        return None
+    if not isinstance(tuning, Mapping):
+        raise TypeError("engine='native' tuning must be a mapping")
+    payload = dict(tuning)
+    allowed = {"engine", "trials", "sampler", "pruner"}
+    unknown = set(payload) - allowed
+    if unknown:
+        raise ValueError(f"engine='native' tuning has unsupported keys: {sorted(unknown)}")
+    if payload.get("engine") != "methods-hpo":
+        raise ValueError("engine='native' tuning requires engine='methods-hpo'")
+    trials = payload.get("trials")
+    if isinstance(trials, bool) or not isinstance(trials, int) or not 1 <= trials <= 64:
+        raise ValueError("engine='native' Methods HPO trials must be an integer in 1..64")
+    sampler = payload.get("sampler", "random")
+    pruner = payload.get("pruner", "none")
+    if sampler not in _NATIVE_METHODS_HPO_SAMPLERS:
+        raise ValueError(f"engine='native' Methods HPO sampler is unsupported: {sampler!r}")
+    if pruner not in _NATIVE_METHODS_HPO_PRUNERS:
+        raise ValueError(f"engine='native' Methods HPO pruner is unsupported: {pruner!r}")
+    return {
+        "operation_id": "hpo:methods",
+        "study": {
+            "controller_id": "controller:methods.hpo",
+            "study_id": "study:nirs4all.native.pls",
+            "methods_abi": "n4m-abi-2.2",
+            "search_space": {
+                "parameters": [
+                    {
+                        "kind": "int",
+                        "name": "n_components",
+                        "low": 1,
+                        "high": 3,
+                        "step": 1,
+                        "log": False,
+                    }
+                ]
+            },
+            "optimizer": {
+                "sampler": sampler,
+                "pruner": pruner,
+                "direction": "minimize",
+                "metric": "rmse",
+                "seed": seed,
+                "n_startup_trials": 0,
+                "max_resource": 0,
+                "reduction_factor": 0,
+            },
+        },
+        "trials": trials,
+        "parameter_paths": {"n_components": "n_components"},
+    }
 
 
 def _native_model_name(pipeline: list[Any]) -> str:

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -103,26 +103,16 @@ def _resolve_dual_tolerances() -> dict[str, dict[str, Any]]:
             and band["enforced_at"].endswith(enforcement_suffix)
         ]
         if len(matches) != 1:
-            raise DualRunUnsupported(
-                f"engine='dual' could not resolve one default cross_impl_pipeline/{metric_class} tolerance from the compatibility ledger"
-            )
+            raise DualRunUnsupported(f"engine='dual' could not resolve one default cross_impl_pipeline/{metric_class} tolerance from the compatibility ledger")
         band = matches[0]
         abs_tol = band.get("abs_tol")
         rel_tol = band.get("rel_tol")
-        if (
-            not isinstance(band.get("band_id"), str)
-            or type(abs_tol) not in (int, float)
-            or type(rel_tol) not in (int, float)
-        ):
-            raise DualRunUnsupported(
-                f"engine='dual' found an invalid cross_impl_pipeline/{metric_class} tolerance in the compatibility ledger"
-            )
+        if not isinstance(band.get("band_id"), str) or type(abs_tol) not in (int, float) or type(rel_tol) not in (int, float):
+            raise DualRunUnsupported(f"engine='dual' found an invalid cross_impl_pipeline/{metric_class} tolerance in the compatibility ledger")
         absolute = cast(int | float, abs_tol)
         relative = cast(int | float, rel_tol)
         if absolute < 0 or relative < 0:
-            raise DualRunUnsupported(
-                f"engine='dual' found an invalid cross_impl_pipeline/{metric_class} tolerance in the compatibility ledger"
-            )
+            raise DualRunUnsupported(f"engine='dual' found an invalid cross_impl_pipeline/{metric_class} tolerance in the compatibility ledger")
         resolved[metric_class] = {
             "band_id": band["band_id"],
             "numeric_path": band["numeric_path"],
@@ -201,13 +191,9 @@ def _dual_semantic_observation(
     if not splits or not y_pred_by_sample:
         raise DualRunUnsupported(f"engine='dual' {leg} leg did not expose concrete OOF predictions and validation splits")
     if expected_folds is not None and len(splits) != expected_folds:
-        raise DualRunUnsupported(
-            f"engine='dual' {leg} leg exposed {len(splits)} validation splits, expected {expected_folds} from the declared KFold"
-        )
+        raise DualRunUnsupported(f"engine='dual' {leg} leg exposed {len(splits)} validation splits, expected {expected_folds} from the declared KFold")
     if expected_sample_count is not None and set(y_pred_by_sample) != set(range(expected_sample_count)):
-        raise DualRunUnsupported(
-            f"engine='dual' {leg} leg OOF sample IDs do not exactly cover 0..{expected_sample_count - 1}"
-        )
+        raise DualRunUnsupported(f"engine='dual' {leg} leg OOF sample IDs do not exactly cover 0..{expected_sample_count - 1}")
     return {
         "winner": best["config_name"],
         "splits": splits,
@@ -254,12 +240,7 @@ def _require_dual_supported_request(
     X, y = dataset
     if X.ndim != 2 or y.ndim != 1 or X.shape[0] != y.shape[0] or X.shape[0] == 0 or X.shape[1] == 0:
         raise DualRunUnsupported("engine='dual' requires a non-empty X.shape == (n_samples, n_features) and y.shape == (n_samples,)")
-    if (
-        not np.issubdtype(X.dtype, np.floating)
-        or not np.issubdtype(y.dtype, np.floating)
-        or not np.all(np.isfinite(X))
-        or not np.all(np.isfinite(y))
-    ):
+    if not np.issubdtype(X.dtype, np.floating) or not np.issubdtype(y.dtype, np.floating) or not np.all(np.isfinite(X)) or not np.all(np.isfinite(y)):
         raise DualRunUnsupported("engine='dual' requires finite floating-point X and y for its regression-only oracle")
     if type_of_target(y) != "continuous":
         raise DualRunUnsupported("engine='dual' requires a continuous regression target, not classification labels")
@@ -299,11 +280,7 @@ def _dual_comparison_report(
     prediction_tolerance = resolved_tolerances.get("prediction")
     if not isinstance(score_tolerance, Mapping) or not isinstance(prediction_tolerance, Mapping):
         raise DualRunUnsupported("engine='dual' has no resolved score and prediction tolerances")
-    if any(
-        type(tolerance.get(key)) not in (int, float)
-        for tolerance in (score_tolerance, prediction_tolerance)
-        for key in ("absolute", "relative")
-    ):
+    if any(type(tolerance.get(key)) not in (int, float) for tolerance in (score_tolerance, prediction_tolerance) for key in ("absolute", "relative")):
         raise DualRunUnsupported("engine='dual' has invalid resolved numeric tolerances")
 
     legacy_observation = _dual_semantic_observation(
@@ -725,7 +702,12 @@ def run(
             KFold/PLS pipeline, ``refit=True``, ``save_artifacts=True`` and
             ``save_charts=False``. Unsupported workflow features are refused
             before execution; this path never falls through to the legacy
-            orchestrator.
+            orchestrator.  Its optional strict HPO V1 operation is
+            ``tuning={'engine': 'methods-hpo', 'trials': N}``; it is executed
+            by DAG-ML's native Methods scheduler, not by the older Python
+            objective adapter.  The V1 search space is the attested integer
+            PLS ``n_components`` domain 1..3, and its checkpoint/evidence is
+            available on ``NativeMethodsRunResult`` after a successful run.
             The dual subset requires exact built-in ``list``/``dict`` and exact NumPy arrays,
             ``KFold(shuffle=False)``, ``PLSRegression``, finite floating-point ``X`` and continuous
             regression ``y``,
@@ -748,7 +730,10 @@ def run(
             dataset loaders, arbitrary structural model selection and legacy
             execution remain fail-closed. Deterministic model-local
             ``finetune_params`` grids are still the native path for the older
-            graph-generation subset.
+            graph-generation subset. With ``engine='native'``, only the
+            separate strict ``methods-hpo`` shape documented above is
+            accepted; generic ``space``, ``score_data``, callbacks and
+            workspace-resume fields are refused before execution.
 
         calibration: Optional top-level conformal calibration payload for the
             currently supported native tuning subset. This is equivalent to
@@ -886,8 +871,8 @@ def run(
     if custom_training_loss_requested and selected_engine != "dag-ml":
         raise ValueError("training_losses/local_implementations require engine='dag-ml'")
     if selected_engine == "native":
-        if tuning is not None or calibration is not None:
-            raise NotImplementedError("engine='native' tuning and calibration are not available through run() yet")
+        if calibration is not None:
+            raise NotImplementedError("engine='native' conformal calibration is not available through run() yet")
         if not isinstance(pipeline, list):
             raise TypeError("engine='native' requires a list pipeline")
         if not isinstance(dataset, Mapping):
@@ -897,6 +882,8 @@ def run(
         from .native_training import run_native_methods
 
         if session is not None:
+            if tuning is not None:
+                raise NotImplementedError("engine='native' Methods HPO is stateless; do not combine tuning with a NativeMethodsSession")
             if not isinstance(session, NativeMethodsSession):
                 raise TypeError("engine='native' requires a NativeMethodsSession, not a legacy Session")
             if pipeline is not session.pipeline:
@@ -932,6 +919,7 @@ def run(
             report_naming=report_naming,
             results_path=results_path,
             runner_kwargs=runner_kwargs,
+            tuning=tuning,
         )
     if isinstance(session, NativeMethodsSession):
         raise ValueError("NativeMethodsSession requires engine='native'; it never falls back to another engine")
@@ -952,9 +940,7 @@ def run(
     if tuning is not None:
         if custom_training_loss_requested:
             raise NotImplementedError(
-                "run(tuning=...) does not yet thread DAG-ML process-local training losses; "
-                "use a concrete engine='dag-ml' pipeline until the native tuning adapter binds "
-                "training_losses and local_implementations."
+                "run(tuning=...) does not yet thread DAG-ML process-local training losses; use a concrete engine='dag-ml' pipeline until the native tuning adapter binds training_losses and local_implementations."
             )
         tuning = _coerce_public_tuning_payload(tuning)
         if selected_engine == "dag-ml":

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -56,6 +56,7 @@ class RawArrayDagMLTrainingCompiler:
     training_losses: tuple[Mapping[str, Any], ...] = ()
     local_implementations: Any = None
     methods_library_path: str | None = None
+    methods_hpo_operation: Mapping[str, Any] | None = None
 
     def compile_fit(
         self,
@@ -88,6 +89,7 @@ class RawArrayDagMLTrainingCompiler:
             training_losses=self.training_losses,
             local_implementations=self.local_implementations,
             methods_library_path=self.methods_library_path,
+            methods_hpo_operation=self.methods_hpo_operation,
         )
         compiler = DagMLTrainingRequestCompiler(
             contracts,
@@ -123,6 +125,7 @@ def lower_raw_array_training_contracts(
     training_losses: tuple[Mapping[str, Any], ...] = (),
     local_implementations: Any = None,
     methods_library_path: str | None = None,
+    methods_hpo_operation: Mapping[str, Any] | None = None,
 ) -> DagMLTrainingRequestContracts:
     """Lower a linear raw-array pipeline into executable DAG-ML contracts."""
 
@@ -154,11 +157,20 @@ def lower_raw_array_training_contracts(
         manifests = [_portable_methods_pls_manifest()]
     artifact = dag_ml.compile_pipeline_dsl_artifact_with_controllers(dsl, manifests)
     graph = artifact.graph.to_dict()
+    if portable_methods:
+        _mark_portable_methods_pls_graph(graph)
     campaign = artifact.campaign_template.to_dict()
+    output_requests = [_default_output_request(graph)]
+    if methods_hpo_operation is not None:
+        if not portable_methods:
+            raise ValueError("Methods HPO requires the portable Methods execution lane")
+        campaign.setdefault("metadata", {})["methods_hpo_operation"] = _bind_methods_hpo_target(
+            methods_hpo_operation,
+            output_requests[0]["node_id"],
+        )
     if campaign.get("root_seed") is None:
         campaign["root_seed"] = seed
     data_envelopes, data_identities = _data_contracts_from_campaign(campaign, envelope)
-    output_requests = [_default_output_request(graph)]
     request_spec = DagMLTrainingRequestSpec(
         request_id=request_id,
         plan_id=plan_id,
@@ -196,11 +208,7 @@ def lower_raw_array_training_contracts(
         run_id=run_id,
         bundle_id=bundle_id,
         diagnostics={"nirs4all_raw_array_samples": identity_frame.n_samples},
-        methods_inputs=(
-            _methods_inputs_from_arrays(X, y, identity_frame, next(iter(data_envelopes)))
-            if portable_methods
-            else None
-        ),
+        methods_inputs=(_methods_inputs_from_arrays(X, y, identity_frame, next(iter(data_envelopes))) if portable_methods else None),
         methods_library_path=methods_library_path,
     )
 
@@ -257,11 +265,7 @@ def _supported_linear_steps(pipeline: Any) -> tuple[list[Any], Any, dict[str, st
         context="native raw-array",
     )
     model_steps = [step for step in steps if isinstance(step, dict) and "model" in step]
-    allowed_keys = (
-        frozenset({"train_params"})
-        if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None
-        else frozenset()
-    )
+    allowed_keys = frozenset({"train_params"}) if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None else frozenset()
     reject_native_training_param_overrides(
         steps,
         context="native raw-array",
@@ -278,18 +282,11 @@ def _validate_portable_methods_pipeline(steps: list[Any]) -> None:
     """Refuse every raw fit shape the Methods PLS lane cannot represent exactly."""
 
     if len(steps) != 1 or not isinstance(steps[0], Mapping) or set(steps[0]) - {"model"}:
-        raise ValueError(
-            "portable Methods training currently supports exactly one PLSRegression model step after the splitter"
-        )
+        raise ValueError("portable Methods training currently supports exactly one PLSRegression model step after the splitter")
     model = steps[0].get("model")
     cls = model if isinstance(model, type) else type(model)
-    if (
-        getattr(cls, "__name__", None) != "PLSRegression"
-        or not str(getattr(cls, "__module__", "")).startswith("sklearn.cross_decomposition")
-    ):
-        raise ValueError(
-            "portable Methods training currently supports sklearn.cross_decomposition.PLSRegression only"
-        )
+    if getattr(cls, "__name__", None) != "PLSRegression" or not str(getattr(cls, "__module__", "")).startswith("sklearn.cross_decomposition"):
+        raise ValueError("portable Methods training currently supports sklearn.cross_decomposition.PLSRegression only")
     components = getattr(model, "n_components", None)
     if not isinstance(components, int) or isinstance(components, bool) or components < 1:
         raise ValueError("portable Methods PLS requires a positive integer n_components")
@@ -320,9 +317,7 @@ def _portable_methods_pls_manifest() -> dict[str, Any]:
         "operator_kind": "model",
         "priority": 100,
         "supported_phases": ["FIT_CV", "REFIT", "PREDICT"],
-        "input_ports": [
-            {"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}
-        ],
+        "input_ports": [{"name": "x", "kind": "data", "representation": "tabular_numeric", "cardinality": "one"}],
         "output_ports": [
             {"name": "oof", "kind": "prediction", "representation": None, "cardinality": "one"},
             {"name": "model", "kind": "artifact", "representation": None, "cardinality": "one"},
@@ -341,6 +336,42 @@ def _portable_methods_pls_manifest() -> dict[str, Any]:
         "rng_policy": "uses_core_seed",
         "artifact_policy": "serializable",
     }
+
+
+def _mark_portable_methods_pls_graph(graph: Mapping[str, Any]) -> None:
+    """Make the model's executable operator the native portable ``pls`` one.
+
+    Controller metadata alone is insufficient for Methods HPO: its scheduler
+    validates both the controller and the target's transparent operator
+    declaration.  This edit happens before request signing, so it remains
+    attested provenance rather than a post-selection execution rewrite.
+    """
+
+    nodes = graph.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError("portable Methods graph must contain a node list")
+    models = [node for node in nodes if isinstance(node, dict) and node.get("kind") == "model"]
+    if len(models) != 1:
+        raise ValueError("portable Methods graph must contain exactly one model node")
+    models[0]["operator"] = "pls"
+
+
+def _bind_methods_hpo_target(operation: Mapping[str, Any], target_node_id: str) -> dict[str, Any]:
+    """Attach the only graph-derived field of a native Methods HPO operation.
+
+    The tuner is a scheduler operation, not a graph node.  Keeping the target
+    binding here means the public native API never asks callers to guess an
+    internal node identifier, while DAG-ML still signs and validates the full
+    descriptor before it creates a native optimizer session.
+    """
+
+    if not isinstance(operation, Mapping):
+        raise TypeError("methods_hpo_operation must be a mapping")
+    bound = copy.deepcopy(dict(operation))
+    if "target_node_id" in bound:
+        raise ValueError("methods_hpo_operation must not supply target_node_id")
+    bound["target_node_id"] = target_node_id
+    return bound
 
 
 def _methods_inputs_from_arrays(

--- a/nirs4all/pipeline/dagml/result.py
+++ b/nirs4all/pipeline/dagml/result.py
@@ -191,7 +191,7 @@ def _legacy_fold_id(native_fold_id: str) -> str:
     webapp / ``PredictionAggregator`` that key on it) uses the bare zero-based index ``"0"`` / ``"1"`` /
     …. Any non-``foldN`` id (defensive) is returned unchanged.
     """
-    return native_fold_id[len("fold"):] if native_fold_id.startswith("fold") and native_fold_id[len("fold"):].isdigit() else native_fold_id
+    return native_fold_id[len("fold") :] if native_fold_id.startswith("fold") and native_fold_id[len("fold") :].isdigit() else native_fold_id
 
 
 def _native_variant_config_map(scores: dict[str, Any] | None, ordered_config_names: list[str], winner_config_name: str | None = None) -> dict[Any, str]:
@@ -215,13 +215,7 @@ def _native_variant_config_map(scores: dict[str, Any] | None, ordered_config_nam
     Returns ``{fold_variant_id: config_name}`` keyed by the variant's own (non-``None``) fold-level id —
     the avg's native ``None`` tag is not a key.
     """
-    cv_variant_ids = list(
-        dict.fromkeys(
-            report.get("variant_id")
-            for report in (scores or {}).get("reports", [])
-            if report["partition"] == "validation" and report.get("fold_id") != "avg"
-        )
-    )
+    cv_variant_ids = list(dict.fromkeys(report.get("variant_id") for report in (scores or {}).get("reports", []) if report["partition"] == "validation" and report.get("fold_id") != "avg"))
     if winner_config_name is not None and cv_variant_ids and winner_config_name in ordered_config_names:
         # Winner-first: pair cv_variant_ids[0] (the SELECTED variant, whose reports lead) with the
         # content-recovered winner name; the losers take the remaining names in expand order (winner removed
@@ -505,6 +499,13 @@ def _scores_to_run_result(
     # `variant:base` identity instead. Both are the same single-producer OOF evidence, so the lookup
     # below accepts the latter only when the former is absent.
     cv_variant_ids = list(dict.fromkeys(variant_id for (variant_id, partition, fold_id) in by_key if partition == "validation" and fold_id != "avg"))
+    # Scheduler-owned Methods HPO deliberately persists only one terminal
+    # sample-level OOF-average report per candidate.  It does not invent
+    # fold-grain reports merely for the legacy compatibility table.  Preserve
+    # that exact evidence by projecting its average-only candidates directly;
+    # the normal fold path above remains authoritative whenever it exists.
+    if not cv_variant_ids:
+        cv_variant_ids = list(dict.fromkeys(variant_id for (variant_id, partition, fold_id) in by_key if partition == "validation" and fold_id == "avg" and variant_id is not None))
     if final_variant_id is not _MISSING and final_variant_id in cv_variant_ids:
         cv_variant_ids = [final_variant_id] + [variant_id for variant_id in cv_variant_ids if variant_id != final_variant_id]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.5",
+    "dag-ml>=0.3.6",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.5",
+    "dag-ml>=0.3.6",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
     # ABI 2.2 carries the optimizer symbols required by DAG-ML Methods training.

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -108,6 +108,118 @@ def test_run_native_environment_selection_is_also_fail_closed_for_unsupported_re
         run([], {})
 
 
+def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public HPO lane is scheduler metadata, never a Python objective."""
+
+    class Estimator:
+        training_outcome_ = {
+            "outcome_fingerprint": "b" * 64,
+            "selected_variant_id": "hpo:trial:0",
+            "methods_hpo_resume_state": {"schema_version": 1, "checkpoint": {"format": "N4MOPT"}},
+            "score_set": {
+                "schema_version": 2,
+                "selection_metric": "rmse",
+                "reports": [
+                    {
+                        "producer_node": "model:methods",
+                        "producer_port": "oof",
+                        "partition": "validation",
+                        "fold_id": "avg",
+                        "level": "sample",
+                        "metrics": {"rmse": 0.25},
+                        "row_count": 2,
+                        "target_names": ["y"],
+                        "target_width": 1,
+                        "variant_id": "hpo:trial:0",
+                    }
+                ],
+            },
+        }
+
+    observed: dict[str, object] = {}
+
+    def native_fit(*_args, **kwargs):  # noqa: ANN002, ANN003
+        observed.update(kwargs)
+        return Estimator()
+
+    monkeypatch.setattr("nirs4all.api.native_training.fit_native_pipeline", native_fit)
+    result = run(
+        [{"split": "stub"}, {"model": "stub"}],
+        {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["s1", "s2"]},
+        engine="native",
+        save_charts=False,
+        random_state=17,
+        tuning={"engine": "methods-hpo", "trials": 3},
+    )
+
+    assert isinstance(result, NativeMethodsRunResult)
+    assert result.native_selected_variant_id == "hpo:trial:0"
+    assert result.native_methods_hpo_resume_state == {"schema_version": 1, "checkpoint": {"format": "N4MOPT"}}
+    operation = observed["methods_hpo_operation"]
+    assert operation == {
+        "operation_id": "hpo:methods",
+        "study": {
+            "controller_id": "controller:methods.hpo",
+            "study_id": "study:nirs4all.native.pls",
+            "methods_abi": "n4m-abi-2.2",
+            "search_space": {
+                "parameters": [
+                    {
+                        "kind": "int",
+                        "name": "n_components",
+                        "low": 1,
+                        "high": 3,
+                        "step": 1,
+                        "log": False,
+                    }
+                ]
+            },
+            "optimizer": {
+                "sampler": "random",
+                "pruner": "none",
+                "direction": "minimize",
+                "metric": "rmse",
+                "seed": 17,
+                "n_startup_trials": 0,
+                "max_resource": 0,
+                "reduction_factor": 0,
+            },
+        },
+        "trials": 3,
+        "parameter_paths": {"n_components": "n_components"},
+    }
+
+
+@pytest.mark.parametrize(
+    "tuning, message",
+    [
+        ({"trials": 2}, "requires engine='methods-hpo'"),
+        ({"engine": "methods-hpo", "trials": 0}, "integer in 1..64"),
+        ({"engine": "methods-hpo", "trials": 2, "score_data": {}}, "unsupported keys"),
+        ({"engine": "methods-hpo", "trials": 2, "sampler": "tpe"}, "sampler is unsupported"),
+    ],
+)
+def test_run_native_refuses_generic_or_partial_tuning_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    tuning: dict[str, object],
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.fit_native_pipeline",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("native execution was reached")),
+    )
+    with pytest.raises(ValueError, match=message):
+        run(
+            [{"split": "stub"}, {"model": "stub"}],
+            {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["s1", "s2"]},
+            engine="native",
+            save_charts=False,
+            tuning=tuning,
+        )
+
+
 @pytest.mark.parametrize(
     ("pipeline", "dataset", "kwargs", "message"),
     [
@@ -164,9 +276,7 @@ def test_predict_native_archive_is_explicit_and_never_constructs_a_legacy_runner
     observed: dict[str, object] = {}
 
     def native_predict(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
-        observed.update(
-            path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), methods_library_path=methods_library_path, groups=groups, metadata=metadata
-        )
+        observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), methods_library_path=methods_library_path, groups=groups, metadata=metadata)
         return NativeArchivePrediction(
             values=np.asarray([[2.0], [3.0]]),
             sample_ids=("p1", "p2"),
@@ -241,9 +351,7 @@ def test_predict_native_archive_selects_dagml_materialized_conformal_intervals(
         ("portable.n4a", {"X": [[1.0]], "sample_ids": ["p1"]}, {"coverage": 0.9}, "not materialized"),
     ],
 )
-def test_predict_native_archive_fails_closed_before_execution(
-    monkeypatch: pytest.MonkeyPatch, model, data, kwargs, message
-) -> None:
+def test_predict_native_archive_fails_closed_before_execution(monkeypatch: pytest.MonkeyPatch, model, data, kwargs, message) -> None:
     if kwargs.get("coverage") is not None:
         monkeypatch.setattr(
             "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",

--- a/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_training_lowerer.py
@@ -153,9 +153,7 @@ def test_portable_methods_lowering_uses_only_the_native_controller_and_identity_
         "prediction_caches": "retain",
         "fitted_artifacts": "portable_required",
     }
-    assert [manifest["controller_id"] for manifest in prepared.request["controller_manifests"]] == [
-        "controller:methods.pls"
-    ]
+    assert [manifest["controller_id"] for manifest in prepared.request["controller_manifests"]] == ["controller:methods.pls"]
     node = prepared.request["graph"]["nodes"][0]
     assert node["metadata"]["controller_id"] == "controller:methods.pls"
     assert prepared.methods_inputs == {
@@ -168,6 +166,49 @@ def test_portable_methods_lowering_uses_only_the_native_controller_and_identity_
     }
 
 
+def test_portable_methods_hpo_is_bound_as_campaign_metadata_not_a_graph_tuner() -> None:
+    _require_recent_dag_ml()
+    X = np.arange(12, dtype=float).reshape(6, 2)
+    y = np.arange(6, dtype=float)
+    frame = normalize_fit_identity(X, y, sample_ids=[f"s{index}" for index in range(6)])
+    operation = {
+        "operation_id": "hpo:methods",
+        "study": {
+            "controller_id": "controller:methods.hpo",
+            "study_id": "study:nirs4all.native.pls",
+            "methods_abi": "n4m-abi-2.2",
+            "search_space": {"parameters": [{"kind": "int", "name": "n_components", "low": 1, "high": 3, "step": 1, "log": False}]},
+            "optimizer": {
+                "sampler": "random",
+                "pruner": "none",
+                "direction": "minimize",
+                "metric": "rmse",
+                "seed": 7,
+                "n_startup_trials": 0,
+                "max_resource": 0,
+                "reduction_factor": 0,
+            },
+        },
+        "trials": 2,
+        "parameter_paths": {"n_components": "n_components"},
+    }
+
+    contracts = lower_raw_array_training_contracts(
+        [KFold(n_splits=2), {"model": PLSRegression(n_components=1)}],
+        X,
+        y,
+        identity_frame=frame,
+        methods_library_path="/absolute/libn4m.so",
+        methods_hpo_operation=operation,
+    )
+    prepared = contracts.to_prepared()
+    descriptor = prepared.request["campaign"]["metadata"]["methods_hpo_operation"]
+
+    assert descriptor["target_node_id"] == "model:compat.0"
+    assert "target_node_id" not in operation
+    assert all(node["kind"] != "tuner" for node in prepared.request["graph"]["nodes"])
+
+
 def test_portable_methods_lowering_refuses_non_pls_or_transform_pipelines() -> None:
     _require_recent_dag_ml()
     X = np.arange(12, dtype=float).reshape(6, 2)
@@ -175,9 +216,7 @@ def test_portable_methods_lowering_refuses_non_pls_or_transform_pipelines() -> N
     frame = normalize_fit_identity(X, y, sample_ids=[f"s{index}" for index in range(6)])
 
     with pytest.raises(ValueError, match="PLSRegression only"):
-        lower_raw_array_training_contracts(
-            _pipeline(), X, y, identity_frame=frame, methods_library_path="/absolute/libn4m.so"
-        )
+        lower_raw_array_training_contracts(_pipeline(), X, y, identity_frame=frame, methods_library_path="/absolute/libn4m.so")
 
 
 def test_lower_raw_array_training_contracts_maps_deterministic_finetune_grid() -> None:
@@ -274,10 +313,7 @@ def test_model_controller_routing_accepts_tensorflow_mro() -> None:
     )
 
     pytest.importorskip("tensorflow")
-    assert (
-        _model_controller_id(_tiny_tensorflow_regressor())
-        == _TENSORFLOW_MODEL_CONTROLLER_ID
-    )
+    assert _model_controller_id(_tiny_tensorflow_regressor()) == _TENSORFLOW_MODEL_CONTROLLER_ID
 
 
 @pytest.mark.torch
@@ -309,9 +345,7 @@ def test_tensorflow_seed_maps_wide_core_seed_deterministically() -> None:
     _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
     first_tensorflow = tf.random.uniform((3,))
     _seed_differentiable_backend(_TENSORFLOW_MODEL_CONTROLLER_ID, seed)
-    np.testing.assert_array_equal(
-        first_tensorflow.numpy(), tf.random.uniform((3,)).numpy()
-    )
+    np.testing.assert_array_equal(first_tensorflow.numpy(), tf.random.uniform((3,)).numpy())
 
 
 def test_node_runner_rejects_missing_registry_and_multiple_loss_requirements() -> None:
@@ -327,9 +361,7 @@ def test_node_runner_rejects_missing_registry_and_multiple_loss_requirements() -
     with pytest.raises(RuntimeError, match="process-local loss registry"):
         _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, None)
 
-    task["required_loss_attestations"].append(
-        {"phase": "FIT_CV", "loss_id": "other-loss@1"}
-    )
+    task["required_loss_attestations"].append({"phase": "FIT_CV", "loss_id": "other-loss@1"})
     with pytest.raises(NotImplementedError, match="one training loss per task"):
         _bind_training_loss(task, _PYTORCH_MODEL_CONTROLLER_ID, object())
 
@@ -484,21 +516,10 @@ def test_raw_array_training_executes_local_torch_loss_and_attests_each_phase() -
     assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
     assert all(role_index == 0 for _, _, _, role_index in bind_calls)
     outcome = estimator.training_outcome_.to_dict()
-    model_lineage = [
-        record
-        for record in outcome["lineage"]
-        if record["node_id"] == "model:compat.0"
-        and record["phase"] in {"FIT_CV", "REFIT"}
-    ]
+    model_lineage = [record for record in outcome["lineage"] if record["node_id"] == "model:compat.0" and record["phase"] in {"FIT_CV", "REFIT"}]
     assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
-    assert all(
-        [attestation["loss_id"] for attestation in record["loss_attestations"]]
-        == ["example.loss.nirs4all-torch-squared@1"]
-        for record in model_lineage
-    )
-    assert outcome["execution_bundle"]["refit_artifacts"][0][
-        "training_loss_fingerprint"
-    ]
+    assert all([attestation["loss_id"] for attestation in record["loss_attestations"]] == ["example.loss.nirs4all-torch-squared@1"] for record in model_lineage)
+    assert outcome["execution_bundle"]["refit_artifacts"][0]["training_loss_fingerprint"]
 
 
 @pytest.mark.tensorflow
@@ -595,18 +616,9 @@ def test_raw_array_training_executes_local_tensorflow_loss_and_detaches_refit_ar
     assert {phase for phase, _, _, _ in bind_calls} == {"FIT_CV", "REFIT"}
     assert all(role_index == 0 for _, _, _, role_index in bind_calls)
     outcome = estimator.training_outcome_.to_dict()
-    model_lineage = [
-        record
-        for record in outcome["lineage"]
-        if record["node_id"] == "model:compat.0"
-        and record["phase"] in {"FIT_CV", "REFIT"}
-    ]
+    model_lineage = [record for record in outcome["lineage"] if record["node_id"] == "model:compat.0" and record["phase"] in {"FIT_CV", "REFIT"}]
     assert {record["phase"] for record in model_lineage} == {"FIT_CV", "REFIT"}
-    assert all(
-        [attestation["loss_id"] for attestation in record["loss_attestations"]]
-        == ["example.loss.nirs4all-tensorflow-squared@1"]
-        for record in model_lineage
-    )
+    assert all([attestation["loss_id"] for attestation in record["loss_attestations"]] == ["example.loss.nirs4all-tensorflow-squared@1"] for record in model_lineage)
 
 
 def test_raw_array_training_compiler_executes_native_deterministic_finetune_when_supported() -> None:


### PR DESCRIPTION
## Summary

- routes `run(engine="native", tuning={"engine":"methods-hpo", "trials": N})` through the published DAG-ML 0.3.6 Methods scheduler
- keeps V1 deliberately strict: PLS `n_components` 1..3, random/no-pruner, no legacy score callback, workspace resume, or fallback
- preserves and exposes the attested selected variant and durable N4MOPT resume state
- projects terminal HPO OOF-average evidence without fabricating fold reports

## Verification

- `python3.11 -m pytest tests/unit/api -q` — 482 passed
- raw lowerer/API targeted suite — 43 passed, 6 skipped
- `ruff check` and format check, `git diff --check`
- published `dag-ml==0.3.6` + real `libn4m`: native public HPO (2 trials) selected/refit successfully and retained N4MOPT state

The public V1 surface intentionally refuses adaptive sampler/pruner modes pending a separately qualified policy.