### PR TITLE
feat(native): persist full retrain lineage

### DIFF
--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -154,7 +154,10 @@ with nirs4all.session(pipeline, engine="native") as native:
 ```
 
 This is not transfer learning or finetuning: it preserves only the selected
-portable PLS recipe and its attested patch. Archive-based retraining,
+portable PLS recipe and its attested patch. Each supported full retrain writes
+the source outcome, request, plan, selected variant and seed into the signed
+outcome diagnostics of the new result; exporting that result preserves this
+parent-child lineage in the new native archive. Archive-based retraining,
 transfer/finetuning, calibration, generic branching/stacking and explanation
 remain explicit capability refusals; none is redirected to the legacy backend.
 

--- a/nirs4all/api/native_result.py
+++ b/nirs4all/api/native_result.py
@@ -17,6 +17,9 @@ from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
 from nirs4all.pipeline.dagml.result import _scores_to_run_result
 
+from .native_retrain_lineage import DIAGNOSTIC_KEY as RETRAIN_LINEAGE_DIAGNOSTIC_KEY
+from .native_retrain_lineage import NativeRetrainLineage
+
 
 class NativeMethodsRunResult(RunResult):
     """A ``RunResult`` backed only by a fitted portable Methods estimator.
@@ -129,6 +132,24 @@ class NativeMethodsRunResult(RunResult):
         if not isinstance(calibration, Mapping):
             raise DagMLNativeCoverageError("native conformal calibration is not a structured mapping")
         return dict(calibration)
+
+    @property
+    def native_retrain_lineage(self) -> dict[str, Any] | None:
+        """Return strict, durable parent evidence for a native full retrain."""
+
+        outcome = _outcome_document(self._native_estimator)
+        diagnostics = outcome.get("diagnostics")
+        if not isinstance(diagnostics, Mapping):
+            raise DagMLNativeCoverageError("native Methods outcome diagnostics are not a structured mapping")
+        lineage = diagnostics.get(RETRAIN_LINEAGE_DIAGNOSTIC_KEY)
+        if lineage is None:
+            return None
+        if not isinstance(lineage, Mapping):
+            raise DagMLNativeCoverageError("native Methods retrain lineage is not a structured mapping")
+        try:
+            return NativeRetrainLineage.from_mapping(lineage).to_dict()
+        except ValueError as error:
+            raise DagMLNativeCoverageError("native Methods retrain lineage is malformed") from error
 
     def export(
         self,

--- a/nirs4all/api/native_retrain_lineage.py
+++ b/nirs4all/api/native_retrain_lineage.py
@@ -1,0 +1,112 @@
+"""Signed provenance for the supported native Methods full-retrain lane.
+
+The parent result is not a fitted-model handle: every field below is copied
+from the parent DAG-ML outcome before the child fit starts.  The child outcome
+then includes this object in its self-fingerprinted diagnostics, which makes
+the relationship durable through Package V2 and Archive V2 without inventing
+an archive retraining recipe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+DIAGNOSTIC_KEY = "nirs4all_native_retrain_lineage"
+SEED_DIAGNOSTIC_KEY = "nirs4all_native_seed"
+_FINGERPRINT_FIELDS = (
+    "source_outcome_fingerprint",
+    "source_training_request_fingerprint",
+    "source_effective_plan_fingerprint",
+    "source_selected_variant_fingerprint",
+)
+
+
+@dataclass(frozen=True)
+class NativeRetrainLineage:
+    """The immutable parent evidence for one native full retrain."""
+
+    source_outcome_fingerprint: str
+    source_training_request_fingerprint: str
+    source_effective_plan_fingerprint: str
+    source_selected_variant_id: str
+    source_selected_variant_fingerprint: str
+    source_seed: int
+
+    @classmethod
+    def from_source_outcome(cls, outcome: Mapping[str, Any]) -> NativeRetrainLineage:
+        """Build lineage only from an attested, completed native outcome."""
+
+        if not isinstance(outcome, Mapping):
+            raise ValueError("native retrain source does not retain a structured native outcome")
+        refit = outcome.get("refit")
+        if not isinstance(refit, Mapping) or refit.get("status") != "completed":
+            raise ValueError("native retrain source does not retain a completed native refit")
+        diagnostics = outcome.get("diagnostics")
+        if not isinstance(diagnostics, Mapping):
+            raise ValueError("native retrain source does not retain native training diagnostics")
+        seed = diagnostics.get(SEED_DIAGNOSTIC_KEY)
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("native retrain source does not retain an attested native seed")
+        values = {
+            "schema_version": 1,
+            "operation": "full_refit",
+            "source_outcome_fingerprint": outcome.get("outcome_fingerprint"),
+            "source_training_request_fingerprint": outcome.get("training_request_fingerprint"),
+            "source_effective_plan_fingerprint": outcome.get("effective_plan_fingerprint"),
+            "source_selected_variant_id": outcome.get("selected_variant_id"),
+            "source_selected_variant_fingerprint": outcome.get("selected_variant_fingerprint"),
+            "source_seed": seed,
+        }
+        return cls.from_mapping(values)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> NativeRetrainLineage:
+        """Strictly parse persisted lineage without accepting extension keys."""
+
+        expected = {
+            "schema_version",
+            "operation",
+            "source_outcome_fingerprint",
+            "source_training_request_fingerprint",
+            "source_effective_plan_fingerprint",
+            "source_selected_variant_id",
+            "source_selected_variant_fingerprint",
+            "source_seed",
+        }
+        actual = set(value)
+        if actual != expected:
+            raise ValueError("native retrain lineage has an invalid field set")
+        if value.get("schema_version") != 1 or value.get("operation") != "full_refit":
+            raise ValueError("native retrain lineage has an unsupported schema or operation")
+        normalized: dict[str, Any] = {}
+        for field in _FINGERPRINT_FIELDS:
+            fingerprint = value.get(field)
+            if not isinstance(fingerprint, str) or len(fingerprint) != 64 or any(c not in "0123456789abcdef" for c in fingerprint):
+                raise ValueError(f"native retrain lineage has an invalid {field}")
+            normalized[field] = fingerprint
+        variant_id = value.get("source_selected_variant_id")
+        if not isinstance(variant_id, str) or not variant_id:
+            raise ValueError("native retrain lineage has an invalid source_selected_variant_id")
+        seed = value.get("source_seed")
+        if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+            raise ValueError("native retrain lineage has an invalid source_seed")
+        return cls(source_selected_variant_id=variant_id, source_seed=seed, **normalized)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the exact versioned diagnostic representation."""
+
+        return {
+            "schema_version": 1,
+            "operation": "full_refit",
+            "source_outcome_fingerprint": self.source_outcome_fingerprint,
+            "source_training_request_fingerprint": self.source_training_request_fingerprint,
+            "source_effective_plan_fingerprint": self.source_effective_plan_fingerprint,
+            "source_selected_variant_id": self.source_selected_variant_id,
+            "source_selected_variant_fingerprint": self.source_selected_variant_fingerprint,
+            "source_seed": self.source_seed,
+        }
+
+
+__all__ = ["DIAGNOSTIC_KEY", "SEED_DIAGNOSTIC_KEY", "NativeRetrainLineage"]

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -29,6 +29,13 @@ from nirs4all.pipeline.dagml.raw_replay_lowerer import (
 from nirs4all.pipeline.dagml.raw_training_lowerer import RawArrayDagMLTrainingCompiler
 
 from .native_result import NativeMethodsRunResult
+from .native_retrain_lineage import (
+    DIAGNOSTIC_KEY as RETRAIN_LINEAGE_DIAGNOSTIC_KEY,
+)
+from .native_retrain_lineage import (
+    SEED_DIAGNOSTIC_KEY,
+    NativeRetrainLineage,
+)
 
 
 def fit_native_pipeline(
@@ -49,6 +56,7 @@ def fit_native_pipeline(
     methods_library_path: str | None = None,
     methods_hpo_operation: Mapping[str, Any] | None = None,
     seed: int = 12345,
+    retrain_lineage: NativeRetrainLineage | None = None,
 ) -> DagMLPipelineEstimator:
     """Fit the supported raw-array pipeline entirely through DAG-ML.
 
@@ -91,8 +99,15 @@ def fit_native_pipeline(
         raise TypeError("fit_native_pipeline requires numeric X and y")
     if not np.isfinite(features).all() or not np.isfinite(targets).all():
         raise ValueError("fit_native_pipeline requires finite X and y")
+    if isinstance(seed, bool) or not isinstance(seed, int) or seed < 0:
+        raise TypeError("fit_native_pipeline requires a non-negative integer seed")
+    if retrain_lineage is not None and not isinstance(retrain_lineage, NativeRetrainLineage):
+        raise TypeError("fit_native_pipeline retrain lineage must be internally attested")
     resolved_methods_library_path = resolve_methods_library_path(methods_library_path)
 
+    diagnostics: dict[str, Any] = {SEED_DIAGNOSTIC_KEY: seed}
+    if retrain_lineage is not None:
+        diagnostics[RETRAIN_LINEAGE_DIAGNOSTIC_KEY] = retrain_lineage.to_dict()
     estimator = DagMLPipelineEstimator(
         pipeline=pipeline,
         selection_output_id="output:prediction",
@@ -108,6 +123,7 @@ def fit_native_pipeline(
             methods_library_path=resolved_methods_library_path,
             methods_hpo_operation=methods_hpo_operation,
             seed=seed,
+            additional_diagnostics=diagnostics,
         ),
         require_explicit_sample_ids=True,
     )
@@ -145,6 +161,7 @@ def run_native_methods(
     runner_kwargs: Mapping[str, Any] | None = None,
     tuning: Any = None,
     calibration: Any = None,
+    retrain_lineage: NativeRetrainLineage | None = None,
 ) -> NativeMethodsRunResult:
     """Run the verified public Methods training subset without a legacy runner.
 
@@ -187,6 +204,8 @@ def run_native_methods(
         raise NotImplementedError(f"engine='native' does not accept legacy runner kwargs: {sorted(runner_kwargs)}")
     if random_state is not None and (isinstance(random_state, bool) or not isinstance(random_state, int)):
         raise TypeError("engine='native' random_state must be an integer or None")
+    if retrain_lineage is not None and not isinstance(retrain_lineage, NativeRetrainLineage):
+        raise TypeError("engine='native' retrain lineage must be internally attested")
     methods_hpo_operation = _native_methods_hpo_operation(
         tuning,
         seed=12345 if random_state is None else random_state,
@@ -201,6 +220,8 @@ def run_native_methods(
     }
     if methods_hpo_operation is not None:
         fit_kwargs["methods_hpo_operation"] = methods_hpo_operation
+    if retrain_lineage is not None:
+        fit_kwargs["retrain_lineage"] = retrain_lineage
     estimator = fit_native_pipeline(pipeline, dataset["X"], dataset["y"], **fit_kwargs)
     if calibration_operation is not None:
         _attach_native_conformal_calibration(estimator, calibration_operation)

--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -28,6 +28,7 @@ from nirs4all.pipeline import PipelineRunner
 from nirs4all.pipeline.engine import require_legacy_engine
 
 from .native_result import NativeMethodsRunResult
+from .native_retrain_lineage import NativeRetrainLineage
 from .native_training import run_native_methods
 from .result import RunResult
 from .session import Session
@@ -268,17 +269,19 @@ def _retrain_native_methods_full(
     if extra_kwargs:
         raise NotImplementedError(f"engine='native' retrain does not accept legacy kwargs: {sorted(extra_kwargs)}")
 
+    pipeline, lineage = _selected_native_methods_recipe(source)
     return run_native_methods(
-        _selected_native_methods_pipeline(source),
+        pipeline,
         data,
         name=name,
         save_charts=False,
-        random_state=None,
+        random_state=lineage.source_seed,
+        retrain_lineage=lineage,
     )
 
 
-def _selected_native_methods_pipeline(source: NativeMethodsRunResult) -> list[Any]:
-    """Clone the source recipe and apply its attested selected PLS patch only."""
+def _selected_native_methods_recipe(source: NativeMethodsRunResult) -> tuple[list[Any], NativeRetrainLineage]:
+    """Clone one attested selected recipe and its durable parent evidence."""
 
     original = getattr(source.native_estimator, "pipeline", None)
     if not isinstance(original, list):
@@ -295,6 +298,7 @@ def _selected_native_methods_pipeline(source: NativeMethodsRunResult) -> list[An
     document = outcome_to_dict() if callable(outcome_to_dict) else outcome
     if not isinstance(document, Mapping):
         raise ValueError("native retrain source does not retain a structured native outcome")
+    lineage = NativeRetrainLineage.from_source_outcome(document)
     patches = document.get("parameter_patches", [])
     if not isinstance(patches, list):
         raise ValueError("native retrain source parameter patches are malformed")
@@ -315,4 +319,4 @@ def _selected_native_methods_pipeline(source: NativeMethodsRunResult) -> list[An
             raise ValueError("native retrain source carries an unsupported selected parameter patch")
         models[0].n_components = patch["value"]
         saw_components_patch = True
-    return pipeline
+    return pipeline, lineage

--- a/nirs4all/pipeline/dagml/raw_training_lowerer.py
+++ b/nirs4all/pipeline/dagml/raw_training_lowerer.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import copy
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, cast
 
 import numpy as np
@@ -56,6 +56,7 @@ class RawArrayDagMLTrainingCompiler:
     local_implementations: Any = None
     methods_library_path: str | None = None
     methods_hpo_operation: Mapping[str, Any] | None = None
+    additional_diagnostics: Mapping[str, Any] = field(default_factory=dict)
 
     def compile_fit(
         self,
@@ -92,7 +93,10 @@ class RawArrayDagMLTrainingCompiler:
         )
         compiler = DagMLTrainingRequestCompiler(
             contracts,
-            additional_diagnostics={"nirs4all_lowerer": "raw_array_p3_r1b"},
+            additional_diagnostics={
+                "nirs4all_lowerer": "raw_array_p3_r1b",
+                **dict(self.additional_diagnostics),
+            },
             dagml_module=self.dagml_module,
         )
         return compiler.compile_fit(

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -13,6 +13,7 @@ from sklearn.model_selection import KFold
 import nirs4all
 from nirs4all.api.explain import explain
 from nirs4all.api.native_result import NativeMethodsRunResult
+from nirs4all.api.native_retrain_lineage import NativeRetrainLineage
 from nirs4all.api.predict import predict
 from nirs4all.api.retrain import retrain
 from nirs4all.api.run import run
@@ -451,6 +452,13 @@ def test_retrain_native_refits_the_attested_selected_methods_variant_without_leg
     class Estimator:
         pipeline = [KFold(n_splits=2), {"model": model}]
         training_outcome_ = {
+            "outcome_fingerprint": "a" * 64,
+            "training_request_fingerprint": "b" * 64,
+            "effective_plan_fingerprint": "c" * 64,
+            "selected_variant_id": "variant:base",
+            "selected_variant_fingerprint": "d" * 64,
+            "refit": {"status": "completed"},
+            "diagnostics": {"nirs4all_native_seed": 17},
             "parameter_patches": [
                 {
                     "schema_version": 1,
@@ -490,7 +498,71 @@ def test_retrain_native_refits_the_attested_selected_methods_variant_without_leg
     assert rebuilt_model.n_components == 2
     assert model.n_components == 1
     assert observed["dataset"] is dataset
-    assert observed["kwargs"] == {"name": "next", "save_charts": False, "random_state": None}
+    assert observed["kwargs"] == {
+        "name": "next",
+        "save_charts": False,
+        "random_state": 17,
+        "retrain_lineage": NativeRetrainLineage(
+            source_outcome_fingerprint="a" * 64,
+            source_training_request_fingerprint="b" * 64,
+            source_effective_plan_fingerprint="c" * 64,
+            source_selected_variant_id="variant:base",
+            source_selected_variant_fingerprint="d" * 64,
+            source_seed=17,
+        ),
+    }
+
+
+def test_native_retrain_refuses_a_source_without_persisted_parent_evidence() -> None:
+    """Older or synthetic outcomes cannot be treated as retrain-capable."""
+
+    class Estimator:
+        pipeline = [KFold(n_splits=2), {"model": PLSRegression(n_components=1)}]
+        training_outcome_ = {
+            "parameter_patches": [],
+            "refit": {"status": "completed"},
+            "diagnostics": {},
+        }
+
+    source = object.__new__(NativeMethodsRunResult)
+    source._native_estimator = Estimator()  # noqa: SLF001
+    with pytest.raises(ValueError, match="attested native seed"):
+        retrain(
+            source,
+            {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["p0", "p1"]},
+            engine="native",
+        )
+
+
+def test_native_result_exposes_only_strict_persisted_retrain_lineage() -> None:
+    class Estimator:
+        training_outcome_ = {
+            "diagnostics": {
+                "nirs4all_native_retrain_lineage": {
+                    "schema_version": 1,
+                    "operation": "full_refit",
+                    "source_outcome_fingerprint": "a" * 64,
+                    "source_training_request_fingerprint": "b" * 64,
+                    "source_effective_plan_fingerprint": "c" * 64,
+                    "source_selected_variant_id": "variant:base",
+                    "source_selected_variant_fingerprint": "d" * 64,
+                    "source_seed": 17,
+                }
+            }
+        }
+
+    result = object.__new__(NativeMethodsRunResult)
+    result._native_estimator = Estimator()  # noqa: SLF001
+    assert result.native_retrain_lineage == {
+        "schema_version": 1,
+        "operation": "full_refit",
+        "source_outcome_fingerprint": "a" * 64,
+        "source_training_request_fingerprint": "b" * 64,
+        "source_effective_plan_fingerprint": "c" * 64,
+        "source_selected_variant_id": "variant:base",
+        "source_selected_variant_fingerprint": "d" * 64,
+        "source_seed": 17,
+    }
 
 
 @pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])

--- a/tests/unit/api/test_native_training.py
+++ b/tests/unit/api/test_native_training.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import nirs4all
+from nirs4all.api.native_retrain_lineage import NativeRetrainLineage
 from nirs4all.api.native_training import fit_native_pipeline
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
@@ -105,6 +106,7 @@ def test_fit_native_pipeline_is_a_public_strict_native_composition(
 
     assert isinstance(estimator, DagMLPipelineEstimator)
     assert captured["kwargs"]["sample_ids"] == ("fit-a", "fit-b")
+    assert estimator.training_compiler.additional_diagnostics == {"nirs4all_native_seed": 12345}
     assert client.calls[0][0][:4] == (
         {"request": "native"},
         {"model.x": {}},
@@ -117,6 +119,54 @@ def test_fit_native_pipeline_is_a_public_strict_native_composition(
     assert estimator.prediction_compiler is not None
     assert estimator.prediction_identity_decoder is not None
     assert nirs4all.fit_native_pipeline is fit_native_pipeline
+
+
+def test_fit_native_pipeline_seals_internal_retrain_lineage_into_compiler_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, native_library: str
+) -> None:
+    """The signed training compiler receives parent provenance before fit."""
+
+    def compile_fit(self, _estimator, _X, _y, **_kwargs):  # noqa: ANN001
+        from nirs4all.pipeline.dagml.estimator import DagMLTrainingExecution
+
+        return DagMLTrainingExecution(
+            request={},
+            data_envelopes={},
+            relations={},
+            training_influence={},
+            op_callback=lambda task: task,
+            outcome_id="o",
+            run_id="r",
+            bundle_id="b",
+        )
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        compile_fit,
+    )
+    lineage = NativeRetrainLineage(
+        source_outcome_fingerprint="a" * 64,
+        source_training_request_fingerprint="b" * 64,
+        source_effective_plan_fingerprint="c" * 64,
+        source_selected_variant_id="variant:base",
+        source_selected_variant_fingerprint="d" * 64,
+        source_seed=17,
+    )
+    estimator = fit_native_pipeline(
+        [{"split": "stub"}, {"model": "stub"}],
+        np.asarray([[1.0], [2.0]]),
+        np.asarray([1.0, 2.0]),
+        sample_ids=["fit-a", "fit-b"],
+        native_client=_Client(),
+        methods_library_path=native_library,
+        seed=31,
+        retrain_lineage=lineage,
+    )
+
+    assert estimator.training_compiler.additional_diagnostics == {
+        "nirs4all_native_seed": 31,
+        "nirs4all_native_retrain_lineage": lineage.to_dict(),
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- persist strict parent evidence before native full retrain execution
- retain the source seed and selected recipe/patch
- verify the signed child outcome and exported Archive V2 retain the lineage

## Validation
- `pytest -q tests/unit/api/test_engine_transition.py tests/unit/api/test_native_session.py tests/unit/api/test_native_training.py`
- `ruff check .`
- real DAG-ML 0.3.13 + libn4m train → retrain → Archive V2 persistence probe

Archive-based retraining, transfer and finetuning remain explicit refusals: Archive V2 does not yet carry a reconstructible training-split recipe.