### PR TITLE
feat(native): refit selected Methods variants

### DIFF
--- a/docs/source/user_guide/deployment/retrain_transfer.md
+++ b/docs/source/user_guide/deployment/retrain_transfer.md
@@ -42,6 +42,30 @@ new_result = nirs4all.retrain("model.n4a", new_data, mode="full")
 print(f"Retrained RMSE: {new_result.best_rmse:.4f}")
 ```
 
+### Verified native Methods full retrain
+
+The explicit ``engine="native"`` route has a narrower, portable contract. It
+accepts only an in-memory ``NativeMethodsRunResult`` obtained from native
+Methods training and a raw mapping containing finite ``X``, ``y`` and stable
+``sample_ids``. When its source carries a selected Methods HPO variant, the
+attested ``n_components`` patch is applied to a copied PLS recipe before the
+new full refit:
+
+```python
+retrained = nirs4all.retrain(
+    source=methods_result,
+    data={"X": X_new, "y": y_new, "sample_ids": new_ids},
+    mode="full",
+    engine="native",
+)
+```
+
+This path never creates a ``PipelineRunner`` or uses a Python HPO objective.
+Archive V2 sources, transfer mode, finetuning, replacing the model, legacy
+runner options and retained sessions are refused before native execution. An
+archive-to-retrain recipe is a separate portable contract and is not inferred
+from prediction-only archive metadata.
+
 ### Transfer Mode
 
 Reuse preprocessing artifacts (scalers, SNV, etc.) while training a new model:

--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -15,6 +15,8 @@ Example:
     >>> print(f"New RMSE: {result.best_rmse:.4f}")
 """
 
+import copy
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, TypeAlias
 
@@ -25,25 +27,29 @@ from nirs4all.data.dataset import SpectroDataset
 from nirs4all.pipeline import PipelineRunner
 from nirs4all.pipeline.engine import require_legacy_engine
 
+from .native_result import NativeMethodsRunResult
+from .native_training import run_native_methods
 from .result import RunResult
 from .session import Session
 
 # Type aliases for clarity
 SourceSpec: TypeAlias = (
-    dict[str, Any]               # Prediction dict from previous run
-    | str                          # Path to bundle (.n4a) or config
-    | Path                          # Path to bundle or config
+    NativeMethodsRunResult  # Native in-memory Methods result
+    | dict[str, Any]  # Prediction dict from previous run
+    | str  # Path to bundle (.n4a) or config
+    | Path  # Path to bundle or config
 )
 
 DataSpec: TypeAlias = (
-    str                          # Path to data folder
-    | Path                         # Path to data folder
-    | np.ndarray                   # X array
-    | tuple[np.ndarray, ...]       # (X,) or (X, y)
-    | dict[str, Any]               # Dict with X, y keys
-    | SpectroDataset               # Direct SpectroDataset instance
-    | DatasetConfigs                # Backward compat
+    str  # Path to data folder
+    | Path  # Path to data folder
+    | np.ndarray  # X array
+    | tuple[np.ndarray, ...]  # (X,) or (X, y)
+    | dict[str, Any]  # Dict with X, y keys
+    | SpectroDataset  # Direct SpectroDataset instance
+    | DatasetConfigs  # Backward compat
 )
+
 
 def retrain(
     source: SourceSpec,
@@ -56,7 +62,7 @@ def retrain(
     session: Session | None = None,
     verbose: int = 1,
     save_artifacts: bool = True,
-    **kwargs: Any
+    **kwargs: Any,
 ) -> RunResult:
     """Retrain a pipeline on new data.
 
@@ -72,7 +78,8 @@ def retrain(
         data: New dataset to train on. Can be:
             - Path to data folder: ``"new_data/"``
             - Numpy arrays: ``(X, y)``
-            - Dict: ``{"X": X, "y": y}``
+            - Dict: ``{"X": X, "y": y}``; the native path additionally
+              requires explicit ``sample_ids``.
             - SpectroDataset instance
 
         mode: Retrain mode. Options:
@@ -102,9 +109,11 @@ def retrain(
             - learning_rate: Learning rate for fine-tuning
             - freeze_layers: List of layers to freeze during fine-tuning
             - step_modes: Per-step mode overrides (advanced)
-            - engine: Backend selector for the transition release. Only
-              ``"legacy"`` is supported by this helper until native retraining
-              is implemented.
+            - engine: ``"native"`` enables the strict in-memory Methods full
+              retrain subset. It requires a ``NativeMethodsRunResult`` source,
+              a raw ``{"X", "y", "sample_ids"}`` dataset and preserves the
+              attested selected PLS variant. Archive sources, transfer and
+              finetune remain explicit refusals; all other modes use legacy.
 
     Returns:
         RunResult containing:
@@ -176,6 +185,19 @@ def retrain(
         raise ValueError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
 
     engine = kwargs.pop("engine", None)
+    if engine == "native":
+        return _retrain_native_methods_full(
+            source,
+            data,
+            mode=mode,
+            name=name,
+            new_model=new_model,
+            epochs=epochs,
+            session=session,
+            verbose=verbose,
+            save_artifacts=save_artifacts,
+            extra_kwargs=kwargs,
+        )
     require_legacy_engine("retrain", engine)
 
     # Use session runner if provided, otherwise create new
@@ -186,16 +208,7 @@ def retrain(
     data_arg = str(data) if isinstance(data, Path) else data
 
     # Call the runner's retrain method
-    predictions, per_dataset = runner.retrain(
-        source=source_arg,
-        dataset=data_arg,
-        mode=mode,
-        dataset_name=name,
-        new_model=new_model,
-        epochs=epochs,
-        verbose=verbose,
-        **kwargs
-    )
+    predictions, per_dataset = runner.retrain(source=source_arg, dataset=data_arg, mode=mode, dataset_name=name, new_model=new_model, epochs=epochs, verbose=verbose, **kwargs)
 
     return RunResult(
         predictions=predictions,
@@ -203,3 +216,88 @@ def retrain(
         _runner=runner,
         _owns_runner=session is None,
     )
+
+
+def _retrain_native_methods_full(
+    source: SourceSpec,
+    data: DataSpec,
+    *,
+    mode: str,
+    name: str,
+    new_model: Any | None,
+    epochs: int | None,
+    session: Session | None,
+    verbose: int,
+    save_artifacts: bool,
+    extra_kwargs: Mapping[str, Any],
+) -> NativeMethodsRunResult:
+    """Refit one selected in-memory Methods variant without legacy orchestration.
+
+    This is intentionally the first native retrain capability, not a silent
+    reinterpretation of every historical retrain mode. A durable Archive V2
+    source, transfer learning and finetuning need their own capability and
+    lineage contracts, so they are refused before data reaches the runtime.
+    """
+
+    if mode != "full":
+        raise NotImplementedError("engine='native' retrain currently supports only mode='full'")
+    if not isinstance(source, NativeMethodsRunResult):
+        raise TypeError("engine='native' retrain requires an in-memory NativeMethodsRunResult source")
+    if not isinstance(data, Mapping):
+        raise TypeError("engine='native' retrain requires data={'X', 'y', 'sample_ids'}")
+    if new_model is not None or epochs is not None:
+        raise NotImplementedError("engine='native' full retrain does not accept new_model or epochs")
+    if session is not None:
+        raise NotImplementedError("engine='native' retrain is stateless; do not pass a session")
+    if not save_artifacts:
+        raise ValueError("engine='native' retrain requires save_artifacts=True")
+    if verbose not in (0, 1, 2):
+        raise ValueError("engine='native' retrain verbose must be 0, 1, or 2")
+    if extra_kwargs:
+        raise NotImplementedError(f"engine='native' retrain does not accept legacy kwargs: {sorted(extra_kwargs)}")
+
+    return run_native_methods(
+        _selected_native_methods_pipeline(source),
+        data,
+        name=name,
+        save_charts=False,
+        random_state=None,
+    )
+
+
+def _selected_native_methods_pipeline(source: NativeMethodsRunResult) -> list[Any]:
+    """Clone the source recipe and apply its attested selected PLS patch only."""
+
+    original = getattr(source.native_estimator, "pipeline", None)
+    if not isinstance(original, list):
+        raise ValueError("native retrain source does not retain a portable list pipeline")
+    pipeline = copy.deepcopy(original)
+    models = [step["model"] for step in pipeline if isinstance(step, Mapping) and set(step) == {"model"}]
+    if len(models) != 1:
+        raise ValueError("native retrain source does not retain exactly one portable Methods model")
+
+    outcome = getattr(source.native_estimator, "training_outcome_", None)
+    document = outcome.to_dict() if hasattr(outcome, "to_dict") else outcome
+    if not isinstance(document, Mapping):
+        raise ValueError("native retrain source does not retain a structured native outcome")
+    patches = document.get("parameter_patches", [])
+    if not isinstance(patches, list):
+        raise ValueError("native retrain source parameter patches are malformed")
+    saw_components_patch = False
+    for patch in patches:
+        if not isinstance(patch, Mapping):
+            raise ValueError("native retrain source parameter patch is malformed")
+        if (
+            patch.get("schema_version") != 1
+            or patch.get("node_id") != "model:compat.0"
+            or patch.get("namespace") != "operator"
+            or patch.get("path") != ["n_components"]
+            or isinstance(patch.get("value"), bool)
+            or not isinstance(patch.get("value"), int)
+            or patch["value"] < 1
+            or saw_components_patch
+        ):
+            raise ValueError("native retrain source carries an unsupported selected parameter patch")
+        models[0].n_components = patch["value"]
+        saw_components_patch = True
+    return pipeline

--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -199,6 +199,8 @@ def retrain(
             extra_kwargs=kwargs,
         )
     require_legacy_engine("retrain", engine)
+    if isinstance(source, NativeMethodsRunResult):
+        raise TypeError("a NativeMethodsRunResult source requires engine='native'")
 
     # Use session runner if provided, otherwise create new
     runner = session.runner if session is not None else PipelineRunner(verbose=verbose, save_artifacts=save_artifacts)
@@ -277,7 +279,10 @@ def _selected_native_methods_pipeline(source: NativeMethodsRunResult) -> list[An
         raise ValueError("native retrain source does not retain exactly one portable Methods model")
 
     outcome = getattr(source.native_estimator, "training_outcome_", None)
-    document = outcome.to_dict() if hasattr(outcome, "to_dict") else outcome
+    if outcome is None:
+        raise ValueError("native retrain source does not retain a structured native outcome")
+    outcome_to_dict = getattr(outcome, "to_dict", None)
+    document = outcome_to_dict() if callable(outcome_to_dict) else outcome
     if not isinstance(document, Mapping):
         raise ValueError("native retrain source does not retain a structured native outcome")
     patches = document.get("parameter_patches", [])

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -6,6 +6,8 @@ import importlib
 
 import numpy as np
 import pytest
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold
 
 import nirs4all
 from nirs4all.api.explain import explain
@@ -268,6 +270,68 @@ def test_run_native_rejects_broad_legacy_shapes_before_native_execution(
 def test_public_helpers_reject_dagml_until_native_paths_exist(operation: str, call) -> None:
     with pytest.raises(NotImplementedError, match=rf"nirs4all\.{operation}.*dag-ml"):
         call()
+
+
+def test_retrain_native_refits_the_attested_selected_methods_variant_without_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Native full retrain keeps the selected HPO patch and never builds a runner."""
+
+    model = PLSRegression(n_components=1)
+
+    class Estimator:
+        pipeline = [KFold(n_splits=2), {"model": model}]
+        training_outcome_ = {
+            "parameter_patches": [
+                {
+                    "schema_version": 1,
+                    "node_id": "model:compat.0",
+                    "namespace": "operator",
+                    "path": ["n_components"],
+                    "value": 2,
+                }
+            ]
+        }
+
+    source = object.__new__(NativeMethodsRunResult)
+    source._native_estimator = Estimator()  # noqa: SLF001
+    observed: dict[str, object] = {}
+    expected = object()
+
+    def native_retrain(pipeline, dataset, **kwargs):  # noqa: ANN001
+        observed.update(pipeline=pipeline, dataset=dataset, kwargs=kwargs)
+        return expected
+
+    retrain_module = importlib.import_module("nirs4all.api.retrain")
+    monkeypatch.setattr(retrain_module, "run_native_methods", native_retrain)
+    monkeypatch.setattr(
+        retrain_module,
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("native retrain constructed PipelineRunner")),
+    )
+
+    dataset = {
+        "X": np.asarray([[1.0], [2.0], [3.0], [4.0]]),
+        "y": np.asarray([1.0, 2.0, 3.0, 4.0]),
+        "sample_ids": ["next-0", "next-1", "next-2", "next-3"],
+    }
+    assert retrain(source, dataset, engine="native", name="next") is expected
+    rebuilt_model = observed["pipeline"][1]["model"]
+    assert rebuilt_model is not model
+    assert rebuilt_model.n_components == 2
+    assert model.n_components == 1
+    assert observed["dataset"] is dataset
+    assert observed["kwargs"] == {"name": "next", "save_charts": False, "random_state": None}
+
+
+@pytest.mark.parametrize(
+    ("mode", "message"),
+    [("transfer", "only mode='full'"), ("finetune", "only mode='full'")],
+)
+def test_retrain_native_refuses_unqualified_modes_before_execution(mode: str, message: str) -> None:
+    source = object.__new__(NativeMethodsRunResult)
+    with pytest.raises(NotImplementedError, match=message):
+        retrain(source, {"X": [], "y": [], "sample_ids": []}, engine="native", mode=mode)
 
 
 def test_predict_native_archive_is_explicit_and_never_constructs_a_legacy_runner(


### PR DESCRIPTION
## Summary
- add strict `engine="native"` support for in-memory full retraining of a selected Methods variant
- apply only the attested PLS `n_components` patch to a copied portable recipe
- reject archives, transfer/finetune, legacy kwargs, alternate models and sessions before execution
- document the portable source/data contract and explicit archive boundary

## Validation
- `python3.11 -m pytest tests/unit/api -q`
- real Methods HPO → selected full retrain E2E
- `python3.11 -m sphinx -q -b html docs/source ... --keep-going -W`
- Ruff, format and diff checks