### PR TITLE
feat(native): prepare identity-bound conformal calibration

### DIFF
--- a/nirs4all/api/native_result.py
+++ b/nirs4all/api/native_result.py
@@ -112,6 +112,24 @@ class NativeMethodsRunResult(RunResult):
             raise DagMLNativeCoverageError("native selected variant id is malformed")
         return value
 
+    @property
+    def native_conformal_calibration(self) -> dict[str, Any] | None:
+        """Return the DAG-ML-attested conformal state, when calibration ran.
+
+        The mapping is the native contract emitted after the exact calibration
+        replay was attached.  No Python interval state is reconstructed here;
+        Archive V2 and native PREDICT remain the authoritative persistence and
+        materialization paths.
+        """
+
+        outcome = _outcome_document(self._native_estimator)
+        calibration = outcome.get("conformal_calibration")
+        if calibration is None:
+            return None
+        if not isinstance(calibration, Mapping):
+            raise DagMLNativeCoverageError("native conformal calibration is not a structured mapping")
+        return dict(calibration)
+
     def export(
         self,
         output_path: str | Path,

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -16,6 +16,10 @@ import numpy as np
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.methods_runtime import resolve_methods_library_path
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+from nirs4all.pipeline.dagml.native_conformal_calibration import (
+    NativeConformalCalibrationError,
+    compile_methods_conformal_calibration_replay,
+)
 from nirs4all.pipeline.dagml.raw_replay_lowerer import (
     RawArrayMethodsReplayCompiler,
     RawArrayMethodsReplayError,
@@ -139,6 +143,7 @@ def run_native_methods(
     results_path: Any = None,
     runner_kwargs: Mapping[str, Any] | None = None,
     tuning: Any = None,
+    calibration: Any = None,
 ) -> NativeMethodsRunResult:
     """Run the verified public Methods training subset without a legacy runner.
 
@@ -184,6 +189,7 @@ def run_native_methods(
         tuning,
         seed=12345 if random_state is None else random_state,
     )
+    calibration_operation = _native_conformal_calibration_operation(calibration)
 
     fit_kwargs: dict[str, Any] = {
         "sample_ids": dataset["sample_ids"],
@@ -194,6 +200,8 @@ def run_native_methods(
     if methods_hpo_operation is not None:
         fit_kwargs["methods_hpo_operation"] = methods_hpo_operation
     estimator = fit_native_pipeline(pipeline, dataset["X"], dataset["y"], **fit_kwargs)
+    if calibration_operation is not None:
+        _attach_native_conformal_calibration(estimator, calibration_operation)
     return NativeMethodsRunResult.from_estimator(
         estimator,
         dataset_name=name or "native",
@@ -203,6 +211,137 @@ def run_native_methods(
 
 _NATIVE_METHODS_HPO_SAMPLERS = frozenset({"random"})
 _NATIVE_METHODS_HPO_PRUNERS = frozenset({"none"})
+_NATIVE_CONFORMAL_POLICIES = frozenset({"marginal", "joint_max"})
+_NATIVE_CONFORMAL_SMALL_SAMPLE_POLICIES = frozenset({"error", "unbounded"})
+
+
+def _native_conformal_calibration_operation(calibration: Any) -> dict[str, Any] | None:
+    """Parse the explicit raw-array conformal cohort accepted by native run.
+
+    This does not accept the broad legacy/tuning calibration aliases.  The
+    caller supplies the actual calibration measurements and stable sample
+    identities; the native DAG-ML coordinator derives every fingerprint,
+    residual and quantile from the resulting PREDICT replay.
+    """
+
+    if calibration is None:
+        return None
+    if not isinstance(calibration, Mapping):
+        raise TypeError("engine='native' calibration must be a mapping")
+    payload = dict(calibration)
+    allowed = {
+        "X",
+        "y",
+        "sample_ids",
+        "groups",
+        "metadata",
+        "coverages",
+        "multi_target_policy",
+        "small_sample_policy",
+    }
+    unknown = set(payload) - allowed
+    if unknown:
+        raise ValueError(f"engine='native' calibration has unsupported keys: {sorted(unknown)}")
+    missing = {"X", "y", "sample_ids", "coverages"} - set(payload)
+    if missing:
+        raise ValueError(f"engine='native' calibration is missing required keys: {sorted(missing)}")
+    coverages = payload["coverages"]
+    if isinstance(coverages, (str, bytes)) or not isinstance(coverages, Sequence):
+        raise TypeError("engine='native' calibration coverages must be a non-empty sequence")
+    normalized_coverages: list[float] = []
+    for coverage in coverages:
+        if isinstance(coverage, bool) or not isinstance(coverage, int | float):
+            raise TypeError("engine='native' calibration coverages must be finite numbers")
+        numeric_coverage = float(coverage)
+        if not np.isfinite(numeric_coverage) or not 0.0 < numeric_coverage < 1.0:
+            raise ValueError("engine='native' calibration coverages must lie strictly between zero and one")
+        normalized_coverages.append(numeric_coverage)
+    if not normalized_coverages or len(set(normalized_coverages)) != len(normalized_coverages):
+        raise ValueError("engine='native' calibration coverages must be non-empty and unique")
+    multi_target_policy = payload.get("multi_target_policy", "marginal")
+    if multi_target_policy not in _NATIVE_CONFORMAL_POLICIES:
+        raise ValueError(f"engine='native' calibration multi_target_policy is unsupported: {multi_target_policy!r}")
+    small_sample_policy = payload.get("small_sample_policy", "error")
+    if small_sample_policy not in _NATIVE_CONFORMAL_SMALL_SAMPLE_POLICIES:
+        raise ValueError(f"engine='native' calibration small_sample_policy is unsupported: {small_sample_policy!r}")
+    return {
+        "X": payload["X"],
+        "y": payload["y"],
+        "sample_ids": payload["sample_ids"],
+        "groups": payload.get("groups"),
+        "metadata": payload.get("metadata"),
+        "coverages": normalized_coverages,
+        "multi_target_policy": multi_target_policy,
+        "small_sample_policy": small_sample_policy,
+    }
+
+
+def _attach_native_conformal_calibration(
+    estimator: DagMLPipelineEstimator,
+    calibration: Mapping[str, Any],
+) -> None:
+    """Attach a native calibration replay and refresh the portable package.
+
+    The replay is compiled from the package emitted by the just-completed fit.
+    Its target-free PREDICT result and separately identity-bound truth cross
+    the Python boundary unchanged.  Only DAG-ML may derive calibration
+    provenance, residuals or interval quantiles.
+    """
+
+    package = estimator.predictor_package_
+    training_result = getattr(estimator, "training_result_", None)
+    if package is None or training_result is None:
+        raise DagMLNativeCoverageError("native conformal calibration requires a fitted portable Methods Package V2")
+    try:
+        replay = compile_methods_conformal_calibration_replay(
+            package,
+            calibration["X"],
+            calibration["y"],
+            sample_ids=calibration["sample_ids"],
+            groups=calibration.get("groups"),
+            metadata=calibration.get("metadata"),
+            methods_library_path=getattr(getattr(estimator, "prediction_compiler", None), "methods_library_path", None),
+            dagml_module=estimator.dagml_module,
+        )
+    except (KeyError, NativeConformalCalibrationError, TypeError, ValueError) as error:
+        raise DagMLNativeCoverageError("native conformal calibration cohort is not replayable") from error
+    replay_outcome = estimator.execute_compiled_replay(replay.execution)
+    attach = getattr(training_result, "attach_conformal_calibration", None)
+    export = getattr(training_result, "export_portable_predictor_package", None)
+    if not callable(attach) or not callable(export):
+        raise DagMLNativeCoverageError("installed DAG-ML lacks native conformal calibration attachment")
+    attach(
+        replay_outcome,
+        binding_id=replay.binding_id,
+        calibration_relations=replay.calibration_relations,
+        truth=replay.truth,
+        coverages=calibration["coverages"],
+        multi_target_policy=calibration["multi_target_policy"],
+        small_sample_policy=calibration["small_sample_policy"],
+    )
+    package_id = _portable_package_id(package)
+    estimator.training_outcome_ = getattr(training_result, "outcome", None)
+    estimator.predictor_package_ = export(
+        package_id,
+        fitted_artifact_mode="portable_required",
+        artifact_load_mode="native_portable",
+    )
+    try:
+        validate_native_methods_package(estimator.predictor_package_)
+    except RawArrayMethodsReplayError as error:
+        raise DagMLNativeCoverageError("native conformal calibration did not re-export a portable Methods Package V2") from error
+
+
+def _portable_package_id(package: Any) -> str:
+    """Read the durable Package V2 id without fabricating an export identity."""
+
+    document = package.to_dict() if hasattr(package, "to_dict") else package
+    if not isinstance(document, Mapping):
+        raise DagMLNativeCoverageError("native conformal calibration package is not a structured contract")
+    package_id = document.get("package_id")
+    if not isinstance(package_id, str) or not package_id:
+        raise DagMLNativeCoverageError("native conformal calibration package has no stable package_id")
+    return package_id
 
 
 def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] | None:

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -8,6 +8,7 @@ re-running that workflow through :class:`PipelineRunner` during export.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
@@ -316,8 +317,10 @@ def _attach_native_conformal_calibration(
         calibration_relations=replay.calibration_relations,
         truth=replay.truth,
         coverages=calibration["coverages"],
-        multi_target_policy=calibration["multi_target_policy"],
-        small_sample_policy=calibration["small_sample_policy"],
+        # The released DAG-ML facade accepts object values directly but treats
+        # scalar strings as pre-serialized TCV1 JSON contracts.
+        multi_target_policy=json.dumps(calibration["multi_target_policy"]),
+        small_sample_policy=json.dumps(calibration["small_sample_policy"]),
     )
     package_id = _portable_package_id(package)
     estimator.training_outcome_ = getattr(training_result, "outcome", None)

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -871,8 +871,6 @@ def run(
     if custom_training_loss_requested and selected_engine != "dag-ml":
         raise ValueError("training_losses/local_implementations require engine='dag-ml'")
     if selected_engine == "native":
-        if calibration is not None:
-            raise NotImplementedError("engine='native' conformal calibration is not available through run() yet")
         if not isinstance(pipeline, list):
             raise TypeError("engine='native' requires a list pipeline")
         if not isinstance(dataset, Mapping):
@@ -884,6 +882,8 @@ def run(
         if session is not None:
             if tuning is not None:
                 raise NotImplementedError("engine='native' Methods HPO is stateless; do not combine tuning with a NativeMethodsSession")
+            if calibration is not None:
+                raise NotImplementedError("engine='native' conformal calibration is stateless; do not combine it with a NativeMethodsSession")
             if not isinstance(session, NativeMethodsSession):
                 raise TypeError("engine='native' requires a NativeMethodsSession, not a legacy Session")
             if pipeline is not session.pipeline:
@@ -920,6 +920,7 @@ def run(
             results_path=results_path,
             runner_kwargs=runner_kwargs,
             tuning=tuning,
+            calibration=calibration,
         )
     if isinstance(session, NativeMethodsSession):
         raise ValueError("NativeMethodsSession requires engine='native'; it never falls back to another engine")

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -316,6 +316,84 @@ class DagMLPipelineEstimator(BaseEstimator):
             raise DagMLNativeCoverageError("DagMLPipelineEstimator.predict_with_identity() requires a native prediction decoder; P1 does not synthesize Python predictions from replay JSON")
         return cast(np.ndarray, np.asarray(self.prediction_decoder(replay_outcome)))
 
+    def replay_with_identity(
+        self,
+        X: Any,
+        *,
+        sample_ids: Any,
+        groups: Any = None,
+        metadata: Any = None,
+    ) -> Any:
+        """Return the native PREDICT replay for an explicitly identified cohort.
+
+        This is the evidence-preserving counterpart of
+        :meth:`predict_with_identity`.  It intentionally returns the DAG-ML
+        replay contract rather than decoding it into a NumPy array, so callers
+        such as the conformal attachment lane can bind the exact replay to
+        identity-keyed truth in DAG-ML.  It never supplies targets, computes
+        provenance, or invokes a legacy runner.
+        """
+
+        check_is_fitted(self, attributes=["training_result_", "output_binding_"])
+        identity_frame = normalize_predict_identity(
+            X,
+            sample_ids=sample_ids,
+            groups=groups,
+            metadata=metadata,
+            require_explicit_sample_ids=True,
+        )
+        replay = self._compile_replay(X, mode="predict", identity_frame=identity_frame)
+        return self.execute_compiled_replay(replay)
+
+    def execute_compiled_replay(self, replay: DagMLReplayExecution) -> Any:
+        """Execute one already-compiled native replay exactly once.
+
+        Compilation owns request, relation and identity attestation.  This
+        method only transports that exact contract to DAG-ML and guarantees
+        the compiler's cleanup hook executes on both success and failure.
+        It is public so higher-level native operations can retain the same
+        replay evidence for a later DAG-ML attachment rather than compiling a
+        second, potentially distinct request.
+        """
+
+        check_is_fitted(self, attributes=["training_result_", "output_binding_"])
+        if not isinstance(replay, DagMLReplayExecution):
+            raise TypeError("execute_compiled_replay requires DagMLReplayExecution")
+        if self.predictor_package_ is None:
+            raise DagMLNativeCoverageError("DagMLPipelineEstimator has no portable predictor package to replay")
+        try:
+            if replay.methods_inputs is not None or replay.methods_library_path is not None:
+                if replay.methods_inputs is None or replay.methods_library_path is None:
+                    raise DagMLNativeCoverageError(
+                        "native Methods replay requires inputs and an explicit libn4m path"
+                    )
+                return self._client().replay_loaded_methods_predictor_package(
+                    self.predictor_package_,
+                    replay.request,
+                    replay.data_envelopes,
+                    replay.methods_inputs,
+                    methods_library_path=replay.methods_library_path,
+                    outcome_id=replay.outcome_id,
+                    run_id=replay.run_id,
+                    warnings=replay.warnings,
+                    diagnostics=replay.diagnostics,
+                )
+            return self._client().replay_loaded_predictor_package(
+                self.predictor_package_,
+                replay.request,
+                replay.data_envelopes,
+                replay.artifact_handles,
+                replay.op_callback,
+                outcome_id=replay.outcome_id,
+                run_id=replay.run_id,
+                artifact_callback=replay.artifact_callback,
+                warnings=replay.warnings,
+                diagnostics=replay.diagnostics,
+            )
+        finally:
+            if replay.cleanup is not None:
+                replay.cleanup()
+
     def export_native_archive(
         self,
         archive_path: str | Path,
@@ -411,39 +489,7 @@ class DagMLPipelineEstimator(BaseEstimator):
             require_explicit_sample_ids=(self.require_explicit_sample_ids if require_explicit_sample_ids is None else require_explicit_sample_ids),
         )
         replay = self._compile_replay(X, mode=mode, identity_frame=identity_frame)
-        try:
-            if replay.methods_inputs is not None or replay.methods_library_path is not None:
-                if replay.methods_inputs is None or replay.methods_library_path is None:
-                    raise DagMLNativeCoverageError(
-                        "native Methods replay requires inputs and an explicit libn4m path"
-                    )
-                outcome = self._client().replay_loaded_methods_predictor_package(
-                    self.predictor_package_,
-                    replay.request,
-                    replay.data_envelopes,
-                    replay.methods_inputs,
-                    methods_library_path=replay.methods_library_path,
-                    outcome_id=replay.outcome_id,
-                    run_id=replay.run_id,
-                    warnings=replay.warnings,
-                    diagnostics=replay.diagnostics,
-                )
-            else:
-                outcome = self._client().replay_loaded_predictor_package(
-                    self.predictor_package_,
-                    replay.request,
-                    replay.data_envelopes,
-                    replay.artifact_handles,
-                    replay.op_callback,
-                    outcome_id=replay.outcome_id,
-                    run_id=replay.run_id,
-                    artifact_callback=replay.artifact_callback,
-                    warnings=replay.warnings,
-                    diagnostics=replay.diagnostics,
-                )
-        finally:
-            if replay.cleanup is not None:
-                replay.cleanup()
+        outcome = self.execute_compiled_replay(replay)
         return outcome, identity_frame
 
     def _compile_replay(

--- a/nirs4all/pipeline/dagml/fit_identity.py
+++ b/nirs4all/pipeline/dagml/fit_identity.py
@@ -99,6 +99,41 @@ class DagMLPredictIdentityFrame:
         }
 
 
+@dataclass(frozen=True)
+class DagMLCalibrationIdentityFrame:
+    """Explicit PREDICT identities plus an attested measured-target proof.
+
+    Calibration is evaluated through a PREDICT replay so a Methods provider
+    does not receive targets as execution inputs.  Unlike ordinary inference,
+    its replay provenance must still bind the separately supplied measured
+    truth.  The target fingerprint has the same raw-array profile as native
+    training and is never synthesized from a sentinel.
+    """
+
+    n_samples: int
+    sample_ids: tuple[str, ...]
+    groups: tuple[str | None, ...]
+    metadata_rows: tuple[dict[str, Any], ...]
+    explicit_sample_ids: bool
+    data_content_fingerprint: str
+    target_content_fingerprint: str
+    fingerprint: str
+
+    def metadata_by_sample_id(self) -> dict[str, dict[str, Any]]:
+        """Return row metadata keyed by the exact public sample id."""
+
+        return {sample_id: dict(row) for sample_id, row in zip(self.sample_ids, self.metadata_rows, strict=True) if row}
+
+    def group_by_sample_id(self) -> dict[str, str]:
+        """Return non-null groups keyed by the exact public sample id."""
+
+        return {
+            sample_id: group
+            for sample_id, group in zip(self.sample_ids, self.groups, strict=True)
+            if group is not None
+        }
+
+
 def normalize_fit_identity(
     X: Any,
     y: Any,
@@ -182,6 +217,41 @@ def normalize_predict_identity(
         explicit_sample_ids=explicit,
         data_content_fingerprint=data_content_fingerprint,
         fingerprint=fingerprint,
+    )
+
+
+def normalize_calibration_identity(
+    X: Any,
+    y: Any,
+    *,
+    sample_ids: Sequence[Any] | None = None,
+    groups: Sequence[Any] | None = None,
+    metadata: Mapping[str, Sequence[Any]] | Sequence[Mapping[str, Any]] | None = None,
+    require_explicit_sample_ids: bool = False,
+) -> DagMLCalibrationIdentityFrame:
+    """Bind a measured calibration cohort without changing PREDICT inputs."""
+
+    predict = normalize_predict_identity(
+        X,
+        sample_ids=sample_ids,
+        groups=groups,
+        metadata=metadata,
+        require_explicit_sample_ids=require_explicit_sample_ids,
+    )
+    targets = np.ascontiguousarray(np.asarray(y))
+    if targets.ndim not in (1, 2) or targets.shape[0] != predict.n_samples:
+        raise ValueError("native DAG-ML calibration identity requires row-aligned one- or two-dimensional y")
+    if not np.issubdtype(targets.dtype, np.number) or not np.isfinite(targets).all():
+        raise ValueError("native DAG-ML calibration identity requires finite numeric y")
+    return DagMLCalibrationIdentityFrame(
+        n_samples=predict.n_samples,
+        sample_ids=predict.sample_ids,
+        groups=predict.groups,
+        metadata_rows=predict.metadata_rows,
+        explicit_sample_ids=predict.explicit_sample_ids,
+        data_content_fingerprint=predict.data_content_fingerprint,
+        target_content_fingerprint=target_content_fingerprint(y),
+        fingerprint=predict.fingerprint,
     )
 
 
@@ -311,6 +381,18 @@ def feature_content_fingerprint(X: Any) -> str:
     return hasher.hexdigest()
 
 
+def target_content_fingerprint(y: Any) -> str:
+    """Return the exact raw-array target proof used by native training."""
+
+    array = np.ascontiguousarray(np.asarray(y))
+    hasher = hashlib.sha256()
+    hasher.update(b"y")
+    hasher.update(str(array.shape).encode("utf-8"))
+    hasher.update(str(array.dtype).encode("utf-8"))
+    hasher.update(array.tobytes())
+    return hasher.hexdigest()
+
+
 def _content_fingerprint(X: Any, y: Any | None) -> str:
     hasher = hashlib.sha256()
     _update_array_hash(hasher, np.asarray(X), "X")
@@ -346,8 +428,11 @@ def _identity_fingerprint(
 
 __all__ = [
     "DagMLFitIdentityFrame",
+    "DagMLCalibrationIdentityFrame",
     "DagMLPredictIdentityFrame",
     "feature_content_fingerprint",
+    "normalize_calibration_identity",
     "normalize_fit_identity",
     "normalize_predict_identity",
+    "target_content_fingerprint",
 ]

--- a/nirs4all/pipeline/dagml/native_conformal_calibration.py
+++ b/nirs4all/pipeline/dagml/native_conformal_calibration.py
@@ -14,7 +14,7 @@ from typing import Any, cast
 import numpy as np
 
 from .estimator import DagMLReplayExecution
-from .fit_identity import DagMLPredictIdentityFrame, normalize_predict_identity
+from .fit_identity import DagMLCalibrationIdentityFrame, normalize_calibration_identity
 from .raw_replay_lowerer import (
     RawArrayMethodsReplayCompiler,
     RawArrayMethodsReplayError,
@@ -56,10 +56,10 @@ def compile_methods_conformal_calibration_replay(
 ) -> NativeConformalCalibrationReplay:
     """Compile a finite, explicitly identified calibration cohort.
 
-    The replay itself remains PREDICT, so the Methods provider never gets a
-    target sentinel.  The exact same stable sample ids occur in the point
-    prediction request and in ``truth``; DAG-ML rejects any non-identical join
-    when calibration is attached.
+    The replay itself remains PREDICT, so the Methods provider never receives
+    targets as execution inputs.  Its envelope nevertheless carries the
+    measured-target fingerprint required by DAG-ML, and the same stable sample
+    ids occur in the point prediction request and in ``truth``.
     """
 
     if sample_ids is None:
@@ -88,8 +88,9 @@ def compile_methods_conformal_calibration_replay(
         )
 
     try:
-        identity_frame = normalize_predict_identity(
+        identity_frame = normalize_calibration_identity(
             values,
+            y,
             sample_ids=sample_ids,
             groups=groups,
             metadata=metadata,
@@ -135,7 +136,7 @@ def compile_methods_conformal_calibration_replay(
 
 def _calibration_relations(
     execution: DagMLReplayExecution,
-    identity_frame: DagMLPredictIdentityFrame,
+    identity_frame: DagMLCalibrationIdentityFrame,
 ) -> dict[str, Any]:
     """Extract the one relation authority shared by every replay envelope."""
 

--- a/nirs4all/pipeline/dagml/native_conformal_calibration.py
+++ b/nirs4all/pipeline/dagml/native_conformal_calibration.py
@@ -1,0 +1,169 @@
+"""Identity-bound calibration replay inputs for the native Methods lane.
+
+This module only compiles host data into the existing DAG-ML PREDICT and
+conformal-truth contracts.  It never computes residuals, quantiles,
+fingerprints, or interval bounds: those remain owned by DAG-ML.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+
+from .estimator import DagMLReplayExecution
+from .fit_identity import DagMLPredictIdentityFrame, normalize_predict_identity
+from .raw_replay_lowerer import (
+    RawArrayMethodsReplayCompiler,
+    RawArrayMethodsReplayError,
+    _single_output_binding,
+    validate_native_methods_package,
+)
+
+
+class NativeConformalCalibrationError(RuntimeError):
+    """A raw calibration cohort cannot be represented by the native lane."""
+
+
+@dataclass(frozen=True)
+class NativeConformalCalibrationReplay:
+    """One native PREDICT replay plus identity-keyed calibration truth.
+
+    ``truth`` is intentionally a JSON-shaped value for
+    ``dag_ml.TrainingResult.attach_conformal_calibration``.  It has no
+    provenance fields: DAG-ML derives and validates those from the source
+    outcome, replay and relation set at attachment time.
+    """
+
+    execution: DagMLReplayExecution
+    binding_id: str
+    calibration_relations: dict[str, Any]
+    truth: dict[str, list[Any]]
+
+
+def compile_methods_conformal_calibration_replay(
+    package: Any,
+    X: Any,
+    y: Any,
+    *,
+    sample_ids: Sequence[Any] | None,
+    groups: Sequence[Any] | None = None,
+    metadata: Mapping[str, Sequence[Any]] | Sequence[Mapping[str, Any]] | None = None,
+    methods_library_path: str | None = None,
+    dagml_module: str = "dag_ml",
+) -> NativeConformalCalibrationReplay:
+    """Compile a finite, explicitly identified calibration cohort.
+
+    The replay itself remains PREDICT, so the Methods provider never gets a
+    target sentinel.  The exact same stable sample ids occur in the point
+    prediction request and in ``truth``; DAG-ML rejects any non-identical join
+    when calibration is attached.
+    """
+
+    if sample_ids is None:
+        raise NativeConformalCalibrationError(
+            "native conformal calibration requires explicit sample_ids"
+        )
+    values = np.ascontiguousarray(np.asarray(X, dtype=float))
+    if values.ndim != 2 or values.shape[0] == 0:
+        raise NativeConformalCalibrationError(
+            "native conformal calibration X must be a non-empty two-dimensional matrix"
+        )
+    if not np.isfinite(values).all():
+        raise NativeConformalCalibrationError(
+            "native conformal calibration X contains a non-finite value"
+        )
+    truth_values = np.ascontiguousarray(np.asarray(y, dtype=float))
+    if truth_values.ndim == 1:
+        truth_values = truth_values.reshape(-1, 1)
+    if truth_values.ndim != 2 or truth_values.shape[0] != values.shape[0]:
+        raise NativeConformalCalibrationError(
+            "native conformal calibration y must be a row-aligned one- or two-dimensional matrix"
+        )
+    if not np.isfinite(truth_values).all():
+        raise NativeConformalCalibrationError(
+            "native conformal calibration y contains a non-finite value"
+        )
+
+    try:
+        identity_frame = normalize_predict_identity(
+            values,
+            sample_ids=sample_ids,
+            groups=groups,
+            metadata=metadata,
+            require_explicit_sample_ids=True,
+        )
+        document = validate_native_methods_package(package)
+        binding = _single_output_binding(document)
+    except (RawArrayMethodsReplayError, TypeError, ValueError) as error:
+        raise NativeConformalCalibrationError(str(error)) from error
+    target_names = binding["target_names"]
+    if truth_values.shape[1] != len(target_names):
+        raise NativeConformalCalibrationError(
+            "native conformal calibration y width does not match the portable output binding"
+        )
+
+    compiler = RawArrayMethodsReplayCompiler(
+        document,
+        dagml_module=dagml_module,
+        methods_library_path=methods_library_path,
+        outcome_id="outcome:nirs4all.raw_calibration_predict",
+        run_id="run:nirs4all.raw_calibration_predict",
+        request_id="replay:nirs4all.raw_calibration_predict",
+    )
+    try:
+        execution = compiler.compile_replay(
+            None,
+            values,
+            mode="predict",
+            identity_frame=identity_frame,
+        )
+    except RawArrayMethodsReplayError as error:
+        raise NativeConformalCalibrationError(str(error)) from error
+    return NativeConformalCalibrationReplay(
+        execution=execution,
+        binding_id=binding["binding_id"],
+        calibration_relations=_calibration_relations(execution, identity_frame),
+        truth={
+            "sample_ids": list(identity_frame.sample_ids),
+            "values": truth_values.tolist(),
+        },
+    )
+
+
+def _calibration_relations(
+    execution: DagMLReplayExecution,
+    identity_frame: DagMLPredictIdentityFrame,
+) -> dict[str, Any]:
+    """Extract the one relation authority shared by every replay envelope."""
+
+    relations = [
+        dict(cast(Mapping[str, Any], envelope.get("coordinator_relations")))
+        for envelope in execution.data_envelopes.values()
+        if isinstance(envelope, Mapping)
+        and isinstance(envelope.get("coordinator_relations"), Mapping)
+    ]
+    if not relations or len(relations) != len(execution.data_envelopes):
+        raise NativeConformalCalibrationError(
+            "native calibration replay has no coordinator relation authority"
+        )
+    first = relations[0]
+    if any(relation != first for relation in relations[1:]):
+        raise NativeConformalCalibrationError(
+            "native calibration replay has conflicting coordinator relation authorities"
+        )
+    records = first.get("records")
+    if not isinstance(records, list) or [record.get("sample_id") for record in records if isinstance(record, Mapping)] != list(identity_frame.sample_ids):
+        raise NativeConformalCalibrationError(
+            "native calibration replay relations do not exactly cover sample_ids"
+        )
+    return first
+
+
+__all__ = [
+    "NativeConformalCalibrationError",
+    "NativeConformalCalibrationReplay",
+    "compile_methods_conformal_calibration_replay",
+]

--- a/nirs4all/pipeline/dagml/raw_replay_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_replay_lowerer.py
@@ -19,7 +19,7 @@ from typing import Any, cast
 import numpy as np
 
 from .estimator import DagMLPipelineEstimator, DagMLReplayExecution
-from .fit_identity import DagMLPredictIdentityFrame
+from .fit_identity import DagMLCalibrationIdentityFrame, DagMLPredictIdentityFrame
 from .methods_replay import MethodsN4mmReplayCallbacks
 
 
@@ -56,11 +56,13 @@ class _ArrayReplayResolver:
 
 @dataclass(frozen=True)
 class RawArrayMethodsReplayCompiler:
-    """Compile a target-free PREDICT cohort for one native Methods Package V2.
+    """Compile a PREDICT cohort for one native Methods Package V2.
 
     The class is intentionally single-output and raw-Matrix-only.  More general
     data plans need a separate, explicitly attested materializer rather than a
-    permissive fallback here.
+    permissive fallback here.  Ordinary PREDICT cohorts carry no target proof;
+    a typed calibration frame may carry an independently measured-target proof
+    while still keeping those values out of provider execution inputs.
     """
 
     package: Any
@@ -77,7 +79,7 @@ class RawArrayMethodsReplayCompiler:
         X: Any,
         *,
         mode: str,
-        identity_frame: DagMLPredictIdentityFrame,
+        identity_frame: DagMLPredictIdentityFrame | DagMLCalibrationIdentityFrame,
     ) -> DagMLReplayExecution:
         """Return native replay inputs for the current, target-free cohort."""
 
@@ -112,7 +114,7 @@ class RawArrayMethodsReplayCompiler:
                 "plan_fingerprint": requirement["plan_fingerprint"],
                 "relation_fingerprint": relation_fingerprint,
                 "data_content_fingerprint": identity_frame.data_content_fingerprint,
-                "target_content_fingerprint": None,
+                "target_content_fingerprint": getattr(identity_frame, "target_content_fingerprint", None),
                 "coordinator_relations": relations,
             }
             for key, requirement in requirements.items()
@@ -288,7 +290,9 @@ def _source_outcome_fingerprint(package: Mapping[str, Any]) -> str:
     return fingerprint
 
 
-def _current_relations(identity_frame: DagMLPredictIdentityFrame) -> dict[str, Any]:
+def _current_relations(
+    identity_frame: DagMLPredictIdentityFrame | DagMLCalibrationIdentityFrame,
+) -> dict[str, Any]:
     records: list[dict[str, Any]] = []
     for sample_id, group, metadata in zip(
         identity_frame.sample_ids,

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -10,7 +10,6 @@ Unsupported syntax fails before native execution.
 from __future__ import annotations
 
 import copy
-import hashlib
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -26,7 +25,7 @@ from .envelope import build_envelope
 from .errors import _reject_multi_model
 from .estimator import DagMLPipelineEstimator, DagMLTrainingExecution
 from .finetune_lowering import lower_deterministic_finetune_params_to_generators, reject_native_training_param_overrides
-from .fit_identity import DagMLFitIdentityFrame, feature_content_fingerprint
+from .fit_identity import DagMLFitIdentityFrame, feature_content_fingerprint, target_content_fingerprint
 from .folds import _build_folds
 from .identity import IdentityMap, SampleIdentity
 from .node_runner import run_node
@@ -149,7 +148,7 @@ def lower_raw_array_training_contracts(
     dag_ml = _import_dagml(dagml_module)
     envelope["relation_fingerprint"] = _core_relation_fingerprint(envelope["coordinator_relations"], dag_ml)
     envelope["data_content_fingerprint"] = feature_content_fingerprint(X)
-    envelope["target_content_fingerprint"] = _array_content_fingerprint("y", y)
+    envelope["target_content_fingerprint"] = target_content_fingerprint(y)
     dsl = assemble_cv_refit_dsl(steps, identity, envelope, folds, dsl_id="nirs4all-raw-fit", n_splits=len(folds))
     manifests = controller_manifests()
     if portable_methods:
@@ -473,16 +472,6 @@ def _training_influence_manifest(
     }
     manifest["manifest_fingerprint"] = tcv1_fingerprint_without(manifest, "manifest_fingerprint")
     return manifest
-
-
-def _array_content_fingerprint(label: str, value: Any) -> str:
-    array = np.ascontiguousarray(np.asarray(value))
-    hasher = hashlib.sha256()
-    hasher.update(label.encode("utf-8"))
-    hasher.update(str(array.shape).encode("utf-8"))
-    hasher.update(str(array.dtype).encode("utf-8"))
-    hasher.update(array.tobytes())
-    return hasher.hexdigest()
 
 
 def _core_relation_fingerprint(relations: Mapping[str, Any], dag_ml: Any) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.6",
+    "dag-ml>=0.3.8",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.6",
+    "dag-ml>=0.3.8",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
     # ABI 2.2 carries the optimizer symbols required by DAG-ML Methods training.

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.5
+dag-ml>=0.3.8
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.5
+dag-ml>=0.3.8
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.5
+dag-ml>=0.3.8
 dag-ml-data>=0.2.8

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -219,8 +219,8 @@ def test_run_native_attaches_identity_bound_conformal_calibration_without_legacy
         "calibration_relations": {"records": [{"sample_id": "cal-1"}, {"sample_id": "cal-2"}]},
         "truth": {"sample_ids": ["cal-1", "cal-2"], "values": [[1.5], [2.5]]},
         "coverages": [0.8, 0.95],
-        "multi_target_policy": "marginal",
-        "small_sample_policy": "error",
+        "multi_target_policy": '"marginal"',
+        "small_sample_policy": '"error"',
     }
     assert estimator.predictor_package_ == {"package_id": "package:native", "schema_version": 2, "reexported": True}
     assert result.native_conformal_calibration == {"schema_version": 2, "binding_id": "binding:prediction"}

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -108,6 +109,149 @@ def test_run_native_environment_selection_is_also_fail_closed_for_unsupported_re
 
     with pytest.raises(ValueError, match="missing required keys"):
         run([], {})
+
+
+def test_run_native_attaches_identity_bound_conformal_calibration_without_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public native lane transports one attested replay to DAG-ML."""
+
+    outcome = {
+        "outcome_fingerprint": "c" * 64,
+        "score_set": {
+            "schema_version": 2,
+            "selection_metric": "rmse",
+            "reports": [
+                {
+                    "producer_node": "model:methods",
+                    "producer_port": "oof",
+                    "partition": "validation",
+                    "fold_id": "avg",
+                    "level": "sample",
+                    "metrics": {"rmse": 0.25},
+                    "row_count": 2,
+                    "target_names": ["y"],
+                    "target_width": 1,
+                    "variant_id": "variant:base",
+                }
+            ],
+        },
+    }
+    attached: dict[str, object] = {}
+    replay_outcome = {"replay": "native-attested"}
+
+    class TrainingResult:
+        @property
+        def outcome(self):  # noqa: ANN201
+            return outcome
+
+        def attach_conformal_calibration(self, replay, **kwargs):  # noqa: ANN001
+            assert replay is replay_outcome
+            attached.update(kwargs)
+            outcome["conformal_calibration"] = {"schema_version": 2, "binding_id": kwargs["binding_id"]}
+            return outcome["conformal_calibration"]
+
+        def export_portable_predictor_package(self, package_id, **kwargs):  # noqa: ANN001
+            assert package_id == "package:native"
+            assert kwargs == {"fitted_artifact_mode": "portable_required", "artifact_load_mode": "native_portable"}
+            return {"package_id": package_id, "schema_version": 2, "reexported": True}
+
+    class Estimator:
+        dagml_module = "fake_dag_ml"
+        predictor_package_ = {"package_id": "package:native", "schema_version": 2}
+        prediction_compiler = SimpleNamespace(methods_library_path="/native/libn4m.so")
+
+        def __init__(self) -> None:
+            self.training_result_ = TrainingResult()
+            self.training_outcome_ = outcome
+
+        def execute_compiled_replay(self, execution):  # noqa: ANN001
+            assert execution == "compiled-calibration-replay"
+            return replay_outcome
+
+    estimator = Estimator()
+    compile_observed: dict[str, object] = {}
+
+    def compile_calibration(package, X, y, **kwargs):  # noqa: ANN001
+        assert package is estimator.predictor_package_
+        compile_observed.update(X=np.asarray(X), y=np.asarray(y), kwargs=kwargs)
+        return SimpleNamespace(
+            execution="compiled-calibration-replay",
+            binding_id="binding:prediction",
+            calibration_relations={"records": [{"sample_id": "cal-1"}, {"sample_id": "cal-2"}]},
+            truth={"sample_ids": ["cal-1", "cal-2"], "values": [[1.5], [2.5]]},
+        )
+
+    monkeypatch.setattr("nirs4all.api.native_training.fit_native_pipeline", lambda *_args, **_kwargs: estimator)
+    monkeypatch.setattr("nirs4all.api.native_training.compile_methods_conformal_calibration_replay", compile_calibration)
+    monkeypatch.setattr("nirs4all.api.native_training.validate_native_methods_package", lambda package: package)
+    monkeypatch.setattr(
+        importlib.import_module("nirs4all.api.run"),
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("native calibration constructed a legacy runner")),
+    )
+
+    result = run(
+        [{"split": "stub"}, {"model": "stub"}],
+        {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["train-1", "train-2"]},
+        engine="native",
+        save_charts=False,
+        calibration={
+            "X": np.asarray([[3.0], [4.0]]),
+            "y": np.asarray([1.5, 2.5]),
+            "sample_ids": ["cal-1", "cal-2"],
+            "coverages": [0.8, 0.95],
+        },
+    )
+
+    assert isinstance(result, NativeMethodsRunResult)
+    assert np.array_equal(compile_observed["X"], np.asarray([[3.0], [4.0]]))
+    assert np.array_equal(compile_observed["y"], np.asarray([1.5, 2.5]))
+    assert compile_observed["kwargs"] == {
+        "sample_ids": ["cal-1", "cal-2"],
+        "groups": None,
+        "metadata": None,
+        "methods_library_path": "/native/libn4m.so",
+        "dagml_module": "fake_dag_ml",
+    }
+    assert attached == {
+        "binding_id": "binding:prediction",
+        "calibration_relations": {"records": [{"sample_id": "cal-1"}, {"sample_id": "cal-2"}]},
+        "truth": {"sample_ids": ["cal-1", "cal-2"], "values": [[1.5], [2.5]]},
+        "coverages": [0.8, 0.95],
+        "multi_target_policy": "marginal",
+        "small_sample_policy": "error",
+    }
+    assert estimator.predictor_package_ == {"package_id": "package:native", "schema_version": 2, "reexported": True}
+    assert result.native_conformal_calibration == {"schema_version": 2, "binding_id": "binding:prediction"}
+
+
+@pytest.mark.parametrize(
+    ("calibration", "message"),
+    [
+        ({}, "missing required keys"),
+        ({"X": [], "y": [], "sample_ids": [], "coverages": [0.9, 0.9]}, "non-empty and unique"),
+        ({"X": [], "y": [], "sample_ids": [], "coverages": [1.0]}, "strictly between zero and one"),
+        ({"X": [], "y": [], "sample_ids": [], "coverages": [0.9], "legacy": True}, "unsupported keys"),
+    ],
+)
+def test_run_native_refuses_ambiguous_conformal_calibration_before_fit(
+    monkeypatch: pytest.MonkeyPatch,
+    calibration: dict[str, object],
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.fit_native_pipeline",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("native fit was reached")),
+    )
+    with pytest.raises((TypeError, ValueError), match=message):
+        run(
+            [{"split": "stub"}, {"model": "stub"}],
+            {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["train-1", "train-2"]},
+            engine="native",
+            save_charts=False,
+            calibration=calibration,
+        )
 
 
 def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(

--- a/tests/unit/pipeline/dagml/test_native_conformal_calibration.py
+++ b/tests/unit/pipeline/dagml/test_native_conformal_calibration.py
@@ -9,6 +9,7 @@ import types
 import numpy as np
 import pytest
 
+from nirs4all.pipeline.dagml.fit_identity import target_content_fingerprint
 from nirs4all.pipeline.dagml.native_conformal_calibration import (
     NativeConformalCalibrationError,
     compile_methods_conformal_calibration_replay,
@@ -79,6 +80,10 @@ def test_native_calibration_replay_preserves_exact_truth_and_identities(
     }
     assert replay.execution.request["phase"] == "PREDICT"
     assert replay.execution.request["request_fingerprint"] == "d" * 64
+    assert {
+        envelope["target_content_fingerprint"]
+        for envelope in replay.execution.data_envelopes.values()
+    } == {target_content_fingerprint(np.asarray([1.5, 2.5]))}
     assert replay.calibration_relations["records"] == [
         {
             "observation_id": "calibration.one",

--- a/tests/unit/pipeline/dagml/test_native_conformal_calibration.py
+++ b/tests/unit/pipeline/dagml/test_native_conformal_calibration.py
@@ -1,0 +1,128 @@
+"""Unit proofs for native calibration replay compilation."""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import types
+
+import numpy as np
+import pytest
+
+from nirs4all.pipeline.dagml.native_conformal_calibration import (
+    NativeConformalCalibrationError,
+    compile_methods_conformal_calibration_replay,
+)
+
+
+def _package() -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "training_outcome": {"outcome_fingerprint": "a" * 64},
+        "execution_bundle": {
+            "raw_artifact_payloads": {"artifact:model": [1, 2, 3]},
+            "refit_artifacts": [{"artifact_id": "artifact:model", "kind": "n4m_model"}],
+            "data_requirements": [
+                {
+                    "node_id": "model:base",
+                    "input_name": "x",
+                    "schema_fingerprint": "b" * 64,
+                    "plan_fingerprint": "c" * 64,
+                }
+            ],
+        },
+        "output_bindings": [
+            {
+                "binding_id": "binding:prediction",
+                "node_id": "model:base",
+                "target_names": ["y"],
+            }
+        ],
+    }
+
+
+def _install_fake_dagml(monkeypatch: pytest.MonkeyPatch) -> types.SimpleNamespace:
+    runtime = types.SimpleNamespace()
+
+    def fingerprint(payload: str) -> str:
+        return hashlib.sha256(payload.encode()).hexdigest()
+
+    def sign(request: dict[str, object]) -> dict[str, object]:
+        signed = dict(request)
+        signed["request_fingerprint"] = "d" * 64
+        return signed
+
+    runtime.sample_relation_set_fingerprint_json = fingerprint
+    runtime.sign_training_replay_request = sign
+    monkeypatch.setitem(sys.modules, "dag_ml_native_conformal_test", runtime)
+    return runtime
+
+
+def test_native_calibration_replay_preserves_exact_truth_and_identities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_dagml(monkeypatch)
+    replay = compile_methods_conformal_calibration_replay(
+        _package(),
+        np.asarray([[1.0], [2.0]]),
+        np.asarray([1.5, 2.5]),
+        sample_ids=["calibration.one", "calibration.two"],
+        groups=["g1", "g2"],
+        dagml_module="dag_ml_native_conformal_test",
+        methods_library_path="/native/libn4m.so",
+    )
+
+    assert replay.binding_id == "binding:prediction"
+    assert replay.truth == {
+        "sample_ids": ["calibration.one", "calibration.two"],
+        "values": [[1.5], [2.5]],
+    }
+    assert replay.execution.request["phase"] == "PREDICT"
+    assert replay.execution.request["request_fingerprint"] == "d" * 64
+    assert replay.calibration_relations["records"] == [
+        {
+            "observation_id": "calibration.one",
+            "sample_id": "calibration.one",
+            "target_id": None,
+            "group_id": "g1",
+            "origin_sample_id": None,
+            "source_id": None,
+            "is_augmented": False,
+            "metadata": {},
+        },
+        {
+            "observation_id": "calibration.two",
+            "sample_id": "calibration.two",
+            "target_id": None,
+            "group_id": "g2",
+            "origin_sample_id": None,
+            "source_id": None,
+            "is_augmented": False,
+            "metadata": {},
+        },
+    ]
+
+
+@pytest.mark.parametrize(
+    ("sample_ids", "y", "message"),
+    [
+        (None, np.asarray([1.0, 2.0]), "explicit sample_ids"),
+        (["one", "two"], np.asarray([1.0]), "row-aligned"),
+        (["one", "two"], np.asarray([1.0, np.nan]), "non-finite"),
+    ],
+)
+def test_native_calibration_replay_refuses_unattested_truth(
+    monkeypatch: pytest.MonkeyPatch,
+    sample_ids: object,
+    y: np.ndarray,
+    message: str,
+) -> None:
+    _install_fake_dagml(monkeypatch)
+    with pytest.raises(NativeConformalCalibrationError, match=message):
+        compile_methods_conformal_calibration_replay(
+            _package(),
+            np.asarray([[1.0], [2.0]]),
+            y,
+            sample_ids=sample_ids,  # type: ignore[arg-type]
+            dagml_module="dag_ml_native_conformal_test",
+        )


### PR DESCRIPTION
Phase 1 of native conformal calibration.

Adds an internal, strictly identity-bound calibration replay compiler. It does not yet route public `run(engine="native", calibration=...)`; that requires the next API phase and an end-to-end Methods proof.