### PR TITLE
chore(release): publish 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.1] — 2026-08-26
+
+### Fixed
+
+- Native Methods ABI checks now accept compatible additive runtime minors, and
+  native portable replay requires DAG-ML 0.3.9 so target-free PREDICT preserves
+  validated conformal intervals from the source training evidence.
+
+---
+
 ## [0.12.0] — 2026-08-07
 
 ### ⚙️ Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.12.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.1 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ If you use NIRS4ALL in your research, please cite:
   author = {Gregory Beurier and Denis Cornet and Lauriane Rouan},
   title = {NIRS4ALL: Open spectroscopy for everyone},
   url = {https://github.com/GBeurier/nirs4all},
-  version = {0.12.0},
+  version = {0.12.1},
   year = {2026},
 }
 ```

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.12.0 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.1 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -57,7 +57,7 @@ Synthetic Data Generation:
 See examples/ for more usage examples.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 # Module-level API (primary interface) - Phase 2
 from .api import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.8",
+    "dag-ml>=0.3.9",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.8",
+    "dag-ml>=0.3.9",
     "dag-ml-data>=0.2.9",
     "nirs4all-core[methods]>=0.3.15",
     # ABI 2.2 carries the optimizer symbols required by DAG-ML Methods training.

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.8
+dag-ml>=0.3.9
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.8
+dag-ml>=0.3.9
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.8
+dag-ml>=0.3.9
 dag-ml-data>=0.2.8


### PR DESCRIPTION
## Release 0.12.1

Requires DAG-ML 0.3.9 for native calibrated Archive V2 replay and includes the additive Methods ABI compatibility fix.

Validation:
- native API suite (68 passed)
- ruff and targeted mypy
- sdist/wheel build plus `twine check`
- fresh-environment two-process public cycle: native train + conformal → Archive V2 → fresh-process predict + intervals