### PR TITLE
fix(ci): use CPU-only Torch on Linux runners

### DIFF
--- a/.github/workflows/pre-publish.yml
+++ b/.github/workflows/pre-publish.yml
@@ -96,7 +96,12 @@ jobs:
             grep -v -E '^(jax|jaxlib|flax)' requirements-test.txt > requirements-test-win.txt
             python -m pip install numpy -r requirements-test-win.txt
           else
-            python -m pip install numpy -r requirements-test.txt
+            # Pin tests to the official CPU wheel: PyPI's Linux wheel may load
+            # CUDA/Triton during eager optimizer construction on a CPU runner.
+            grep -v '^torch' requirements-test.txt > requirements-test-linux.txt
+            python -m pip install numpy -r requirements-test-linux.txt
+            python -m pip install --index-url https://download.pytorch.org/whl/cpu \
+              'torch==2.13.0+cpu'
           fi
 
       - name: Install package (editable, no-deps — deps already from requirements-test.txt)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,13 @@ jobs:
             grep -v -E '^(jax|jaxlib|flax)' requirements-test.txt > requirements-test-win.txt
             python -m pip install numpy -r requirements-test-win.txt
           else
-            python -m pip install numpy -r requirements-test.txt
+            # PyPI's Linux wheel pulls CUDA/Triton dependencies even on a CPU
+            # runner. Install the official CPU wheel so eager Torch tests do
+            # not initialize the unsupported Triton runtime.
+            grep -v '^torch' requirements-test.txt > requirements-test-linux.txt
+            python -m pip install numpy -r requirements-test-linux.txt
+            python -m pip install --index-url https://download.pytorch.org/whl/cpu \
+              'torch==2.13.0+cpu'
           fi
 
       - name: Install package (editable, no-deps — deps already from requirements-test.txt)

--- a/.github/workflows/shared-test-and-docs.yml
+++ b/.github/workflows/shared-test-and-docs.yml
@@ -65,7 +65,12 @@ jobs:
             grep -v -E '^(jax|jaxlib|flax)' requirements-test.txt > requirements-test-win.txt
             python -m pip install numpy -r requirements-test-win.txt
           else
-            python -m pip install numpy -r requirements-test.txt
+            # Keep Linux tests on the official CPU wheel. The PyPI wheel pulls
+            # CUDA/Triton even on CPU runners, which is not a valid test target.
+            grep -v '^torch' requirements-test.txt > requirements-test-linux.txt
+            python -m pip install numpy -r requirements-test-linux.txt
+            python -m pip install --index-url https://download.pytorch.org/whl/cpu \
+              'torch==2.13.0+cpu'
           fi
 
       - name: Install package (editable, no-deps — deps already from requirements-test.txt)

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -616,6 +616,25 @@ def _native_param_variant_model_params(pipeline: Any, name: str) -> list[dict[st
         return []
 
 
+def _training_loss_generation_kind(pipeline: list[Any]) -> str:
+    """Classify generators while ignoring validated differentiable fit metadata.
+
+    ``train_params`` remains a Python-route marker in the general classifier:
+    generic controllers cannot be trusted to preserve it.  The public native
+    dispatcher invokes this helper only after it has confirmed the one
+    controller contract that explicitly consumes these parameters.
+    """
+
+    return _generation_kind(
+        [
+            {key: value for key, value in step.items() if key != "train_params"}
+            if isinstance(step, dict)
+            else step
+            for step in pipeline
+        ]
+    )
+
+
 def _dispatch_run(
     pipeline: Any,
     spectro: Any,
@@ -704,6 +723,16 @@ def _dispatch_run(
     detected_source_concat = _detect_source_concat_merge(list(pipeline), spectro.features_sources())
     augmentation_steps = [step for step in pipeline if _is_augmentation_step(step)]
 
+    # ``train_params`` is concrete execution metadata for the one registered
+    # differentiable controller, not a generator.  The general generator
+    # classifier deliberately treats it as an operator-route marker because
+    # most controllers cannot honour fit kwargs.  Here it has already passed
+    # the controller-specific allow-list above, so use a view without that
+    # metadata solely to decide whether a *real* generator is being combined
+    # with a process-local loss.  Keep the original pipeline for lowering so
+    # FIT_CV and REFIT still receive the parameters.
+    loss_routing_generation_kind = _training_loss_generation_kind(list(pipeline))
+
     if _has_finetune_params(list(pipeline)):
         raise NotImplementedError("engine='dag-ml' did not lower finetune_params before native dispatch; this is an internal routing bug, not a supported execution path.")
     if _has_stateful_concat_transform(list(pipeline)):
@@ -722,7 +751,7 @@ def _dispatch_run(
         or detected_source_concat is not None
         or augmentation_steps
         or _is_repetition_dataset(spectro)
-        or _generation_kind(list(pipeline)) != "none"
+        or loss_routing_generation_kind != "none"
         or any(_is_exclude_step(step) for step in pipeline)
     ):
         raise DagMlUnsupported(

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -31,6 +31,7 @@ import numpy as np
 
 from nirs4all.api.result import RunResult
 from nirs4all.core.metrics import is_higher_better
+from nirs4all.pipeline.dagml_bridge import _model_controller_id
 
 from .dataset import _dataset_inputs, _materialize_dataset
 from .detect import (
@@ -649,7 +650,21 @@ def _dispatch_run(
     from nirs4all.core import detect_task_type
 
     pipeline, finetune_overrides = _lower_public_finetune_params(pipeline)
-    reject_native_training_param_overrides(list(pipeline), context="engine='dag-ml'")
+    model_steps = [step for step in pipeline if isinstance(step, dict) and "model" in step]
+    # A dedicated differentiable-model controller receives ``train_params`` in
+    # the portable node metadata and consumes them in both FIT_CV and REFIT.
+    # Generic controllers have no such contract, so retain the fail-closed
+    # rejection rather than silently dropping fit arguments.
+    allowed_training_param_keys = (
+        frozenset({"train_params"})
+        if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None
+        else frozenset()
+    )
+    reject_native_training_param_overrides(
+        list(pipeline),
+        context="engine='dag-ml'",
+        allowed_keys=allowed_training_param_keys,
+    )
     config_name = _derive_config_name(pipeline, name)
     # The ordered legacy per-variant config names for a SWEEP (empty for a single concrete pipeline). The
     # native-generation and operator-expand paths below project EVERY variant's CV rows (legacy

--- a/tests/regression/test_public_api_contract.py
+++ b/tests/regression/test_public_api_contract.py
@@ -58,25 +58,26 @@ EXPECTED_SIGNATURES: dict[str, str] = {
         "nirs4all.data.config.DatasetConfigs | list[str | pathlib.Path | numpy.ndarray | "
         "tuple[numpy.ndarray, ...] | dict[str, typing.Any] | "
         "nirs4all.data.dataset.SpectroDataset | nirs4all.data.config.DatasetConfigs], *, "
-        "name: str = '', session: nirs4all.api.session.Session | None = None, "
+        "name: str = '', session: nirs4all.api.session.Session | nirs4all.api.native_session.NativeMethodsSession | None = None, "
         "verbose: int = 1, save_artifacts: bool = True, save_charts: bool = True, "
         "plots_visible: bool = False, random_state: int | None = None, "
         "refit: bool | dict[str, typing.Any] | list[dict[str, typing.Any]] | None = True, "
         "cache: typing.Any | None = None, project: str | None = None, "
         "report_naming: str = 'nirs', engine: str | None = None, "
         "tuning: typing.Any | None = None, calibration: typing.Any | None = None, "
-        "results_path: str | pathlib.Path | None = None, **runner_kwargs: Any) -> "
-        "'RunResult | TunedSingleEstimatorConformalResult'"
+        "results_path: str | pathlib.Path | None = None, training_losses: tuple[collections.abc.Mapping[str, typing.Any], ...] = (), "
+        "local_implementations: typing.Any | None = None, **runner_kwargs: Any) -> "
+        "'RunResult | NativeMethodsRunResult | TunedSingleEstimatorConformalResult'"
     ),
     "predict": (
         "(model: 'ModelSpec | None' = None, data: 'DataSpec | None' = None, *, "
         "chain_id: 'str | None' = None, workspace_path: 'str | Path | None' = None, "
         "name: 'str' = 'prediction_dataset', all_predictions: 'bool' = False, "
-        "session: 'Session | None' = None, verbose: 'int' = 0, "
+        "session: 'Session | NativeArchiveSession | NativeMethodsSession | None' = None, verbose: 'int' = 0, "
         "coverage: 'float | list[float] | tuple[float, ...] | None' = None, "
         "save_to_workspace: 'bool' = False, workspace_metadata: 'Mapping[str, Any] | None' = None, "
         "workspace_result_metadata: 'Mapping[str, Any] | None' = None, "
-        "**runner_kwargs: 'Any') -> 'PredictResult'"
+        "methods_library_path: 'str | Path | None' = None, **runner_kwargs: 'Any') -> 'PredictResult'"
     ),
     "explain": (
         "(model: dict[str, typing.Any] | str | pathlib.Path, "
@@ -89,7 +90,7 @@ EXPECTED_SIGNATURES: dict[str, str] = {
         "nirs4all.api.result.ExplainResult"
     ),
     "retrain": (
-        "(source: dict[str, typing.Any] | str | pathlib.Path, "
+        "(source: nirs4all.api.native_result.NativeMethodsRunResult | dict[str, typing.Any] | str | pathlib.Path, "
         "data: str | pathlib.Path | numpy.ndarray | tuple[numpy.ndarray, ...] | "
         "dict[str, typing.Any] | nirs4all.data.dataset.SpectroDataset | "
         "nirs4all.data.config.DatasetConfigs, *, mode: str = 'full', "
@@ -98,15 +99,15 @@ EXPECTED_SIGNATURES: dict[str, str] = {
         "session: nirs4all.api.session.Session | None = None, verbose: int = 1, "
         "save_artifacts: bool = True, **kwargs: Any) -> nirs4all.api.result.RunResult"
     ),
-    "session": ("(pipeline: list[typing.Any] | None = None, name: str = '', **kwargs: Any) -> collections.abc.Generator[nirs4all.api.session.Session, None, None]"),
-    "load_session": ("(path: str | pathlib.Path) -> nirs4all.api.session.Session"),
+    "session": ("(pipeline: 'list[Any] | None' = None, name: 'str' = '', **kwargs: 'Any') -> 'Generator[Session | NativeMethodsSession, None, None]'"),
+    "load_session": ("(path: 'str | Path', *, engine: 'str' = 'legacy', methods_library_path: 'str | Path | None' = None) -> 'Session | NativeArchiveSession'"),
     "generate": (
         "(n_samples: 'int' = 1000, *, random_state: 'int | None' = None, "
         "complexity: \"Literal['simple', 'realistic', 'complex']\" = 'simple', "
         "wavelength_range: 'tuple[float, float] | None' = None, "
         "components: 'list[str] | None' = None, "
         "target_range: 'tuple[float, float] | None' = None, train_ratio: 'float' = 0.8, "
-        "as_dataset: 'bool' = True, name: 'str' = 'synthetic_nirs', **kwargs: 'Any') -> "
+        "as_dataset: 'bool' = True, name: 'str' = 'synthetic_nirs', engine: 'str | None' = None, **kwargs: 'Any') -> "
         "'SpectroDataset | tuple[np.ndarray, np.ndarray]'"
     ),
     "tune_single_estimator": (
@@ -298,6 +299,8 @@ EXPECTED_PACKAGE_ALL: list[str] = [
     "ConformalMetricSet",
     "ConformalMultiTarget",
     "ConformalUnit",
+    "DualRunMismatchError",
+    "DualRunUnsupported",
     "ExplainResult",
     "FINETUNE_APPROACHES",
     "FINETUNE_DAGML_APPROACHES",
@@ -319,6 +322,9 @@ EXPECTED_PACKAGE_ALL: list[str] = [
     "FinetuneEvalMode",
     "FinetunePruner",
     "FinetuneSampler",
+    "NativeArchiveSession",
+    "NativeMethodsRunResult",
+    "NativeMethodsSession",
     "NativeTuning",
     "Nirs4AllCalibrationNotImplementedError",
     "OrderedSearchSpaceSpec",
@@ -367,6 +373,7 @@ EXPECTED_PACKAGE_ALL: list[str] = [
     "conformal_metrics",
     "explain",
     "export_calibrated_result",
+    "fit_native_pipeline",
     "framework",
     "generate",
     "generate_run_id",
@@ -381,6 +388,7 @@ EXPECTED_PACKAGE_ALL: list[str] = [
     "keyword_registry_json",
     "keyword_registry_schema_json",
     "load_calibrated_result",
+    "load_native_archive_session",
     "load_session",
     "load_workspace_calibrated_predict_result",
     "load_workspace_calibrated_result",
@@ -418,6 +426,8 @@ EXPECTED_API_ALL: list[str] = [
     "ConformalMetricSet",
     "ConformalMultiTarget",
     "ConformalUnit",
+    "DualRunMismatchError",
+    "DualRunUnsupported",
     "ExplainResult",
     "FINETUNE_APPROACHES",
     "FINETUNE_DAGML_APPROACHES",
@@ -441,6 +451,9 @@ EXPECTED_API_ALL: list[str] = [
     "FinetuneSampler",
     "LazyModelRefitResult",
     "ModelRefitResult",
+    "NativeArchiveSession",
+    "NativeMethodsRunResult",
+    "NativeMethodsSession",
     "NativeTuning",
     "Nirs4AllCalibrationNotImplementedError",
     "OrderedSearchSpaceSpec",
@@ -484,6 +497,7 @@ EXPECTED_API_ALL: list[str] = [
     "conformal_metrics",
     "explain",
     "export_calibrated_result",
+    "fit_native_pipeline",
     "generate",
     "get_keyword_registry",
     "get_keyword_registry_schema",
@@ -494,6 +508,7 @@ EXPECTED_API_ALL: list[str] = [
     "keyword_registry_json",
     "keyword_registry_schema_json",
     "load_calibrated_result",
+    "load_native_archive_session",
     "load_session",
     "load_workspace_calibrated_predict_result",
     "load_workspace_calibrated_result",

--- a/tests/unit/pipeline/dagml/test_finetune_lowering.py
+++ b/tests/unit/pipeline/dagml/test_finetune_lowering.py
@@ -14,6 +14,19 @@ from nirs4all.pipeline.dagml.detect import _generation_kind
 from nirs4all.pipeline.dagml.finetune_lowering import (
     lower_deterministic_finetune_params_to_generators,
 )
+from nirs4all.pipeline.dagml.run_backend import _training_loss_generation_kind
+
+
+def test_local_loss_routing_treats_allowed_train_params_as_concrete_metadata() -> None:
+    """A differentiable controller's fixed fit arguments are not a generator."""
+
+    pipeline = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "train_params": {"epochs": 1}},
+    ]
+
+    assert _generation_kind(pipeline) == "operator"
+    assert _training_loss_generation_kind(pipeline) == "none"
 
 
 def test_deterministic_finetune_plain_grid_lowers_to_step_grid() -> None:


### PR DESCRIPTION
## Summary

Use the official CPU-only Torch wheel for Linux test jobs. PyPI’s Torch 2.13 wheel pulled CUDA/Triton dependencies, which crashed while importing Dynamo on the CPU GitHub runner.

## Validation

- YAML parse of all updated workflows
- `python3.11 -m pytest -q -o addopts='' -p no:xdist tests/unit/pipeline/dagml/test_raw_training_lowerer.py tests/integration/parity/test_dagml_run_selector.py` (27 passed, 13 skipped)
- `git diff --check`

The release workflow will exercise the real CPU Torch matrix before PyPI publication.