### PR TITLE
fix(native): validate archive sessions before replay

### DIFF
--- a/docs/source/reference/api/session.md
+++ b/docs/source/reference/api/session.md
@@ -91,7 +91,9 @@ nirs4all.load_session(
 - `path` (str|Path): Path to the `.n4a` bundle file to load
 - `engine`: `"legacy"` (default) preserves the existing `BundleLoader` session.
   `"native"` opens a fail-closed Core Archive V2 Methods PREDICT session and
-  accepts no legacy fallback.
+  accepts no legacy fallback. Opening a native session validates the Core
+  container and DAG-ML Package V2 before prediction data or an N4MM runtime is
+  touched.
 
 **Returns:**
 - `Session` for `engine="legacy"`, ready for legacy prediction.
@@ -136,6 +138,9 @@ native.close()
   legacy prediction, retraining, and save APIs.
 - `NativeArchiveSession` is deliberately PREDICT-only: it owns no legacy
   runner and cannot be repurposed for retraining or export.
+- Native open is a structural preflight, not model hydration: the Methods
+  shared library and its N4MM handle are resolved invocation-by-invocation at
+  `predict(...)`, then released before it returns.
 - The original bundle file is not modified by the loaded session
 
 ## Session Methods

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -128,15 +128,22 @@ def load_native_archive_session(
     *,
     methods_library_path: str | Path | None = None,
 ) -> NativeArchiveSession:
-    """Open a portable Archive V2 PREDICT session without a legacy runner.
+    """Open a validated portable Archive V2 PREDICT session without a legacy runner.
 
     With ``nirs4all[native]``, the compatible Methods shared library is
     discovered from the installed ``nirs4all-methods`` wheel for each
     invocation. ``methods_library_path`` remains an explicit deployment
-    override for invocation-local N4MM hydration.
+    override for invocation-local N4MM hydration.  Opening the session first
+    validates the Core container and DAG-ML Package V2, but deliberately does
+    not load an N4MM model or consume caller data; native model hydration stays
+    invocation-local to :meth:`NativeArchiveSession.predict`.
     """
 
-    return NativeArchiveSession(path, methods_library_path=methods_library_path)
+    archive_path = Path(path)
+    from nirs4all.pipeline.dagml.native_archive_replay import validate_methods_archive_v2
+
+    validate_methods_archive_v2(archive_path)
+    return NativeArchiveSession(archive_path, methods_library_path=methods_library_path)
 
 
 class Session:

--- a/nirs4all/pipeline/dagml/native_archive_replay.py
+++ b/nirs4all/pipeline/dagml/native_archive_replay.py
@@ -22,7 +22,11 @@ from .fit_identity import normalize_predict_identity
 from .methods_replay import MethodsN4mmReplayCallbacks, MethodsPortableReplayError
 from .methods_runtime import resolve_methods_library_path
 from .native_client import DagMLNativeCoverageError
-from .raw_replay_lowerer import RawArrayMethodsReplayCompiler, RawArrayMethodsReplayError
+from .raw_replay_lowerer import (
+    RawArrayMethodsReplayCompiler,
+    RawArrayMethodsReplayError,
+    validate_native_methods_package,
+)
 
 if TYPE_CHECKING:
     from .resolver import MaterializationResolver
@@ -103,6 +107,25 @@ def write_methods_archive_v2(
     if reference["archive_id"] != archive_id:
         raise NativeArchiveReplayError("Core Archive V2 writer returned a mismatched archive id")
     return {"archive_id": str(reference["archive_id"]), "archive_sha256": str(reference["archive_sha256"])}
+
+
+def validate_methods_archive_v2(archive_path: str | Path) -> None:
+    """Preflight one Archive V2 without loading a Methods runtime or any cohort.
+
+    Core owns archive/container integrity and returns only the opaque Package
+    member.  DAG-ML then validates the Package V2 contract; this adapter adds
+    the public raw-Methods closure check.  Keeping that sequence at session
+    open time ensures malformed archives fail before callers provide feature
+    rows or native N4MM hydration is attempted.
+    """
+
+    _dag_ml, package, _package_document = _load_methods_archive_package(archive_path)
+    try:
+        validate_native_methods_package(package)
+    except RawArrayMethodsReplayError as error:
+        raise NativeArchiveReplayError(
+            "Core Archive V2 does not contain a replayable portable Methods package"
+        ) from error
 
 
 def replay_methods_archive_v2(
@@ -230,15 +253,20 @@ def predict_methods_archive_v2_raw_result(
         replay = compiler.compile_replay(
             None, X, mode="predict", identity_frame=identity
         )
-        outcome = dag_ml.replay_loaded_methods_predictor_package(
-            package,
-            replay.request,
-            replay.data_envelopes,
-            replay.methods_inputs,
-            methods_library_path=library_path,
-            outcome_id=replay.outcome_id,
-            run_id=replay.run_id,
-        )
+        try:
+            outcome = dag_ml.replay_loaded_methods_predictor_package(
+                package,
+                replay.request,
+                replay.data_envelopes,
+                replay.methods_inputs,
+                methods_library_path=library_path,
+                outcome_id=replay.outcome_id,
+                run_id=replay.run_id,
+            )
+        except Exception as error:
+            raise NativeArchiveReplayError(
+                "DAG-ML Methods Archive V2 replay was refused"
+            ) from error
         return _decode_exact_raw_prediction(
             outcome,
             identity.sample_ids,
@@ -266,7 +294,12 @@ def _load_methods_archive_package(
             "native Archive V2 replay requires dag-ml with portable artifact callbacks"
         ) from error
 
-    package_bytes = read_portable_predictor_package_v2(str(archive_path))
+    try:
+        package_bytes = read_portable_predictor_package_v2(str(archive_path))
+    except Exception as error:
+        raise NativeArchiveReplayError(
+            "Core Archive V2 rejected the portable predictor package"
+        ) from error
     if not isinstance(package_bytes, bytes):
         raise NativeArchiveReplayError("Core Archive V2 reader did not return package bytes")
     try:
@@ -508,6 +541,7 @@ __all__ = [
     "NativeArchiveConformalInterval",
     "NativeArchivePrediction",
     "NativeArchiveReplayError",
+    "validate_methods_archive_v2",
     "predict_methods_archive_v2_raw",
     "predict_methods_archive_v2_raw_result",
     "replay_methods_archive_v2",

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -5,13 +5,24 @@ import pytest
 
 from nirs4all.api.predict import predict
 from nirs4all.api.session import NativeArchiveSession, load_native_archive_session, load_session
-from nirs4all.pipeline.dagml.native_archive_replay import NativeArchivePrediction
+from nirs4all.pipeline.dagml.native_archive_replay import (
+    NativeArchivePrediction,
+    NativeArchiveReplayError,
+)
 
 
 def test_native_archive_session_replays_explicit_ids_and_closes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     observed: dict[str, object] = {}
+
+    def validate(path) -> None:  # noqa: ANN001
+        observed["validated_path"] = str(path)
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
+        validate,
+    )
 
     def replay(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
         observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids), methods_library_path=methods_library_path, groups=groups, metadata=metadata)
@@ -38,6 +49,7 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
     assert session.closed
     assert observed["sample_ids"] == ["p1", "p2"]
     assert observed["methods_library_path"] == "/native/libn4m.so"
+    assert observed["validated_path"] == "portable.n4a"
     with pytest.raises(RuntimeError, match="closed"):
         session.predict(np.asarray([[1.0]]), sample_ids=["p3"])
 
@@ -54,6 +66,10 @@ def test_load_session_native_uses_the_portable_session_without_bundle_loader(
             raise AssertionError("native load_session constructed a legacy BundleLoader")
 
     monkeypatch.setattr("nirs4all.pipeline.bundle.BundleLoader", UnexpectedBundleLoader)
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
+        lambda path: None,
+    )
 
     loaded = load_session(archive, engine="native")
 
@@ -80,6 +96,10 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
         "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
         replay,
     )
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
+        lambda path: None,
+    )
     native_session = load_native_archive_session(
         "portable.n4a", methods_library_path="/native/libn4m.so"
     )
@@ -95,7 +115,34 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
     assert observed["sample_ids"] == ["p1", "p2"]
 
 
-def test_predict_native_session_refuses_explicit_non_native_engine() -> None:
+def test_load_native_archive_session_refuses_a_bad_package_before_prediction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opening rejects an invalid archive before a caller supplies feature data."""
+
+    def reject(_path) -> None:  # noqa: ANN001
+        raise NativeArchiveReplayError("bad archive package")
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
+        reject,
+    )
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("prediction was attempted")),
+    )
+
+    with pytest.raises(NativeArchiveReplayError, match="bad archive package"):
+        load_native_archive_session("invalid.n4a")
+
+
+def test_predict_native_session_refuses_explicit_non_native_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
+        lambda path: None,
+    )
     with pytest.raises(ValueError, match="explicit non-native engine"):
         predict(
             data={"X": np.asarray([[1.0]]), "sample_ids": ["p1"]},

--- a/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
@@ -218,6 +218,29 @@ def test_raw_archive_predict_composes_core_dagml_and_methods_without_legacy(
             "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"], methods_library_path="/native/libn4m.so"
         )
 
+    def refused_replay(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("native provider rejected the current cohort")
+
+    runtime.replay_loaded_methods_predictor_package = refused_replay
+    with pytest.raises(NativeArchiveReplayError, match="DAG-ML Methods Archive V2 replay was refused"):
+        predict_methods_archive_v2_raw(
+            "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"], methods_library_path="/native/libn4m.so"
+        )
+
+    monkeypatch.setitem(
+        sys.modules,
+        "nirs4all_core",
+        types.SimpleNamespace(
+            read_portable_predictor_package_v2=lambda _path: (_ for _ in ()).throw(
+                RuntimeError("corrupt archive")
+            )
+        ),
+    )
+    with pytest.raises(NativeArchiveReplayError, match="Core Archive V2 rejected"):
+        predict_methods_archive_v2_raw(
+            "portable.n4a", np.asarray([[1.0], [2.0]]), sample_ids=["sample.one", "sample.two"], methods_library_path="/native/libn4m.so"
+        )
+
 
 def test_raw_archive_predict_resolves_the_bundled_methods_library(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- validate the Core Archive V2 and DAG-ML Package V2 when opening a native session
- reject malformed/non-portable archives before feature rows or N4MM hydration
- document structural preflight versus invocation-local native handles

## Validation
- `python3.11 -m pytest tests/unit/api/test_native_archive_session.py tests/unit/api/test_engine_transition.py tests/unit/docs/test_native_tuning_conformal_docs.py -q`
- real public Archive V2 load/close with `dag-ml==0.3.13` and `nirs4all-core==0.3.20`
- `python3.11 -m ruff check nirs4all/api/session.py nirs4all/pipeline/dagml/native_archive_replay.py tests/unit/api/test_native_archive_session.py`
- `git diff --check`