### PR TITLE
feat(export): bundle captured native dag-ml refit

### DIFF
--- a/nirs4all/api/result.py
+++ b/nirs4all/api/result.py
@@ -1555,6 +1555,9 @@ class RunResult:
                     "the dag-ml run's non-existent workspace); export the run's best model with "
                     "result.export(path) (no source/chain_id)."
                 )
+            native = self._dagml_native_export_bundle(output_path, format)
+            if native is not None:
+                return native
             if legacy_refit_compatibility:
                 delegate = self._dagml_export_delegate()
                 if delegate is None:
@@ -1567,7 +1570,6 @@ class RunResult:
 
         if legacy_refit_compatibility:
             raise ValueError("compatibility='legacy-refit' is only valid for engine='dag-ml' results")
-
         # Store-based export path
         if chain_id is not None:
             with self._open_store_for_export() as store:
@@ -1664,6 +1666,50 @@ class RunResult:
 
         joblib.dump(model, output_path, compress=3)
         return output_path
+
+    def _dagml_native_export_bundle(self, output_path: str | Path, format: str) -> Path | None:
+        """Build a native ``.n4a`` from one captured dag-ml REFIT artifact.
+
+        ``None`` means this narrow representation is inapplicable; callers keep
+        their existing transition behaviour.  A successful return never calls
+        the legacy runner or re-fits the pipeline.
+        """
+        if self._dagml_results_dir is None or format != "n4a":
+            return None
+
+        from nirs4all.pipeline.dagml.native_results import read_native_results
+
+        try:
+            native = read_native_results(self._dagml_results_dir)
+            artifacts = native["artifacts"]
+        except Exception as error:  # native storage is untrusted at this boundary
+            logger.debug("native dag-ml .n4a export unavailable: %s", error)
+            return None
+        if len(artifacts) != 1:
+            return None
+
+        artifact = artifacts[0]
+        model = _DagmlExportedModel(artifact["estimator"], artifact["y_transform"])
+        native_manifest = native["manifest"]
+        model_names = native_manifest.get("model_names") or []
+        model_label = str(model_names[0]) if model_names else type(artifact["estimator"]).__name__
+        provenance = {
+            "source_type": "dagml_native",
+            "export_path": "dagml_native",
+            "dagml_run_id": native_manifest.get("run_id"),
+            "dagml_plan_id": native_manifest.get("plan_id"),
+            "dagml_bundle_id": native_manifest.get("bundle_id"),
+            "dagml_selected_variant": native_manifest.get("selected_variant"),
+        }
+        from nirs4all.pipeline.bundle import write_single_model_bundle
+
+        return write_single_model_bundle(
+            model,
+            output_path,
+            model_label=model_label,
+            pipeline_uid=str(native_manifest.get("run_id") or ""),
+            provenance=provenance,
+        )
 
     def export_model(
         self,

--- a/nirs4all/pipeline/bundle/__init__.py
+++ b/nirs4all/pipeline/bundle/__init__.py
@@ -46,6 +46,7 @@ Design Principles:
 from nirs4all.pipeline.bundle.generator import (
     BundleFormat,
     BundleGenerator,
+    write_single_model_bundle,
 )
 from nirs4all.pipeline.bundle.loader import (
     BundleLoader,
@@ -57,4 +58,5 @@ __all__ = [
     "BundleFormat",
     "BundleLoader",
     "BundleMetadata",
+    "write_single_model_bundle",
 ]

--- a/nirs4all/pipeline/bundle/generator.py
+++ b/nirs4all/pipeline/bundle/generator.py
@@ -64,6 +64,64 @@ class BundleFormat(StrEnum):
     def __str__(self) -> str:
         return self.value
 
+
+def write_single_model_bundle(
+    model: Any,
+    output_path: str | Path,
+    *,
+    model_label: str = "model",
+    pipeline_uid: str = "",
+    preprocessing_chain: str = "",
+    provenance: dict[str, Any] | None = None,
+    compress: bool = True,
+) -> Path:
+    """Write a self-contained ``.n4a`` bundle from one predict-capable model.
+
+    This is intentionally separate from :class:`BundleGenerator`: it writes no
+    workspace, resolver, trace, or legacy artifact.  It is the native export
+    boundary for a dag-ml REFIT artifact whose ``predict`` method already
+    applies the complete forward pass and any target inverse transformation.
+    """
+    import io
+
+    import joblib
+
+    output_path = Path(output_path)
+    if output_path.suffix.lower() != ".n4a":
+        output_path = output_path.with_suffix(".n4a")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    safe_label = "".join(char if char.isalnum() else "_" for char in model_label).strip("_") or "model"
+    import nirs4all
+
+    manifest: dict[str, Any] = {
+        "bundle_format_version": BUNDLE_FORMAT_VERSION,
+        "nirs4all_version": getattr(nirs4all, "__version__", "unknown"),
+        "created_at": datetime.now(UTC).isoformat(),
+        "pipeline_uid": pipeline_uid,
+        "source_type": "single_model",
+        "model_step_index": 1,
+        "fold_strategy": "single",
+        "preprocessing_chain": preprocessing_chain,
+    }
+    if provenance:
+        manifest.update(provenance)
+
+    pipeline_config = {
+        "steps": [{"model": {"class": model_label}}],
+        "model_step_index": 1,
+    }
+    compression = zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
+    with zipfile.ZipFile(output_path, "w", compression=compression) as bundle:
+        bundle.writestr("manifest.json", json.dumps(manifest, indent=2))
+        bundle.writestr("pipeline.json", json.dumps(pipeline_config, indent=2))
+        artifact = io.BytesIO()
+        joblib.dump(model, artifact)
+        bundle.writestr(f"artifacts/step_1_foldfinal_{safe_label}.joblib", artifact.getvalue())
+
+    return output_path
+
+
 class BundleGenerator:
     """Generate standalone prediction bundles from trained pipelines.
 

--- a/tests/integration/parity/test_native_single_model_bundle_export.py
+++ b/tests/integration/parity/test_native_single_model_bundle_export.py
@@ -1,0 +1,62 @@
+"""End-to-end native ``.n4a`` export for one captured dag-ml REFIT model."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold
+
+from nirs4all.operators.transforms.scalers import StandardNormalVariate as SNV
+from nirs4all.pipeline.bundle import BundleLoader
+from nirs4all.pipeline.dagml.run_backend import run_via_dagml
+
+from ._datasets import dataset_path
+
+
+def _dagml_cli() -> Path:
+    configured = os.environ.get("N4A_DAGML_CLI")
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parents[3].parent / "dag-ml" / "target" / "release" / "dag-ml-cli"
+
+
+@pytest.mark.parity
+def test_native_single_model_bundle_export_never_refits_legacy(tmp_path, monkeypatch) -> None:
+    cli = _dagml_cli()
+    if not cli.exists():
+        pytest.skip(f"dag-ml-cli binary unavailable: {cli}")
+    pipeline = [SNV(), KFold(n_splits=3, shuffle=True, random_state=42), {"model": PLSRegression(n_components=5)}]
+    result = run_via_dagml(
+        pipeline,
+        dataset_path("regression"),
+        workdir=tmp_path / "work",
+        dagml_cli=str(cli),
+        venv_python=sys.executable,
+        results_path=tmp_path / "results",
+        random_state=42,
+    )
+    assert result._dagml_results_dir is not None  # noqa: SLF001
+    assert len(result._dagml_refit_artifacts) == 1  # noqa: SLF001
+
+    run_module = importlib.import_module("nirs4all.api.run")
+    monkeypatch.setattr(run_module, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("legacy run used")))
+    bundle = result.export(tmp_path / "native.n4a")
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+    dataset = dataset_path("regression")
+    from nirs4all.data.config import DatasetConfigs
+
+    source = DatasetConfigs(dataset).get_dataset_at(0)
+    test_ids = [int(sample) for sample in source.index_column("sample", {"partition": "test"})]
+    x_test = np.asarray(source.x_rows(test_ids, layout="2d"))
+    expected_rows = result.predictions.filter_predictions(partition="test", fold_id="final")
+    assert len(expected_rows) == 1
+    expected = np.asarray(expected_rows[0]["y_pred"], dtype=float).ravel()
+    actual = np.asarray(BundleLoader(bundle).predict(x_test), dtype=float).ravel()
+    assert np.allclose(actual, expected, atol=1e-6)

--- a/tests/unit/api/test_native_dagml_bundle_export.py
+++ b/tests/unit/api/test_native_dagml_bundle_export.py
@@ -1,0 +1,36 @@
+"""The dag-ml native bundle export must not touch the legacy runner."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+from sklearn.cross_decomposition import PLSRegression
+
+from nirs4all.api.result import RunResult
+from nirs4all.pipeline.bundle import BundleLoader
+
+
+def test_dagml_result_exports_captured_refit_without_legacy_run(tmp_path, monkeypatch) -> None:
+    x_train = np.asarray([[-2.0, 1.0], [-1.0, 0.0], [0.0, 1.0], [1.0, -1.0], [2.0, 0.5]])
+    y_train = 1.5 + 2.0 * x_train[:, 0] - 0.75 * x_train[:, 1]
+    estimator = PLSRegression(n_components=1).fit(x_train, y_train)
+    result = RunResult(predictions=object(), per_dataset={"native": {"engine": "dag-ml"}})
+    result._dagml_export_spec = {"pipeline": [], "dataset": object()}  # noqa: SLF001
+    result._dagml_results_dir = tmp_path / "captured"  # noqa: SLF001
+
+    def fake_read_native_results(_path):
+        return {
+            "manifest": {"run_id": "run-native", "model_names": ["PLSRegression"]},
+            "artifacts": [{"estimator": estimator, "y_transform": None}],
+        }
+
+    native_results = importlib.import_module("nirs4all.pipeline.dagml.native_results")
+    monkeypatch.setattr(native_results, "read_native_results", fake_read_native_results)
+    run_module = importlib.import_module("nirs4all.api.run")
+    monkeypatch.setattr(run_module, "run", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("legacy run used")))
+
+    bundle = result.export(tmp_path / "captured.n4a")
+    x_test = np.asarray([[0.5, 1.0]])
+    assert np.allclose(BundleLoader(bundle).predict(x_test), estimator.predict(x_test))
+    assert result._dagml_legacy_result is None  # noqa: SLF001

--- a/tests/unit/pipeline/bundle/test_native_single_model_bundle.py
+++ b/tests/unit/pipeline/bundle/test_native_single_model_bundle.py
@@ -1,0 +1,41 @@
+"""Native single-model ``.n4a`` bundle writer coverage."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+
+import numpy as np
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from nirs4all.api.result import _DagmlExportedModel
+from nirs4all.pipeline.bundle import BundleLoader, write_single_model_bundle
+
+
+def test_native_single_model_bundle_round_trips_without_workspace(tmp_path) -> None:
+    rng = np.random.default_rng(4)
+    x_train = rng.standard_normal((24, 6)).astype(np.float32)
+    y_train = rng.standard_normal((24, 1)).astype(np.float32)
+    x_test = rng.standard_normal((5, 6)).astype(np.float32)
+    pipeline = Pipeline([("scale", StandardScaler()), ("pls", PLSRegression(n_components=2))]).fit(x_train, y_train)
+    model = _DagmlExportedModel(pipeline, None)
+
+    bundle = write_single_model_bundle(
+        model,
+        tmp_path / "native",
+        model_label="PLS / exported",
+        pipeline_uid="run-native-4",
+        provenance={"source_type": "dagml_native", "export_path": "dagml_native"},
+    )
+
+    expected = model.predict(x_test)
+    actual = BundleLoader(bundle).predict(x_test)
+    assert bundle.suffix == ".n4a"
+    assert np.array_equal(actual, expected)
+    with zipfile.ZipFile(bundle) as archive:
+        manifest = json.loads(archive.read("manifest.json"))
+        assert manifest["source_type"] == "dagml_native"
+        assert manifest["model_step_index"] == 1
+        assert any(name.startswith("artifacts/step_1_foldfinal_") for name in archive.namelist())


### PR DESCRIPTION
## Scope

Adds the first direct native `.n4a` writer for a dag-ml run with exactly one captured REFIT artifact. The writer serializes that fitted forward pass into the existing bundle format and bypasses the legacy re-fit bridge.

## Guarantees

- `RunResult.export()` succeeds when the captured native artifact is usable.
- The resulting `BundleLoader` predicts the same final-refit values.
- The integration test poisons `nirs4all.api.run.run`; a successful export proves no legacy re-fit occurred.

## Deliberate boundary

This does not claim full R2 export parity: multiple artifacts, stacking/branches and `n4a.py` still take the transition path. They need a native multi-artifact representation or explicit typed refusal before the native-default flip.

## Local validation

- `N4A_DAGML_CLI=/home/delete/nirs4all/dag-ml/target/release/dag-ml-cli pytest -q tests/unit/pipeline/bundle/test_native_single_model_bundle.py tests/unit/api/test_native_dagml_bundle_export.py tests/integration/parity/test_native_single_model_bundle_export.py` → 3 passed
- Ruff clean.
- Mypy remains blocked by 30 pre-existing project-wide errors in 14 files; this patch adds none.