### PR TITLE
feat(native): refit selected variants in sessions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -101,9 +101,25 @@ jobs:
             MARK=(-m "not tensorflow and not torch and not keras and not jax and not stress")
           fi
 
-          if [ "$RUNNER_OS" == "macOS" ] || [ "$RUNNER_OS" == "Windows" ]; then
-            # macOS and Windows: run serially to avoid xdist worker deadlocks.
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            # macOS: run serially to avoid fork() deadlocks.
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/unit/
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            # Keep native-framework tests out of xdist, then use a bounded
+            # loadfile schedule.  ``worksteal -n auto`` deadlocks Windows
+            # workers, while a fully serial suite exceeds the job budget.
+            python -m pytest -v --timeout=300 \
+              -m torch \
+              tests/unit/operators/models/test_pytorch.py \
+              tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+            python -m pytest -v --timeout=300 \
+              -m tensorflow \
+              tests/unit/operators/models/test_tensorflow.py \
+              tests/unit/pipeline/dagml/test_raw_training_lowerer.py
+            python -m pytest -v --timeout=300 \
+              -m jax tests/unit/operators/models/test_jax.py
+            python -m pytest -v -n 2 --dist loadfile --timeout=300 \
+              -m "not torch and not tensorflow and not keras and not jax" tests/unit/
           else
             # TensorFlow and PyTorch both claim process-global native state. Run
             # each framework's explicit test files in a fresh interpreter; marker
@@ -132,9 +148,25 @@ jobs:
             MARK=(-m "not tensorflow and not torch and not keras and not jax and not stress")
           fi
 
-          if [ "$RUNNER_OS" == "macOS" ] || [ "$RUNNER_OS" == "Windows" ]; then
-            # macOS and Windows: run serially to avoid xdist worker deadlocks.
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            # macOS: run serially to avoid fork() deadlocks.
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/integration/pipeline/
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            # The merge fixtures and TensorFlow replay own process-global or
+            # write-contended state.  Exercise them serially, then bound the
+            # portable remainder to two loadfile workers.
+            python -m pytest -v --timeout=300 \
+              tests/integration/pipeline/test_merge_mixed.py \
+              tests/integration/pipeline/test_merge_per_branch.py
+            python -m pytest -v --timeout=300 \
+              -m tensorflow \
+              tests/integration/pipeline/test_classification_integration.py \
+              tests/integration/pipeline/test_finetune_integration.py \
+              tests/integration/pipeline/test_prediction_reuse_integration.py
+            python -m pytest -v -n 2 --dist loadfile --timeout=300 tests/integration/pipeline/ \
+              -m "not torch and not tensorflow and not keras and not jax" \
+              --ignore=tests/integration/pipeline/test_merge_mixed.py \
+              --ignore=tests/integration/pipeline/test_merge_per_branch.py
           else
             # Serial subset with known write-contention under heavy xdist load
             python -m pytest -v --timeout=300 \

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -101,8 +101,8 @@ jobs:
             MARK=(-m "not tensorflow and not torch and not keras and not jax and not stress")
           fi
 
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            # macOS: run serially to avoid fork() deadlocks
+          if [ "$RUNNER_OS" == "macOS" ] || [ "$RUNNER_OS" == "Windows" ]; then
+            # macOS and Windows: run serially to avoid xdist worker deadlocks.
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/unit/
           else
             # TensorFlow and PyTorch both claim process-global native state. Run
@@ -132,8 +132,8 @@ jobs:
             MARK=(-m "not tensorflow and not torch and not keras and not jax and not stress")
           fi
 
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            # macOS: run serially to avoid fork() deadlocks
+          if [ "$RUNNER_OS" == "macOS" ] || [ "$RUNNER_OS" == "Windows" ]; then
+            # macOS and Windows: run serially to avoid xdist worker deadlocks.
             python -m pytest -v --timeout=120 "${MARK[@]}" tests/integration/pipeline/
           else
             # Serial subset with known write-contention under heavy xdist load

--- a/docs/source/user_guide/deployment/retrain_transfer.md
+++ b/docs/source/user_guide/deployment/retrain_transfer.md
@@ -66,6 +66,10 @@ runner options and retained sessions are refused before native execution. An
 archive-to-retrain recipe is a separate portable contract and is not inferred
 from prediction-only archive metadata.
 
+A trained ``NativeMethodsSession`` exposes the same full-refit operation as
+``native_session.retrain({"X": X_new, "y": y_new, "sample_ids": new_ids})``;
+it replaces the in-memory session result only after the native refit succeeds.
+
 ### Transfer Mode
 
 Reuse preprocessing artifacts (scalers, SNV, etc.) while training a new model:

--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -96,6 +96,31 @@ class NativeMethodsSession:
         )
         return self._result
 
+    def retrain(self, dataset: Mapping[str, Any]) -> NativeMethodsRunResult:
+        """Full-refit the attested selected Methods variant on one new cohort.
+
+        This delegates to the public native retrain contract, which preserves
+        only the selected portable PLS recipe and its attested patch. Transfer
+        learning and finetuning are intentionally not session capabilities.
+        """
+
+        self._require_open()
+        from .retrain import retrain
+
+        result = retrain(
+            self.result,
+            dataset,
+            mode="full",
+            name=self._name,
+            save_artifacts=True,
+            verbose=0,
+            engine="native",
+        )
+        if not isinstance(result, NativeMethodsRunResult):  # pragma: no cover - defensive contract assertion
+            raise RuntimeError("native session retrain did not return a NativeMethodsRunResult")
+        self._result = result
+        return result
+
     def predict(
         self,
         X: Any,

--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -109,7 +109,11 @@ class NativeMethodsSession:
 
         result = retrain(
             self.result,
-            dataset,
+            # ``retrain`` exposes the public ``DataSpec`` union, whose
+            # mapping branch is deliberately a concrete ``dict``.  Sessions
+            # accept any read-only mapping at their boundary, so materialize
+            # it here rather than narrowing the session contract.
+            dict(dataset),
             mode="full",
             name=self._name,
             save_artifacts=True,

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -173,6 +173,43 @@ def test_native_session_retrains_only_through_the_strict_native_full_refit(monke
     }
 
 
+def test_native_hpo_session_refits_the_result_selected_by_its_own_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A session keeps its attested HPO result as the sole native refit source."""
+
+    selected = object.__new__(NativeMethodsRunResult)
+    refitted = object.__new__(NativeMethodsRunResult)
+    tuning = {"engine": "methods-hpo", "trials": 2}
+    native = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}], tuning=tuning)
+    observed: dict[str, object] = {}
+
+    def native_run(_pipeline, _dataset, **kwargs):  # noqa: ANN001
+        observed["tuning"] = kwargs["tuning"]
+        return selected
+
+    def native_retrain(source_arg, _data, **kwargs):  # noqa: ANN001
+        observed["source"] = source_arg
+        observed["retrain_kwargs"] = kwargs
+        return refitted
+
+    monkeypatch.setattr("nirs4all.api.native_session.run_native_methods", native_run)
+    retrain_module = importlib.import_module("nirs4all.api.retrain")
+    monkeypatch.setattr(retrain_module, "retrain", native_retrain)
+
+    dataset = {"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]}
+    assert native.run(dataset) is selected
+    assert native.retrain(dataset) is refitted
+    assert native.result is refitted
+    assert observed["tuning"] == tuning
+    assert observed["source"] is selected
+    assert observed["retrain_kwargs"] == {
+        "mode": "full",
+        "name": "",
+        "save_artifacts": True,
+        "verbose": 0,
+        "engine": "native",
+    }
+
+
 @pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])
 def test_native_session_never_falls_back_to_another_run_engine(engine: str) -> None:
     pipeline = [{"split": "stub"}, {"model": "stub"}]

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import importlib
+
 import numpy as np
 import pytest
 
 import nirs4all
+from nirs4all.api.native_result import NativeMethodsRunResult
 from nirs4all.api.native_session import NativeMethodsSession
 from nirs4all.api.session import session
 
@@ -138,6 +141,36 @@ def test_native_predict_delegates_to_the_trained_native_session(monkeypatch: pyt
 
     assert prediction.y_pred.tolist() == [[4.0], [5.0]]
     assert prediction.metadata == {"engine": "native", "sample_ids": ["p1", "p2"]}
+
+
+def test_native_session_retrains_only_through_the_strict_native_full_refit(monkeypatch: pytest.MonkeyPatch) -> None:
+    source = object.__new__(NativeMethodsRunResult)
+    retrained = object.__new__(NativeMethodsRunResult)
+    native = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}], name="native")
+    native._result = source  # noqa: SLF001
+    observed: dict[str, object] = {}
+
+    def native_retrain(source_arg, data, **kwargs):  # noqa: ANN001
+        observed.update(source=source_arg, data=data, kwargs=kwargs)
+        return retrained
+
+    retrain_module = importlib.import_module("nirs4all.api.retrain")
+    monkeypatch.setattr(retrain_module, "retrain", native_retrain)
+    dataset = {"X": [[3.0]], "y": [3.0], "sample_ids": ["s3"]}
+
+    assert native.retrain(dataset) is retrained
+    assert native.result is retrained
+    assert observed == {
+        "source": source,
+        "data": dataset,
+        "kwargs": {
+            "mode": "full",
+            "name": "native",
+            "save_artifacts": True,
+            "verbose": 0,
+            "engine": "native",
+        },
+    }
 
 
 @pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])


### PR DESCRIPTION
## Summary
- add `NativeMethodsSession.retrain()` for the strict selected-variant native full refit
- replace the session result only after a successful native refit
- document the stateful native refit boundary

This PR depends on #68 and should be retargeted to `main` once #68 is merged.

## Validation
- `python3.11 -m pytest tests/unit/api/test_native_session.py tests/unit/api/test_engine_transition.py -q`
- real `libn4m` session → run → retrain → predict proof
- Ruff, format and diff checks