### PR TITLE
feat(native): expose attested TPE/Median HPO

### DIFF
--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -126,16 +126,18 @@ with nirs4all.session(pipeline, engine="native") as native:
     result.export("model.n4a")
 ```
 
-The only native tuning request is
-``{"engine": "methods-hpo", "trials": N}``: it uses the DAG-ML Methods
-controller with the attested V1 PLS ``n_components`` search space, random
-sampling and no pruner. A session can bind that same request once:
+The native tuning request is ``{"engine": "methods-hpo", "trials": N}``.
+It may additionally select ``sampler="random"|"tpe"`` and
+``pruner="none"|"median"``. It uses the DAG-ML Methods controller with the
+attested V1 PLS ``n_components`` search space; no Python objective, callback,
+intermediate score or optimizer-specific setting can be injected. A session
+can bind that same request once:
 
 ```python
 with nirs4all.session(
     pipeline,
     engine="native",
-    tuning={"engine": "methods-hpo", "trials": 8},
+    tuning={"engine": "methods-hpo", "trials": 8, "sampler": "tpe", "pruner": "median"},
 ) as native:
     result = native.run(dataset)
 ```

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -154,10 +154,11 @@ def run_native_methods(
     than becoming ignored legacy arguments.
 
     ``tuning`` is deliberately a separate, strict native operation rather
-    than the older Python objective adapter.  Its only accepted V1 shape is
-    ``{"engine": "methods-hpo", "trials": N}`` with the fixed V1
-    random/no-pruner policy.  DAG-ML owns all trial execution, SELECT, native
-    incumbent attestation, and the single selected rerun/refit.
+    than the older Python objective adapter.  Its V1 shape is
+    ``{"engine": "methods-hpo", "trials": N}``, optionally selecting the
+    attested ``random``/``tpe`` sampler and ``none``/``median`` pruner.  DAG-ML
+    owns all trial execution, SELECT, native incumbent attestation, and the
+    single selected rerun/refit.
     """
 
     if not isinstance(dataset, Mapping):
@@ -210,8 +211,8 @@ def run_native_methods(
     )
 
 
-_NATIVE_METHODS_HPO_SAMPLERS = frozenset({"random"})
-_NATIVE_METHODS_HPO_PRUNERS = frozenset({"none"})
+_NATIVE_METHODS_HPO_SAMPLERS = frozenset({"random", "tpe"})
+_NATIVE_METHODS_HPO_PRUNERS = frozenset({"none", "median"})
 _NATIVE_CONFORMAL_POLICIES = frozenset({"marginal", "joint_max"})
 _NATIVE_CONFORMAL_SMALL_SAMPLE_POLICIES = frozenset({"error", "unbounded"})
 
@@ -354,7 +355,10 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
     ``space``, ``score_data``, callbacks, or workspace resume fields: those
     belong to the historical Python objective path.  The V1 native search
     space is attested by DAG-ML and intentionally fixes PLS ``n_components``
-    to the portable 1..=3 integer domain.
+    to the portable 1..=3 integer domain.  TPE and the Median pruner remain
+    controller-owned: the public payload cannot provide an objective,
+    intermediate scores, callbacks, or optimiser-specific knobs.  A two-trial
+    startup budget is fixed whenever either needs historical observations.
     """
 
     if tuning is None:
@@ -377,6 +381,7 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
         raise ValueError(f"engine='native' Methods HPO sampler is unsupported: {sampler!r}")
     if pruner not in _NATIVE_METHODS_HPO_PRUNERS:
         raise ValueError(f"engine='native' Methods HPO pruner is unsupported: {pruner!r}")
+    n_startup_trials = 2 if sampler == "tpe" or pruner == "median" else 0
     return {
         "operation_id": "hpo:methods",
         "study": {
@@ -401,7 +406,7 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
                 "direction": "minimize",
                 "metric": "rmse",
                 "seed": seed,
-                "n_startup_trials": 0,
+                "n_startup_trials": n_startup_trials,
                 "max_resource": 0,
                 "reduction_factor": 0,
             },

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -708,11 +708,13 @@ def run(
             ``save_charts=False``. Unsupported workflow features are refused
             before execution; this path never falls through to the legacy
             orchestrator.  Its optional strict HPO V1 operation is
-            ``tuning={'engine': 'methods-hpo', 'trials': N}``; it is executed
-            by DAG-ML's native Methods scheduler, not by the older Python
-            objective adapter.  The V1 search space is the attested integer
-            PLS ``n_components`` domain 1..3, and its checkpoint/evidence is
-            available on ``NativeMethodsRunResult`` after a successful run.
+            ``tuning={'engine': 'methods-hpo', 'trials': N}``, optionally
+            with ``sampler='random'|'tpe'`` and
+            ``pruner='none'|'median'``; it is executed by DAG-ML's native
+            Methods scheduler, not by the older Python objective adapter.
+            The V1 search space is the attested integer PLS ``n_components``
+            domain 1..3, and its checkpoint/evidence is available on
+            ``NativeMethodsRunResult`` after a successful run.
             The dual subset requires exact built-in ``list``/``dict`` and exact NumPy arrays,
             ``KFold(shuffle=False)``, ``PLSRegression``, finite floating-point ``X`` and continuous
             regression ``y``,

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -344,7 +344,8 @@ def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
         ({"trials": 2}, "requires engine='methods-hpo'"),
         ({"engine": "methods-hpo", "trials": 0}, "integer in 1..64"),
         ({"engine": "methods-hpo", "trials": 2, "score_data": {}}, "unsupported keys"),
-        ({"engine": "methods-hpo", "trials": 2, "sampler": "tpe"}, "sampler is unsupported"),
+        ({"engine": "methods-hpo", "trials": 2, "sampler": "sobol"}, "sampler is unsupported"),
+        ({"engine": "methods-hpo", "trials": 2, "pruner": "asha"}, "pruner is unsupported"),
     ],
 )
 def test_run_native_refuses_generic_or_partial_tuning_before_execution(
@@ -364,6 +365,30 @@ def test_run_native_refuses_generic_or_partial_tuning_before_execution(
             save_charts=False,
             tuning=tuning,
         )
+
+
+def test_native_tpe_median_hpo_descriptor_is_closed_and_attested() -> None:
+    """TPE/Median is native scheduler configuration, never a Python objective."""
+
+    from nirs4all.api.native_training import _native_methods_hpo_operation
+
+    operation = _native_methods_hpo_operation(
+        {"engine": "methods-hpo", "trials": 4, "sampler": "tpe", "pruner": "median"},
+        seed=51,
+    )
+
+    assert operation is not None
+    assert operation["trials"] == 4
+    assert operation["study"]["optimizer"] == {
+        "sampler": "tpe",
+        "pruner": "median",
+        "direction": "minimize",
+        "metric": "rmse",
+        "seed": 51,
+        "n_startup_trials": 2,
+        "max_resource": 0,
+        "reduction_factor": 0,
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Expose the released DAG-ML Methods scheduler capabilities on the fail-closed public native lane.

- accepts only `random|tpe` and `none|median`;
- keeps search-space, objective and startup policy controller-owned;
- adds contract/documentation coverage;
- manually exercised the published `dag-ml 0.3.13` + `nirs4all-core 0.3.20` stack with 4 TPE/Median trials, native selection/refit and checkpoint evidence;
- verified the full published native chain: HPO train → Archive V2 save → process/session close → fresh `load_session(..., engine="native")` → identity-bound prediction.

Tests:
- `python3.11 -m pytest tests/unit/docs/test_native_tuning_conformal_docs.py tests/unit/api/test_engine_transition.py tests/unit/api/test_native_session.py -q`
- `python3.11 -m ruff check nirs4all/api/native_training.py nirs4all/api/run.py tests/unit/api/test_engine_transition.py`
- published-package smoke in isolated Python 3.11 venv

`mypy` still reports the repository baseline of 30 unrelated errors; none are in changed files.