### PR TITLE
chore(release): prepare 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.2] — 2026-08-26
+
+### Fixed
+
+- Use the official CPU-only PyTorch wheel on Linux CI runners. The PyPI CUDA/Triton
+  wheel could crash during eager optimizer creation although nirs4all does not
+  request compilation.
+- Preserve process-local differentiable training parameters and route local losses
+  through the native DAG-ML training phases.
+
+---
+
 ## [0.12.1] — 2026-08-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.12.1 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.2 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.12.1 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.2 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -57,7 +57,7 @@ Synthetic Data Generation:
 See examples/ for more usage examples.
 """
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 # Module-level API (primary interface) - Phase 2
 from .api import (


### PR DESCRIPTION
## Summary

Prepare patch release 0.12.2 after the 0.12.1 GitHub release failed before PyPI publication. This release includes the native local-loss correction and CPU-only Linux Torch CI guard.

## Validation

- `python3.11 -m pytest -q -o addopts='' -p no:xdist tests/unit/pipeline/dagml/test_raw_training_lowerer.py tests/integration/parity/test_dagml_run_selector.py` (27 passed, 13 skipped)
- `python3.11 -m build --sdist --wheel`
- workflow YAML parse
- `git diff --check`

Tag `0.12.2` is attached to this release commit; publishing remains gated by the release workflow test matrix.