### PR TITLE
feat(retrain): infer native engine from source

### DIFF
--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -109,11 +109,13 @@ def retrain(
             - learning_rate: Learning rate for fine-tuning
             - freeze_layers: List of layers to freeze during fine-tuning
             - step_modes: Per-step mode overrides (advanced)
-            - engine: ``"native"`` enables the strict in-memory Methods full
-              retrain subset. It requires a ``NativeMethodsRunResult`` source,
-              a raw ``{"X", "y", "sample_ids"}`` dataset and preserves the
-              attested selected PLS variant. Archive sources, transfer and
-              finetune remain explicit refusals; all other modes use legacy.
+            - engine: the strict in-memory Methods full retrain subset is
+              selected automatically by a ``NativeMethodsRunResult`` source,
+              or explicitly with ``"native"``. It requires a raw ``{"X",
+              "y", "sample_ids"}`` dataset and preserves the attested selected
+              PLS variant. Archive sources, transfer and finetune remain
+              explicit refusals; an explicit non-native engine is refused for
+              a native source.
 
     Returns:
         RunResult containing:
@@ -185,6 +187,15 @@ def retrain(
         raise ValueError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
 
     engine = kwargs.pop("engine", None)
+    if isinstance(source, NativeMethodsRunResult):
+        if engine is None:
+            # The source is an already-attested native capability. It must not
+            # be routed through an environment/default legacy selector.
+            engine = "native"
+        elif engine != "native":
+            raise ValueError(
+                "a NativeMethodsRunResult selects native retrain; an explicit non-native engine is refused"
+            )
     if engine == "native":
         return _retrain_native_methods_full(
             source,
@@ -200,8 +211,7 @@ def retrain(
         )
     require_legacy_engine("retrain", engine)
     if isinstance(source, NativeMethodsRunResult):
-        raise TypeError("a NativeMethodsRunResult source requires engine='native'")
-
+        raise RuntimeError("native retrain source escaped native routing")
     # Use session runner if provided, otherwise create new
     runner = session.runner if session is not None else PipelineRunner(verbose=verbose, save_artifacts=save_artifacts)
 

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -315,13 +315,20 @@ def test_retrain_native_refits_the_attested_selected_methods_variant_without_leg
         "y": np.asarray([1.0, 2.0, 3.0, 4.0]),
         "sample_ids": ["next-0", "next-1", "next-2", "next-3"],
     }
-    assert retrain(source, dataset, engine="native", name="next") is expected
+    assert retrain(source, dataset, name="next") is expected
     rebuilt_model = observed["pipeline"][1]["model"]
     assert rebuilt_model is not model
     assert rebuilt_model.n_components == 2
     assert model.n_components == 1
     assert observed["dataset"] is dataset
     assert observed["kwargs"] == {"name": "next", "save_charts": False, "random_state": None}
+
+
+@pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])
+def test_retrain_native_source_refuses_explicit_non_native_engine(engine: str) -> None:
+    source = object.__new__(NativeMethodsRunResult)
+    with pytest.raises(ValueError, match="explicit non-native engine"):
+        retrain(source, {"X": [], "y": [], "sample_ids": []}, engine=engine)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- infer strict native full retraining from an in-memory `NativeMethodsRunResult`
- reject explicit non-native engines before legacy runner construction

## Validation
- `pytest -q tests/unit/api/test_engine_transition.py tests/unit/api/test_native_session.py` (39 passed)
- `ruff check nirs4all/api/retrain.py tests/unit/api/test_engine_transition.py`
- `mypy nirs4all/api/retrain.py` remains at the existing repository baseline: 30 errors in 14 unrelated/pre-existing files