### PR TITLE
feat(native): bind Methods HPO to sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,9 @@ pip install nirs4all[native]
 
 The `native` extra enables the explicit, fail-closed `engine="native"` Methods
 subset: raw-array PLS training with explicit sample IDs, stateful native
-sessions, Archive V2 export/load, and replay. It does not change the default
-engine, fit a legacy runner, or silently fall back for a native request.
+sessions, strict Methods HPO, Archive V2 export/load, and replay. It does not
+change the default engine, fit a legacy runner, or silently fall back for a
+native request.
 
 ### Docker
 

--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -126,9 +126,23 @@ with nirs4all.session(pipeline, engine="native") as native:
     result.export("model.n4a")
 ```
 
-Tuning, calibration, generic branching/stacking, retraining and explanation
-remain explicit capability refusals on this route; none is redirected to the
-legacy backend.
+The only native tuning request is
+``{"engine": "methods-hpo", "trials": N}``: it uses the DAG-ML Methods
+controller with the attested V1 PLS ``n_components`` search space, random
+sampling and no pruner. A session can bind that same request once:
+
+```python
+with nirs4all.session(
+    pipeline,
+    engine="native",
+    tuning={"engine": "methods-hpo", "trials": 8},
+) as native:
+    result = native.run(dataset)
+```
+
+Archive-based retraining, transfer/finetuning, calibration, generic
+branching/stacking and explanation remain explicit capability refusals; none is
+redirected to the legacy backend.
 
 **Example - Single pipeline:**
 

--- a/docs/source/getting_started/installation.md
+++ b/docs/source/getting_started/installation.md
@@ -57,8 +57,8 @@ pip install nirs4all[native]
 
 The `native` extra enables the explicit, fail-closed `engine="native"` Methods
 subset: raw-array PLS training with explicit sample IDs, stateful sessions,
-Archive V2 export/load, and replay. It does not alter the default engine and
-does not fall back to legacy execution for a native request.
+strict Methods HPO, Archive V2 export/load, and replay. It does not alter the
+default engine and does not fall back to legacy execution for a native request.
 
 ### GPU Support (TensorFlow)
 

--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -28,6 +28,7 @@ class NativeMethodsSession:
         *,
         name: str = "",
         random_state: int | None = None,
+        tuning: Mapping[str, Any] | None = None,
     ) -> None:
         if not isinstance(pipeline, list):
             raise TypeError("engine='native' session requires a list pipeline")
@@ -36,6 +37,7 @@ class NativeMethodsSession:
         self._pipeline = pipeline
         self._name = name
         self._random_state = random_state
+        self._tuning = None if tuning is None else dict(tuning)
         self._result: NativeMethodsRunResult | None = None
         self._closed = False
 
@@ -56,6 +58,12 @@ class NativeMethodsSession:
         """The deterministic seed configured for every session training run."""
 
         return self._random_state
+
+    @property
+    def tuning(self) -> dict[str, Any] | None:
+        """Return the session's immutable-at-boundary native tuning request."""
+
+        return None if self._tuning is None else dict(self._tuning)
 
     @property
     def is_trained(self) -> bool:
@@ -82,6 +90,7 @@ class NativeMethodsSession:
             name=self._name,
             save_charts=False,
             random_state=self._random_state,
+            tuning=self._tuning,
         )
         return self._result
 

--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -34,6 +34,8 @@ class NativeMethodsSession:
             raise TypeError("engine='native' session requires a list pipeline")
         if random_state is not None and (isinstance(random_state, bool) or not isinstance(random_state, int)):
             raise TypeError("engine='native' session random_state must be an integer or None")
+        if tuning is not None and not isinstance(tuning, Mapping):
+            raise TypeError("engine='native' session tuning must be a mapping")
         self._pipeline = pipeline
         self._name = name
         self._random_state = random_state

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -52,6 +52,7 @@ def test_native_session_runs_predicts_saves_and_closes_without_legacy_runner(mon
         "name": "native",
         "save_charts": False,
         "random_state": 7,
+        "tuning": None,
     }
     with pytest.raises(RuntimeError, match="closed"):
         native.run({"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]})
@@ -66,6 +67,27 @@ def test_native_session_refuses_missing_pipeline_and_legacy_runner_kwargs() -> N
             pass
 
 
+def test_native_session_binds_the_strict_methods_hpo_operation_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stateful native training forwards only the explicit HPO request."""
+
+    result = _Result()
+    observed: dict[str, object] = {}
+    tuning = {"engine": "methods-hpo", "trials": 3}
+
+    def native_run(_pipeline, _dataset, **kwargs):  # noqa: ANN001
+        observed.update(kwargs)
+        return result
+
+    monkeypatch.setattr("nirs4all.api.native_session.run_native_methods", native_run)
+    native = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}], tuning=tuning)
+
+    assert native.tuning == tuning
+    tuning["trials"] = 99
+    assert native.tuning == {"engine": "methods-hpo", "trials": 3}
+    assert native.run({"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]}) is result
+    assert observed["tuning"] == {"engine": "methods-hpo", "trials": 3}
+
+
 def test_native_run_delegates_to_the_matching_native_session(monkeypatch: pytest.MonkeyPatch) -> None:
     pipeline = [{"split": "stub"}, {"model": "stub"}]
     native = NativeMethodsSession(pipeline, random_state=7)
@@ -78,14 +100,17 @@ def test_native_run_delegates_to_the_matching_native_session(monkeypatch: pytest
 
     monkeypatch.setattr(native, "run", native_run)
 
-    assert nirs4all.run(
-        pipeline,
-        {"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]},
-        engine="native",
-        session=native,
-        save_charts=False,
-        random_state=7,
-    ) is result
+    assert (
+        nirs4all.run(
+            pipeline,
+            {"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]},
+            engine="native",
+            session=native,
+            save_charts=False,
+            random_state=7,
+        )
+        is result
+    )
     assert observed == [{"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]}]
 
     with pytest.raises(ValueError, match="exact pipeline"):

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -65,6 +65,8 @@ def test_native_session_refuses_missing_pipeline_and_legacy_runner_kwargs() -> N
     with pytest.raises(TypeError, match="unexpected keyword"):
         with session([], engine="native", workspace_path="legacy"):
             pass
+    with pytest.raises(TypeError, match="tuning must be a mapping"):
+        NativeMethodsSession([], tuning=["methods-hpo"])  # type: ignore[arg-type]
 
 
 def test_native_session_binds_the_strict_methods_hpo_operation_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- allow a native Methods session to retain the same strict `methods-hpo` request as `run`
- reject a non-mapping tuning request before runtime access and copy the accepted request at the session boundary
- document the verified session HPO contract and its remaining explicit refusals

## Validation
- `python3.11 -m pytest tests/unit/api/test_native_session.py tests/unit/api/test_engine_transition.py -q`
- real `libn4m` session → HPO → selection → N4MOPT proof
- `ruff check nirs4all/api/native_session.py tests/unit/api/test_native_session.py`
- `ruff format --check nirs4all/api/native_session.py tests/unit/api/test_native_session.py`
- `python3.11 -m sphinx -b html docs/source ... --keep-going -W`
- `git diff --check`