### PR TITLE
docs(native): document in-memory session retrain

### DIFF
--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -140,9 +140,21 @@ with nirs4all.session(
     result = native.run(dataset)
 ```
 
-Archive-based retraining, transfer/finetuning, calibration, generic
-branching/stacking and explanation remain explicit capability refusals; none is
-redirected to the legacy backend.
+An in-memory native session can also full-refit its already attested selected
+Methods variant on a new explicitly identified cohort:
+
+```python
+with nirs4all.session(pipeline, engine="native") as native:
+    native.run(dataset)
+    refitted = native.retrain(
+        {"X": X_next, "y": y_next, "sample_ids": ["next-0", "next-1"]}
+    )
+```
+
+This is not transfer learning or finetuning: it preserves only the selected
+portable PLS recipe and its attested patch. Archive-based retraining,
+transfer/finetuning, calibration, generic branching/stacking and explanation
+remain explicit capability refusals; none is redirected to the legacy backend.
 
 **Example - Single pipeline:**
 

--- a/docs/source/user_guide/predictions/session_api.md
+++ b/docs/source/user_guide/predictions/session_api.md
@@ -140,10 +140,14 @@ with nirs4all.load_session(
     )
 ```
 
-This R2 migration surface supports portable **PREDICT** replay only.  Training,
-retraining and explanation remain separate capabilities and are never routed to
-the legacy runner implicitly. The native Methods shared library is explicit for
-each session; a missing library path is refused rather than replaced by Python.
+This persisted R2 surface supports portable **PREDICT** replay only. An
+*in-memory* ``NativeMethodsSession`` may full-refit its already selected,
+attested Methods recipe on a new cohort via ``native.retrain(...)`` before it is
+saved. A loaded ``NativeArchiveSession`` deliberately cannot retrain:
+archive-based retraining, transfer/finetuning and explanation remain explicit
+capability refusals and are never routed to the legacy runner implicitly. The
+native Methods shared library is explicit for each session; a missing library
+path is refused rather than replaced by Python.
 
 ## Session Features
 


### PR DESCRIPTION
Summary:
- document the supported in-memory native session full-refit path
- retain explicit refusal boundaries for persisted archives, transfer, finetuning, calibration and explanation

Validation:
- python3.11 -m sphinx -b html docs/source /tmp/nirs4all-native-v1/.docs-build --keep-going
- git diff --check