### PR TITLE
feat(native): accept explicit prediction identities

### DIFF
--- a/docs/source/user_guide/predictions/session_api.md
+++ b/docs/source/user_guide/predictions/session_api.md
@@ -134,7 +134,8 @@ with nirs4all.load_session(
     methods_library_path=methods_library,
 ) as native:
     prediction = nirs4all.predict(
-        data={"X": X_new, "sample_ids": sample_ids},
+        data=X_new,
+        sample_ids=sample_ids,
         session=native,
         engine="native",
     )

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -80,6 +80,7 @@ def predict(
     workspace_metadata: Mapping[str, Any] | None = None,
     workspace_result_metadata: Mapping[str, Any] | None = None,
     methods_library_path: str | Path | None = None,
+    sample_ids: Any = None,
     **runner_kwargs: Any,
 ) -> PredictResult:
     """Make predictions with a trained model on new data.
@@ -170,6 +171,12 @@ def predict(
             When omitted, the bundled ``nirs4all-methods`` runtime is used. It
             is never used to select a legacy execution path.
 
+        sample_ids: Explicit stable identities for a raw matrix passed to the
+            native Archive V2 path. This is equivalent to
+            ``data={"X": X, "sample_ids": ids}``; it is required when native
+            ``data`` is not already a mapping. A mapping carries its own
+            identities and must not receive a second identity source.
+
         verbose: Verbosity level (0=quiet, 1=info, 2=debug).
             Default: 0
 
@@ -241,6 +248,7 @@ def predict(
         raise ValueError("'data' is required.")
 
     if engine == "native":
+        data = _native_data_with_explicit_sample_ids(data, sample_ids)
         result = _predict_from_native_archive(
             model=model,
             data=data,
@@ -260,6 +268,12 @@ def predict(
     # Narrow the remaining legacy paths for both runtime safety and static
     # checking; none may receive a portable native session.
     assert not isinstance(session, (NativeArchiveSession, NativeMethodsSession))
+
+    # Before this argument became first-class for the explicit native path it
+    # was accepted through ``**runner_kwargs`` by legacy callers. Preserve that
+    # behavior outside native replay instead of silently dropping it.
+    if sample_ids is not None:
+        runner_kwargs["sample_ids"] = sample_ids
 
     if _is_calibrated_replayed_prediction_request(model, data):
         result = _predict_from_calibrated_replayed_arrays(
@@ -401,6 +415,27 @@ def _maybe_publish_predict_result(
     result.metadata["workspace_path"] = str(publish_path)
     result.metadata["workspace_prediction_published"] = True
     return result
+
+
+def _native_data_with_explicit_sample_ids(data: DataSpec, sample_ids: Any) -> DataSpec:
+    """Build the one native current-cohort mapping without inventing identity.
+
+    Native Archive V2 replay accepts only an exact X/identity cohort.  The
+    public keyword form is intentionally a convenience at the boundary, not a
+    second identity source or a fallback to positional row numbers.
+    """
+
+    if sample_ids is None:
+        return data
+    if isinstance(data, Mapping):
+        if "sample_ids" in data:
+            raise ValueError(
+                "engine='native' predict receives sample_ids either in data or as an explicit keyword, not both"
+            )
+        normalized = dict(data)
+        normalized["sample_ids"] = sample_ids
+        return normalized
+    return {"X": data, "sample_ids": sample_ids}
 
 
 def _predict_from_native_archive(

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -540,6 +540,49 @@ def test_predict_native_archive_is_explicit_and_never_constructs_a_legacy_runner
     assert observed["sample_ids"] == ["p1", "p2"]
 
 
+def test_predict_native_archive_accepts_raw_matrix_with_explicit_keyword_identities(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The native public boundary must not require a synthetic mapping wrapper."""
+
+    observed: dict[str, object] = {}
+
+    def native_predict(path, X, *, sample_ids, methods_library_path, groups, metadata):  # noqa: ANN001
+        observed.update(path=str(path), X=np.asarray(X), sample_ids=list(sample_ids))
+        return NativeArchivePrediction(
+            values=np.asarray([[2.0], [3.0]]),
+            sample_ids=("p1", "p2"),
+            intervals={},
+            conformal_guarantee_status=None,
+        )
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
+        native_predict,
+    )
+
+    result = predict(
+        model="portable.n4a",
+        data=np.asarray([[1.0], [2.0]]),
+        sample_ids=["p1", "p2"],
+        engine="native",
+    )
+
+    assert result.y_pred.tolist() == [[2.0], [3.0]]
+    assert observed["path"] == "portable.n4a"
+    assert observed["sample_ids"] == ["p1", "p2"]
+
+
+def test_predict_native_archive_refuses_two_identity_sources_before_replay() -> None:
+    with pytest.raises(ValueError, match="either in data or as an explicit keyword"):
+        predict(
+            model="portable.n4a",
+            data={"X": np.asarray([[1.0]]), "sample_ids": ["p1"]},
+            sample_ids=["p1"],
+            engine="native",
+        )
+
+
 def test_predict_native_archive_selects_dagml_materialized_conformal_intervals(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- accept `predict(..., data=X, sample_ids=ids, engine="native")` for Archive V2 replay
- preserve legacy `sample_ids` forwarding outside the native branch
- reject duplicate identity sources before native replay

## Validation
- real Methods Archive V2 replay with direct X + explicit sample IDs
- `python3.11 -m pytest tests/unit/api/test_engine_transition.py tests/unit/docs/test_native_tuning_conformal_docs.py -q`
- `python3.11 -m ruff check nirs4all/api/predict.py tests/unit/api/test_engine_transition.py`
- `git diff --check`