### PR TITLE
fix(native): add strict DAG-ML fallback control

### DIFF
--- a/docs/source/getting_started/hello_world.md
+++ b/docs/source/getting_started/hello_world.md
@@ -242,6 +242,38 @@ N4A_ENGINE=dag-ml python train.py
 
 If the dag-ml backend is unavailable, or the requested pipeline shape is outside current dag-ml coverage, NIRS4ALL warns and falls back to the legacy engine for catchable unsupported cases.
 
+### Require a native result during migration qualification
+
+During a native migration or a release qualification, make the fallback policy
+explicit. `allow_legacy_fallback=False` turns an unavailable or unsupported
+DAG-ML request into an error before a legacy workspace is created:
+
+```python
+result = nirs4all.run(
+    pipeline="pipeline.yaml",
+    dataset="dataset.yaml",
+    engine="dag-ml",
+    allow_legacy_fallback=False,
+    random_state=42,
+)
+```
+
+This is a qualification switch, not the package default. The default remains
+compatible with existing workflows while native coverage is expanded. A generic
+`RunResult` that does not retain a native Package/Archive artifact also cannot
+be exported through the old refit bridge in strict mode:
+
+```python
+result.export(
+    "exports/qualified-result.n4a",
+    allow_legacy_refit=False,
+)
+```
+
+For a currently supported end-to-end portable workflow, use the strict Methods
+lane documented in {doc}`/api/module_api`; it retains the native Package and
+N4MM evidence needed for Archive V2/V3 export.
+
 ## Next Clicks
 
 - {doc}`/reference/nodes/index` lists every pipeline node keyword and where to use it.

--- a/docs/source/getting_started/hello_world.md
+++ b/docs/source/getting_started/hello_world.md
@@ -260,15 +260,16 @@ result = nirs4all.run(
 
 This is a qualification switch, not the package default. The default remains
 compatible with existing workflows while native coverage is expanded. A generic
-`RunResult` that does not retain a native Package/Archive artifact also cannot
-be exported through the old refit bridge in strict mode:
+`RunResult` that does not retain a native Package/Archive artifact also refuses
+the old refit bridge by default:
 
 ```python
-result.export(
-    "exports/qualified-result.n4a",
-    allow_legacy_refit=False,
-)
+result.export("exports/qualified-result.n4a")
 ```
+
+If compatibility with the historic `.n4a` writer is deliberately required,
+`compatibility="legacy-refit"` opts into that documented, best-effort refit.
+It is not a native export and must not be used as migration evidence.
 
 For a currently supported end-to-end portable workflow, use the strict Methods
 lane documented in {doc}`/api/module_api`; it retains the native Package and

--- a/docs/source/getting_started/hello_world.md
+++ b/docs/source/getting_started/hello_world.md
@@ -11,9 +11,13 @@ This is the shortest useful NIRS4ALL workflow. A dataset is described in YAML or
 | Run training from YAML/JSON | Yes | No native `run` command yet | Via Python bridge/wrapper | Via Python bridge/wrapper | Via process/runtime wrapper |
 | Use native operators as objects | Yes | No | Through Python bridge | Through Python bridge | No native object API in this repo |
 | Export `.n4a` bundle | Yes | Workspace/artifact tooling only | Via Python bridge/wrapper | Via Python bridge/wrapper | Via process/runtime wrapper |
-| Select `dag-ml` engine | `engine="dag-ml"` or `N4A_ENGINE=dag-ml` | Environment only for wrapped Python run | Same wrapped call | Same wrapped call | Same wrapped call |
+| Select `dag-ml` training engine | `run(..., engine="dag-ml")` or `N4A_ENGINE=dag-ml` | Environment only for wrapped Python `run` | Same wrapped call | Same wrapped call | Same wrapped call |
 
 The portable part is the configuration pair below. Language wrappers should keep those files unchanged.
+
+`N4A_ENGINE=dag-ml` selects the training backend for `nirs4all.run`. Public
+helpers that do not yet provide a DAG-ML execution path refuse the environment
+selection instead of silently switching themselves back to the legacy engine.
 
 ## 1. Describe the Dataset
 

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -238,7 +238,7 @@ Environment switches:
 
 | Variable | Effect |
 | --- | --- |
-| `N4A_ENGINE=dag-ml` | Request dag-ml for calls that do not pass `engine=` explicitly. |
+| `N4A_ENGINE=dag-ml` | Request dag-ml for `nirs4all.run` calls that do not pass `engine=` explicitly. A public helper with no DAG-ML path refuses this selection rather than silently using legacy. |
 | `N4A_NATIVE_RESULTS=/path/to/results` | For dag-ml runs, request native result output. |
 
 ## CLI Commands

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -212,14 +212,26 @@ if (run.status !== 0) process.exit(run.status);
 
 The pipeline language is broader than current dag-ml native coverage. Requesting `engine="dag-ml"` is safe for user workflows because catchable unsupported shapes and unavailable dag-ml runtime dependencies warn and re-run on the legacy engine. A genuine dag-ml runtime/operator bug still propagates as an error.
 
+For migration qualification, set `allow_legacy_fallback=False`. In that mode a
+catchable unavailable or unsupported DAG-ML request is returned to the caller
+as an error before any legacy execution starts:
+
 ```python
 result = nirs4all.run(
     pipeline="pipeline.yaml",
     dataset="dataset.yaml",
     engine="dag-ml",
+    allow_legacy_fallback=False,
     random_state=42,
 )
 ```
+
+The same distinction applies to generic result export. The default bridge can
+still perform a legacy refit for compatibility, while
+`result.export(..., allow_legacy_refit=False)` refuses unless the result already
+has the native portable Package/Archive evidence required for export. Neither
+switch changes the default engine; they provide an auditable no-fallback path
+while native coverage is being qualified.
 
 Environment switches:
 

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -226,12 +226,13 @@ result = nirs4all.run(
 )
 ```
 
-The same distinction applies to generic result export. The default bridge can
-still perform a legacy refit for compatibility, while
-`result.export(..., allow_legacy_refit=False)` refuses unless the result already
-has the native portable Package/Archive evidence required for export. Neither
-switch changes the default engine; they provide an auditable no-fallback path
-while native coverage is being qualified.
+The same distinction applies to generic result export. It refuses a DAG-ML
+score-only result unless native portable Package/Archive evidence is available.
+The historic refit bridge is an explicit compatibility opt-in:
+`result.export(..., compatibility="legacy-refit")`. It is best-effort rather
+than native evidence, and neither switch changes the default engine; together
+they provide an auditable no-fallback path while native coverage is being
+qualified.
 
 Environment switches:
 

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -609,6 +609,7 @@ def run(
     project: str | None = None,
     report_naming: str = "nirs",
     engine: str | None = None,
+    allow_legacy_fallback: bool | None = None,
     tuning: Any | None = None,
     calibration: Any | None = None,
     results_path: str | Path | None = None,
@@ -697,6 +698,10 @@ def run(
             no-fallback oracle for the small explicit-array/KFold/PLSRegression subset; it raises a
             typed error for every other shape or unavailable native capability. Override the default
             per-process with ``$N4A_ENGINE`` (e.g. ``$N4A_ENGINE=dag-ml``).
+        allow_legacy_fallback: Transitional policy for ``engine="dag-ml"``.
+            ``None`` preserves the catchable compatibility fallback. ``False``
+            refuses unavailable or unsupported DAG-ML requests before the
+            legacy engine is constructed; ``True`` explicitly permits it.
             ``engine='native'`` runs the verified portable Methods subset: a
             raw ``{'X', 'y', 'sample_ids'}`` dataset, one supported linear
             KFold/PLS pipeline, ``refit=True``, ``save_artifacts=True`` and

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -866,6 +866,9 @@ def run(
         - :func:`nirs4all.session`: Create execution session for resource reuse
         - :class:`nirs4all.PipelineRunner`: Direct runner access for advanced use
     """
+    if allow_legacy_fallback is not None and not isinstance(allow_legacy_fallback, bool):
+        raise TypeError("allow_legacy_fallback must be True, False, or None")
+
     selected_engine = resolve_engine(engine)
     custom_training_loss_requested = bool(training_losses) or local_implementations is not None
     if custom_training_loss_requested and selected_engine != "dag-ml":
@@ -1246,7 +1249,7 @@ def run(
                 local_implementations=local_implementations,
             )
         except DagMlUnavailable as e:
-            if custom_training_loss_requested:
+            if custom_training_loss_requested or allow_legacy_fallback is False:
                 raise
             warnings.warn(
                 f"the dag-ml backend is not available ({e}); falling back to the legacy engine",
@@ -1254,7 +1257,7 @@ def run(
             )
             return _run_legacy()
         except (DagMlUnsupported, NotImplementedError) as e:
-            if custom_training_loss_requested:
+            if custom_training_loss_requested or allow_legacy_fallback is False:
                 raise
             warnings.warn(
                 f"engine='dag-ml' does not support this pipeline shape ({e}); falling back to the legacy engine",

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -89,6 +89,13 @@ def require_legacy_engine(operation: str, engine: str | None = None) -> Engine:
     if selected != "legacy":
         if selected == "dual":
             raise DualRunUnsupported(f"nirs4all.{operation} does not support engine='dual'; the strict dual oracle is implemented only for nirs4all.run on its documented subset.")
+        if selected == "dag-ml":
+            raise NotImplementedError(
+                f"nirs4all.{operation} does not have a dag-ml execution path yet; it does not "
+                "have an execution path under dag-ml. Use "
+                "engine='legacy' for this transition release. nirs4all.run supports "
+                "engine='dag-ml' with documented fallback boundaries."
+            )
         raise NotImplementedError(
             f"nirs4all.{operation} does not have an execution path for engine='{selected}' yet; use "
             "engine='legacy' for this transition release. nirs4all.run supports "

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -24,7 +24,6 @@ Selection precedence: explicit argument > ``$N4A_ENGINE`` env var > :data:`DEFAU
 from __future__ import annotations
 
 import os
-import warnings
 from collections.abc import Mapping
 from typing import Any, Literal, cast
 
@@ -90,17 +89,9 @@ def require_legacy_engine(operation: str, engine: str | None = None) -> Engine:
     if selected != "legacy":
         if selected == "dual":
             raise DualRunUnsupported(f"nirs4all.{operation} does not support engine='dual'; the strict dual oracle is implemented only for nirs4all.run on its documented subset.")
-        env_requested = (os.environ.get(ENGINE_ENV_VAR) or "").strip().lower()
-        if engine is None and env_requested == "dag-ml":
-            warnings.warn(
-                f"{ENGINE_ENV_VAR}=dag-ml is ignored for nirs4all.{operation} in this transition "
-                "release because this helper does not have a dag-ml execution path yet; using "
-                "engine='legacy'. Pass engine='dag-ml' explicitly to fail fast.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-            return "legacy"
         raise NotImplementedError(
-            f"nirs4all.{operation} does not have an execution path for engine={selected!r}; use engine='legacy' for this transition release. nirs4all.run supports engine='dag-ml' with documented fallback boundaries."
+            f"nirs4all.{operation} does not have a {selected} execution path yet; use "
+            "engine='legacy' for this transition release. nirs4all.run supports "
+            "engine='dag-ml' with documented fallback boundaries."
         )
     return selected

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -90,7 +90,7 @@ def require_legacy_engine(operation: str, engine: str | None = None) -> Engine:
         if selected == "dual":
             raise DualRunUnsupported(f"nirs4all.{operation} does not support engine='dual'; the strict dual oracle is implemented only for nirs4all.run on its documented subset.")
         raise NotImplementedError(
-            f"nirs4all.{operation} does not have a {selected} execution path yet; use "
+            f"nirs4all.{operation} does not have an execution path for engine='{selected}' yet; use "
             "engine='legacy' for this transition release. nirs4all.run supports "
             "engine='dag-ml' with documented fallback boundaries."
         )

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -67,10 +67,11 @@ def test_run_dispatches_to_dagml_engine_native() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         result = nirs4all.run(
-            [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
-            dataset_path("regression"),
-            engine="dag-ml",
-        )
+        [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+        dataset_path("regression"),
+        engine="dag-ml",
+        allow_legacy_fallback=False,
+    )
     assert isinstance(result, RunResult)
     assert result.num_predictions > 0
     assert not any(_FALLBACK_WARNING in str(w.message) for w in caught)

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -310,7 +310,11 @@ def test_run_rejects_process_local_losses_on_native_tuning_bypass() -> None:
         )
 
 
-def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("fallback_policy", [None, True], ids=["default", "explicit"])
+def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    fallback_policy: bool | None,
+) -> None:
     """An explicit ``engine="dag-ml"`` run() transparently falls back to the LEGACY engine WITH A
     WARNING when the dag-ml backend is unavailable — simulated by the preflight raising
     DagMlUnavailable. The result is a valid legacy RunResult, never an exception. (dag-ml is selected
@@ -329,10 +333,14 @@ def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(monkeypatch: py
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
+        kwargs = {}
+        if fallback_policy is not None:
+            kwargs["allow_legacy_fallback"] = fallback_policy
         result = nirs4all.run(
             [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
             dataset_path("regression"),
             engine="dag-ml",
+            **kwargs,
         )
     assert isinstance(result, RunResult)
     assert result.num_predictions > 0
@@ -376,6 +384,17 @@ def test_dagml_run_strict_mode_refuses_unsupported_shape_without_legacy_fallback
             dataset_path("regression"),
             engine="dag-ml",
             allow_legacy_fallback=False,
+        )
+
+
+def test_dagml_run_rejects_non_boolean_fallback_policy_before_dispatch() -> None:
+    """The migration switch is closed rather than truthiness-coerced."""
+    with pytest.raises(TypeError, match="allow_legacy_fallback must be True, False, or None"):
+        nirs4all.run(
+            [{"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            allow_legacy_fallback="legacy",  # type: ignore[arg-type]
         )
 
 

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -338,6 +338,46 @@ def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(monkeypatch: py
     assert any("dag-ml backend is not available" in str(w.message) for w in caught)
 
 
+def test_dagml_run_strict_mode_refuses_unavailable_backend_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """R2 qualification mode propagates a backend refusal before legacy work starts."""
+    import nirs4all.pipeline.dagml.run_backend as run_backend
+    from nirs4all.pipeline.dagml.errors import DagMlUnavailable
+
+    def _unavailable(_cli: str) -> None:
+        raise DagMlUnavailable("simulated: strict native backend unavailable")
+
+    monkeypatch.setattr(run_backend, "preflight_dagml_backend", _unavailable)
+    with pytest.raises(DagMlUnavailable, match="strict native backend unavailable"):
+        nirs4all.run(
+            [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            allow_legacy_fallback=False,
+        )
+
+
+def test_dagml_run_strict_mode_refuses_unsupported_shape_without_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A declared coverage boundary is not downgraded to a legacy run in strict mode."""
+    import nirs4all.pipeline.dagml.run_backend as run_backend
+    from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+
+    def _unsupported(*_args: object, **_kwargs: object) -> RunResult:
+        raise DagMlUnsupported("simulated: strict native shape unsupported")
+
+    monkeypatch.setattr(run_backend, "run_via_dagml", _unsupported)
+    with pytest.raises(DagMlUnsupported, match="strict native shape unsupported"):
+        nirs4all.run(
+            [{"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            allow_legacy_fallback=False,
+        )
+
+
 @pytest.mark.parametrize(
     "option",
     [

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -589,8 +589,8 @@ def test_predict_native_archive_fails_closed_before_execution(monkeypatch: pytes
         "retrain",
     ],
 )
-def test_public_helpers_ignore_dagml_env_with_warning(monkeypatch: pytest.MonkeyPatch, operation: str) -> None:
+def test_public_helpers_refuse_dagml_env_without_legacy_fallback(monkeypatch: pytest.MonkeyPatch, operation: str) -> None:
     monkeypatch.setenv("N4A_ENGINE", "dag-ml")
 
-    with pytest.warns(RuntimeWarning, match=rf"N4A_ENGINE=dag-ml.*nirs4all\.{operation}.*legacy"):
-        assert require_legacy_engine(operation) == "legacy"
+    with pytest.raises(NotImplementedError, match=rf"nirs4all\.{operation} does not have a dag-ml execution path"):
+        require_legacy_engine(operation)


### PR DESCRIPTION
## Summary

- add `allow_legacy_fallback=False` to make a DAG-ML qualification run fail closed instead of constructing a legacy fallback
- refuse implicit `N4A_ENGINE=dag-ml` fallback for public helpers with no DAG-ML execution path
- document the strict run policy and the existing explicit legacy-refit export compatibility switch

## Validation

- `python3.11 -m pytest -q tests/unit/api/test_engine_transition.py tests/unit/api/test_result.py tests/integration/parity/test_dagml_run_selector.py` — 140 passed, 7 skipped
- targeted Ruff — pass
- Sphinx strict HTML build — pass

This is rebased directly on current `main`; it deliberately excludes historical native commits already integrated under prior PRs.