### PR TITLE
fix(generate): refuse unsupported native engines

### DIFF
--- a/nirs4all/api/generate.py
+++ b/nirs4all/api/generate.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 import numpy as np
 
+from nirs4all.pipeline.engine import require_legacy_engine
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -43,6 +45,7 @@ def generate(
     train_ratio: float = ...,
     as_dataset: Literal[True] = ...,
     name: str = ...,
+    engine: str | None = ...,
     **kwargs: Any,
 ) -> SpectroDataset: ...
 
@@ -58,6 +61,7 @@ def generate(
     train_ratio: float = ...,
     as_dataset: Literal[False],
     name: str = ...,
+    engine: str | None = ...,
     **kwargs: Any,
 ) -> tuple[np.ndarray, np.ndarray]: ...
 
@@ -72,6 +76,7 @@ def generate(
     train_ratio: float = 0.8,
     as_dataset: bool = True,
     name: str = "synthetic_nirs",
+    engine: str | None = None,
     **kwargs: Any,
 ) -> SpectroDataset | tuple[np.ndarray, np.ndarray]:
     """
@@ -96,6 +101,9 @@ def generate(
         train_ratio: Proportion of samples for training partition.
         as_dataset: If True, returns SpectroDataset. If False, returns (X, y) tuple.
         name: Dataset name.
+        engine: Execution engine selector. Synthetic generation has no native
+            implementation in the current capability ledger, so any explicit
+            non-legacy engine is refused before constructing a dataset.
         **kwargs: Additional arguments passed to SyntheticDatasetBuilder.
 
     Returns:
@@ -125,6 +133,8 @@ def generate(
         generate.classification: Convenience function for classification datasets.
         generate.builder: Access the full builder API.
     """
+    require_legacy_engine("generate", engine)
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(

--- a/tests/unit/api/test_generate.py
+++ b/tests/unit/api/test_generate.py
@@ -19,6 +19,21 @@ class TestGenerateFunction:
         assert isinstance(dataset, SpectroDataset)
         assert dataset.num_samples == 100
 
+    @pytest.mark.parametrize("engine", ["native", "dag-ml", "dual"])
+    def test_non_legacy_engine_is_refused_before_constructing_a_dataset(self, monkeypatch: pytest.MonkeyPatch, engine: str):
+        """Generation has no native capability yet and must not run implicitly."""
+        import nirs4all
+        import nirs4all.synthesis
+
+        monkeypatch.setattr(
+            nirs4all.synthesis,
+            "SyntheticDatasetBuilder",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("generator was constructed")),
+        )
+
+        with pytest.raises((NotImplementedError, ValueError), match="nirs4all.generate|dual"):
+            nirs4all.generate(n_samples=1, engine=engine)
+
     def test_generate_as_arrays(self):
         """Test generation returning arrays."""
         import nirs4all


### PR DESCRIPTION
## Summary
- make the public generation API resolve its engine explicitly
- refuse native, dag-ml and dual generation before constructing the Python generator

## Validation
- `pytest -q tests/unit/api/test_generate.py tests/unit/pipeline/test_engine_selector.py` (45 passed)
- `ruff check nirs4all/api/generate.py tests/unit/api/test_generate.py`
- `mypy nirs4all/api/generate.py` remains at the existing repository baseline: 30 errors in 14 unrelated/pre-existing files