### PR TITLE
fix(native): accept additive Methods ABI minors

### DIFF
--- a/nirs4all/pipeline/dagml/methods_runtime.py
+++ b/nirs4all/pipeline/dagml/methods_runtime.py
@@ -60,7 +60,11 @@ def _require_optimizer_abi(module: Any) -> None:
         raise DagMLNativeCoverageError(
             "installed n4m runtime could not report its ABI; upgrade nirs4all-methods"
         ) from error
-    if len(abi) != 3 or abi[0:2] != (2, 2):
+    # The native HPO/portable-replay surface was introduced in ABI 2.2.
+    # Methods ABI minor versions are additive, so a newer 2.x wheel remains
+    # compatible with the 2.2 symbols DAG-ML calls.  Requiring an exact minor
+    # version would reject a valid upgraded wheel before it can execute.
+    if len(abi) != 3 or abi[0] != 2 or abi[1] < 2:
         raise DagMLNativeCoverageError(
             "installed n4m runtime ABI is incompatible with native DAG-ML Methods execution; "
             "install nirs4all-methods>=1.0.10 or provide a compatible explicit "

--- a/tests/unit/pipeline/dagml/test_methods_runtime.py
+++ b/tests/unit/pipeline/dagml/test_methods_runtime.py
@@ -34,6 +34,22 @@ def test_bundled_methods_runtime_is_resolved_from_official_python_package(
     assert resolve_methods_library_path() == str(library.resolve())
 
 
+def test_bundled_methods_runtime_accepts_a_newer_additive_abi_minor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """The released 1.0.13 wheel carries ABI 2.3, compatible with 2.2."""
+
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"native")
+    module = SimpleNamespace(library_path=lambda: str(library), abi_version=lambda: (2, 3, 0))
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.methods_runtime.importlib.import_module",
+        lambda name: module if name == "n4m" else None,
+    )
+
+    assert resolve_methods_library_path() == str(library.resolve())
+
+
 def test_bundled_methods_runtime_refuses_the_pre_optimizer_abi(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:


### PR DESCRIPTION
## Summary
- accept ABI 2.x Methods wheels with a minor version at least 2
- preserve fail-closed rejection for incompatible or pre-optimizer ABIs
- cover the public 1.0.13 wheel ABI (2.3)

## Validation
- `python3.11 -m pytest tests/unit/pipeline/dagml/test_methods_runtime.py tests/unit/api/test_native_training.py tests/unit/api/test_native_result.py tests/unit/api/test_native_session.py tests/unit/api/test_native_archive_session.py tests/unit/api/test_engine_transition.py -q`
- `ruff check nirs4all/pipeline/dagml/methods_runtime.py tests/unit/pipeline/dagml/test_methods_runtime.py`
- `mypy --follow-imports=skip nirs4all/pipeline/dagml/methods_runtime.py`
- clean-wheel native process-cycle: train → Archive V2 export → fresh-process load/predict, exact output equality