### PR TITLE
feat(predict): infer native engine from session

### DIFF
--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -161,9 +161,9 @@ def predict(
             ``result.metadata`` when publishing the workspace prediction row.
 
         session: Optional legacy :class:`Session` for runner reuse, or an
-            explicitly loaded :class:`NativeArchiveSession` with
-            ``engine="native"``.  Native sessions never construct a legacy
-            runner.
+            explicitly loaded :class:`NativeArchiveSession`. A native session
+            selects native replay by its concrete type; it never constructs a
+            legacy runner. Passing any explicit non-native engine is refused.
 
         methods_library_path: Optional explicit path to the compatible
             ``libn4m`` for ``engine="native"`` Archive V2 Methods prediction.
@@ -221,10 +221,16 @@ def predict(
     """
     engine = runner_kwargs.pop("engine", None)
 
-    if isinstance(session, (NativeArchiveSession, NativeMethodsSession)) and engine != "native":
-        raise ValueError(
-            "a native Methods session requires engine='native'; it never falls back to legacy prediction"
-        )
+    if isinstance(session, (NativeArchiveSession, NativeMethodsSession)):
+        if engine is None:
+            # The session itself is an unambiguous, already-selected native
+            # capability. Do not route it through the process default or an
+            # environment override: neither may construct a legacy runner.
+            engine = "native"
+        elif engine != "native":
+            raise ValueError(
+                "a native Methods session selects native prediction; an explicit non-native engine is refused"
+            )
 
     # ---- Validate mutually exclusive arguments ----
     if model is not None and chain_id is not None:

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -87,7 +87,6 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
     result = predict(
         data={"X": np.asarray([[1.0], [2.0]]), "sample_ids": ["p1", "p2"]},
         session=native_session,
-        engine="native",
     )
 
     assert result.y_pred.tolist() == [[7.0], [8.0]]
@@ -96,11 +95,12 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
     assert observed["sample_ids"] == ["p1", "p2"]
 
 
-def test_predict_native_session_requires_explicit_native_engine() -> None:
-    with pytest.raises(ValueError, match="requires engine='native'"):
+def test_predict_native_session_refuses_explicit_non_native_engine() -> None:
+    with pytest.raises(ValueError, match="explicit non-native engine"):
         predict(
             data={"X": np.asarray([[1.0]]), "sample_ids": ["p1"]},
             session=load_native_archive_session("portable.n4a"),
+            engine="legacy",
         )
 
 


### PR DESCRIPTION
## Summary
- native archive and Methods sessions select the native replay route from their concrete capability
- explicit non-native engine choices remain fail-closed

## Validation
- `pytest -q tests/unit/api/test_native_archive_session.py tests/unit/api/test_native_session.py` (17 passed)
- `ruff check nirs4all/api/predict.py tests/unit/api/test_native_archive_session.py`
- `mypy nirs4all/api/predict.py` remains at the existing repository baseline: 30 errors in 14 unrelated/pre-existing files