### PR TITLE
fix(api): select native sessions at construction

### DIFF
--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 from collections.abc import Generator, Mapping
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 if TYPE_CHECKING:
     from nirs4all.api.native_session import NativeMethodsSession
@@ -170,6 +170,33 @@ class Session:
         >>> session.save("exports/my_model.n4a")
     """
 
+    def __new__(
+        cls,
+        pipeline: list[Any] | None = None,
+        name: str = "",
+        **runner_kwargs: Any,
+    ) -> Session:
+        """Select the session implementation before a legacy runner exists.
+
+        ``session(..., engine="native")`` has always constructed the native
+        session directly.  The public :class:`Session` constructor must obey
+        the same contract: accepting the selector and then retaining it as a
+        legacy ``PipelineRunner`` keyword would silently defeat the explicit
+        native request.
+        """
+
+        engine = runner_kwargs.get("engine", "legacy")
+        if cls is Session and engine == "native":
+            if pipeline is None:
+                raise ValueError("engine='native' session requires an explicit portable pipeline")
+            from nirs4all.api.native_session import NativeMethodsSession
+
+            native_kwargs = {
+                key: value for key, value in runner_kwargs.items() if key != "engine"
+            }
+            return cast(Session, NativeMethodsSession(pipeline, name=name, **native_kwargs))
+        return super().__new__(cls)
+
     def __init__(
         self,
         pipeline: list[Any] | None = None,
@@ -186,6 +213,12 @@ class Session:
                 Common options: verbose, save_artifacts, workspace_path,
                 random_state, plots_visible, etc.
         """
+        engine = runner_kwargs.pop("engine", "legacy")
+        if engine != "legacy":
+            from nirs4all.pipeline.engine import require_legacy_engine
+
+            require_legacy_engine("Session", engine)
+
         self._pipeline = pipeline
         self._name = name or "Session"
         self._runner_kwargs = runner_kwargs
@@ -490,7 +523,7 @@ class Session:
                 "Call session.run(dataset) first."
             )
 
-        return self._last_result.export(path)
+        return Path(self._last_result.export(path))
 
     def close(self) -> None:
         """Clean up session resources.

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -10,7 +10,7 @@ import pytest
 import nirs4all
 from nirs4all.api.native_result import NativeMethodsRunResult
 from nirs4all.api.native_session import NativeMethodsSession
-from nirs4all.api.session import session
+from nirs4all.api.session import Session, session
 
 
 class _Result:
@@ -70,6 +70,24 @@ def test_native_session_refuses_missing_pipeline_and_legacy_runner_kwargs() -> N
             pass
     with pytest.raises(TypeError, match="tuning must be a mapping"):
         NativeMethodsSession([], tuning=["methods-hpo"])  # type: ignore[arg-type]
+
+
+def test_public_session_constructor_selects_native_or_refuses_before_legacy_runner() -> None:
+    pipeline = [{"split": "stub"}, {"model": "stub"}]
+
+    native = Session(pipeline, engine="native", name="native", random_state=7)
+    assert isinstance(native, NativeMethodsSession)
+    assert native.pipeline is pipeline
+    assert native.random_state == 7
+
+    legacy = Session(pipeline, engine="legacy")
+    assert isinstance(legacy, Session)
+    assert "engine" not in legacy._runner_kwargs  # noqa: SLF001
+
+    with pytest.raises(NotImplementedError, match="does not have an execution path"):
+        Session(pipeline, engine="dag-ml")
+    with pytest.raises(ValueError, match="explicit portable pipeline"):
+        Session(engine="native")
 
 
 def test_native_session_binds_the_strict_methods_hpo_operation_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## R2 API session boundary

Makes `Session(..., engine="native")` select `NativeMethodsSession` before a legacy `PipelineRunner` can exist. Unsupported session engines remain fail-closed and the legacy selector is not retained as a runner keyword.

Validation:
- `pytest tests/unit/api/test_native_training.py tests/unit/api/test_native_result.py tests/unit/api/test_native_session.py tests/unit/api/test_native_archive_session.py tests/unit/api/test_engine_transition.py -q` (64 passed)
- `ruff check nirs4all/api/session.py tests/unit/api/test_native_session.py`
- `mypy --follow-imports=skip nirs4all/api/session.py`