### PR TITLE
feat(native): project DAG-ML conformal replay

### DIFF
--- a/nirs4all/pipeline/dagml/native_archive_replay.py
+++ b/nirs4all/pipeline/dagml/native_archive_replay.py
@@ -249,6 +249,7 @@ def predict_methods_archive_v2_raw_result(
         run_id=run_id,
         methods_library_path=library_path,
     )
+    replay: Any | None = None
     try:
         replay = compiler.compile_replay(
             None, X, mode="predict", identity_frame=identity
@@ -274,6 +275,89 @@ def predict_methods_archive_v2_raw_result(
         )
     except (MethodsPortableReplayError, RawArrayMethodsReplayError) as error:
         raise NativeArchiveReplayError(str(error)) from error
+    finally:
+        if replay is not None and replay.cleanup is not None:
+            replay.cleanup()
+
+
+def project_methods_archive_v2_conformal_presentation(
+    archive_path: str | Path,
+    X: Any,
+    *,
+    sample_ids: Any,
+    methods_library_path: str | Path | None = None,
+    groups: Any = None,
+    metadata: Any = None,
+    outcome_id: str = "outcome:nirs4all.archive_conformal_presentation",
+    run_id: str = "run:nirs4all.archive_conformal_presentation",
+) -> dict[str, Any]:
+    """Project DAG-ML's exact scalar conformal replay presentation.
+
+    This is a transport boundary: DAG-ML validates the Package V2 calibration,
+    replay closure, quantiles, and interval arithmetic before producing the
+    presentation.  This adapter only verifies that the returned scalar view is
+    the current prediction block and preserves its exact public identities.
+    It intentionally does not recalibrate or reconstruct interval endpoints.
+    """
+
+    try:
+        library_path = resolve_methods_library_path(methods_library_path)
+    except (DagMLNativeCoverageError, OSError, TypeError, ValueError, RuntimeError) as error:
+        raise NativeArchiveReplayError(
+            "native Archive V2 conformal presentation could not resolve a compatible Methods runtime"
+        ) from error
+
+    dag_ml, package, package_document = _load_methods_archive_package(archive_path)
+    identity = normalize_predict_identity(
+        X,
+        sample_ids=sample_ids,
+        groups=groups,
+        metadata=metadata,
+        require_explicit_sample_ids=True,
+    )
+    compiler = RawArrayMethodsReplayCompiler(
+        package,
+        outcome_id=outcome_id,
+        run_id=run_id,
+        methods_library_path=library_path,
+    )
+    replay: Any | None = None
+    try:
+        replay = compiler.compile_replay(
+            None, X, mode="predict", identity_frame=identity
+        )
+        try:
+            outcome = dag_ml.replay_loaded_methods_predictor_package(
+                package,
+                replay.request,
+                replay.data_envelopes,
+                replay.methods_inputs,
+                methods_library_path=library_path,
+                outcome_id=replay.outcome_id,
+                run_id=replay.run_id,
+            )
+        except Exception as error:
+            raise NativeArchiveReplayError(
+                "DAG-ML Methods Archive V2 conformal replay was refused"
+            ) from error
+        projector = getattr(dag_ml, "build_conformal_presentation_v1", None)
+        if not callable(projector):
+            raise NativeArchiveReplayError(
+                "installed DAG-ML lacks the native conformal presentation projector; upgrade DAG-ML"
+            )
+        presentation = projector(package, replay.request, outcome)
+        _validate_conformal_presentation_transport(
+            presentation,
+            package_document=package_document,
+            outcome=outcome,
+            sample_ids=identity.sample_ids,
+        )
+        return dict(presentation)
+    except (MethodsPortableReplayError, RawArrayMethodsReplayError) as error:
+        raise NativeArchiveReplayError(str(error)) from error
+    finally:
+        if replay is not None and replay.cleanup is not None:
+            replay.cleanup()
 
 
 def _load_methods_archive_package(
@@ -354,6 +438,119 @@ def _decode_exact_raw_prediction(
         intervals=intervals,
         conformal_guarantee_status=guarantee_status,
     )
+
+
+def _validate_conformal_presentation_transport(
+    presentation: Any,
+    *,
+    package_document: dict[str, Any],
+    outcome: Any,
+    sample_ids: tuple[str, ...],
+) -> None:
+    """Close DAG-ML's scalar presentation over this exact replay result.
+
+    The native projector is the semantic authority.  This narrow check exists
+    solely to prevent a caller from attaching a valid presentation belonging
+    to a different package, output binding, or current cohort.
+    """
+
+    required = {
+        "schema_version",
+        "package_fingerprint",
+        "replay_outcome_fingerprint",
+        "binding_id",
+        "target_name",
+        "sample_ids",
+        "point_predictions",
+        "intervals",
+        "calibration_fingerprint",
+        "presentation_fingerprint",
+    }
+    if not isinstance(presentation, dict) or set(presentation) != required:
+        raise NativeArchiveReplayError("DAG-ML conformal presentation has an unsupported shape")
+    if presentation.get("schema_version") != 1 or presentation.get("sample_ids") != list(sample_ids):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation identities do not match the current cohort"
+        )
+    calibration = package_document.get("conformal_calibration")
+    if not isinstance(calibration, dict):
+        raise NativeArchiveReplayError(
+            "DAG-ML produced a conformal presentation without Package V2 calibration"
+        )
+    if (
+        presentation.get("package_fingerprint") != package_document.get("package_fingerprint")
+        or presentation.get("calibration_fingerprint")
+        != calibration.get("calibration_fingerprint")
+    ):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation provenance does not match Package V2"
+        )
+    document = outcome.to_dict() if hasattr(outcome, "to_dict") else outcome
+    if not isinstance(document, dict) or presentation.get("replay_outcome_fingerprint") != document.get(
+        "outcome_fingerprint"
+    ):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation provenance does not match replay"
+        )
+    outputs = document.get("outputs")
+    if not isinstance(outputs, list) or len(outputs) != 1 or not isinstance(outputs[0], dict):
+        raise NativeArchiveReplayError("DAG-ML conformal presentation requires one replay output")
+    binding = outputs[0].get("binding")
+    blocks = outputs[0].get("predictions")
+    if (
+        not isinstance(binding, dict)
+        or presentation.get("binding_id") != binding.get("binding_id")
+        or not isinstance(blocks, list)
+        or len(blocks) != 1
+        or not isinstance(blocks[0], dict)
+        or blocks[0].get("sample_ids") != list(sample_ids)
+    ):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation does not close its selected point block"
+        )
+    values = blocks[0].get("values")
+    points = presentation.get("point_predictions")
+    if (
+        not isinstance(values, list)
+        or any(not isinstance(row, list) or len(row) != 1 for row in values)
+        or points != [row[0] for row in values]
+    ):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation points are not the exact replay values"
+        )
+    intervals = presentation.get("intervals")
+    if not isinstance(intervals, list) or not intervals:
+        raise NativeArchiveReplayError("DAG-ML conformal presentation has no interval blocks")
+    seen_coverages: set[float] = set()
+    for interval in intervals:
+        if not isinstance(interval, dict) or set(interval) != {"coverage", "lower", "upper", "qhat"}:
+            raise NativeArchiveReplayError("DAG-ML conformal presentation interval is malformed")
+        coverage = interval.get("coverage")
+        lower, upper = interval.get("lower"), interval.get("upper")
+        if (
+            isinstance(coverage, bool)
+            or not isinstance(coverage, (int, float))
+            or not 0.0 < float(coverage) < 1.0
+            or float(coverage) in seen_coverages
+            or not isinstance(lower, list)
+            or not isinstance(upper, list)
+            or len(lower) != len(sample_ids)
+            or len(upper) != len(sample_ids)
+        ):
+            raise NativeArchiveReplayError("DAG-ML conformal presentation interval coverage is invalid")
+        seen_coverages.add(float(coverage))
+        for point, lower_value, upper_value in zip(points, lower, upper, strict=True):
+            if lower_value is None or upper_value is None:
+                if lower_value is not None or upper_value is not None:
+                    raise NativeArchiveReplayError(
+                        "DAG-ML conformal presentation interval has a half-unbounded endpoint"
+                    )
+                continue
+            if any(
+                isinstance(value, bool) or not isinstance(value, (int, float)) or not math.isfinite(float(value))
+                for value in (point, lower_value, upper_value)
+            ) or float(lower_value) > float(point) or float(point) > float(upper_value):
+                raise NativeArchiveReplayError("DAG-ML conformal presentation interval does not contain its point")
 
 
 def _decode_native_conformal_intervals(
@@ -544,6 +741,7 @@ __all__ = [
     "validate_methods_archive_v2",
     "predict_methods_archive_v2_raw",
     "predict_methods_archive_v2_raw_result",
+    "project_methods_archive_v2_conformal_presentation",
     "replay_methods_archive_v2",
     "write_methods_archive_v2",
 ]

--- a/tests/unit/pipeline/dagml/test_native_archive_presentation.py
+++ b/tests/unit/pipeline/dagml/test_native_archive_presentation.py
@@ -1,0 +1,85 @@
+"""Transport-only validation for native conformal archive presentation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nirs4all.pipeline.dagml.native_archive_replay import (
+    NativeArchiveReplayError,
+    _validate_conformal_presentation_transport,
+)
+
+
+def _package() -> dict[str, object]:
+    return {
+        "package_fingerprint": "a" * 64,
+        "conformal_calibration": {"calibration_fingerprint": "b" * 64},
+    }
+
+
+def _outcome() -> SimpleNamespace:
+    return SimpleNamespace(
+        to_dict=lambda: {
+            "outcome_fingerprint": "c" * 64,
+            "outputs": [
+                {
+                    "binding": {"binding_id": "binding:pls"},
+                    "predictions": [
+                        {
+                            "sample_ids": ["p1", "p2"],
+                            "values": [[2.0], [3.0]],
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+def _presentation() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "package_fingerprint": "a" * 64,
+        "replay_outcome_fingerprint": "c" * 64,
+        "binding_id": "binding:pls",
+        "target_name": "moisture",
+        "sample_ids": ["p1", "p2"],
+        "point_predictions": [2.0, 3.0],
+        "intervals": [
+            {"coverage": 0.9, "lower": [1.0, 2.0], "upper": [3.0, 4.0], "qhat": 1.0}
+        ],
+        "calibration_fingerprint": "b" * 64,
+        "presentation_fingerprint": "d" * 64,
+    }
+
+
+def test_native_conformal_presentation_closes_exact_replay_points() -> None:
+    _validate_conformal_presentation_transport(
+        _presentation(),
+        package_document=_package(),
+        outcome=_outcome(),
+        sample_ids=("p1", "p2"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda p: p.update(sample_ids=["p2", "p1"]), "identities"),
+        (lambda p: p.update(point_predictions=[2.0, 3.1]), "points"),
+        (lambda p: p.update(package_fingerprint="e" * 64), "provenance"),
+        (lambda p: p["intervals"][0].update(lower=[None, 2.0]), "half-unbounded"),
+    ],
+)
+def test_native_conformal_presentation_refuses_resigned_transport_mismatch(mutate, message: str) -> None:
+    presentation = _presentation()
+    mutate(presentation)
+    with pytest.raises(NativeArchiveReplayError, match=message):
+        _validate_conformal_presentation_transport(
+            presentation,
+            package_document=_package(),
+            outcome=_outcome(),
+            sample_ids=("p1", "p2"),
+        )

--- a/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
@@ -13,6 +13,7 @@ from nirs4all.pipeline.dagml.native_archive_replay import (
     NativeArchiveReplayError,
     predict_methods_archive_v2_raw,
     predict_methods_archive_v2_raw_result,
+    project_methods_archive_v2_conformal_presentation,
     write_methods_archive_v2,
 )
 from nirs4all.pipeline.dagml.raw_replay_lowerer import (
@@ -391,6 +392,91 @@ def test_raw_archive_predict_projects_exact_native_conformal_intervals(
             sample_ids=["sample.one", "sample.two"],
             methods_library_path="/native/libn4m.so",
         )
+
+
+def test_raw_archive_projects_dagml_owned_scalar_conformal_presentation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The adapter transports the owner projection without interval arithmetic."""
+
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.resolve_methods_library_path",
+        lambda path: str(path),
+    )
+    runtime = _install_fake_runtime(monkeypatch)
+    package = _package()
+    package["package_fingerprint"] = "a" * 64
+    package["conformal_calibration"] = {"calibration_fingerprint": "b" * 64}
+
+    class _Package:
+        def __init__(self, raw: str) -> None:
+            self._document = json.loads(raw)
+
+        def to_dict(self) -> dict[str, object]:
+            return self._document
+
+    outcome = {
+        "outcome_fingerprint": "c" * 64,
+        "outputs": [
+            {
+                "binding": {"binding_id": "binding:prediction"},
+                "predictions": [
+                    {
+                        "sample_ids": ["sample.one", "sample.two"],
+                        "values": [[1.5], [2.5]],
+                    }
+                ],
+            }
+        ],
+    }
+    observed: dict[str, object] = {}
+
+    def project(native_package, request, replay_outcome):  # noqa: ANN001
+        observed.update(package=native_package, request=request, outcome=replay_outcome)
+        return {
+            "schema_version": 1,
+            "package_fingerprint": "a" * 64,
+            "replay_outcome_fingerprint": "c" * 64,
+            "binding_id": "binding:prediction",
+            "target_name": "y",
+            "sample_ids": ["sample.one", "sample.two"],
+            "point_predictions": [1.5, 2.5],
+            "intervals": [
+                {
+                    "coverage": 0.9,
+                    "lower": [1.0, 2.0],
+                    "upper": [2.0, 3.0],
+                    "qhat": 0.5,
+                }
+            ],
+            "calibration_fingerprint": "b" * 64,
+            "presentation_fingerprint": "d" * 64,
+        }
+
+    runtime.PortablePredictorPackage = _Package
+    runtime.replay_loaded_methods_predictor_package = lambda *_args, **_kwargs: outcome
+    runtime.build_conformal_presentation_v1 = project
+    monkeypatch.setitem(sys.modules, "dag_ml", runtime)
+    monkeypatch.setitem(
+        sys.modules,
+        "nirs4all_core",
+        types.SimpleNamespace(
+            read_portable_predictor_package_v2=lambda _path: json.dumps(package).encode()
+        ),
+    )
+
+    presentation = project_methods_archive_v2_conformal_presentation(
+        "portable.n4a",
+        np.asarray([[1.0], [2.0]]),
+        sample_ids=["sample.one", "sample.two"],
+        methods_library_path="/native/libn4m.so",
+    )
+
+    assert presentation["sample_ids"] == ["sample.one", "sample.two"]
+    assert presentation["point_predictions"] == [1.5, 2.5]
+    assert observed["package"].to_dict() == package
+    assert observed["outcome"] is outcome
+    assert observed["request"]["phase"] == "PREDICT"
 
 
 def test_native_archive_writer_composes_dagml_and_core_without_rebuilding_members(


### PR DESCRIPTION
## Summary

- expose the DAG-ML-owned scalar conformal presentation for a native Archive V2 PREDICT replay
- bind the transport projection exactly to the current package, replay, selected output and stable sample identities
- clean up raw replay state on every result path

No conformal calibration or interval endpoint arithmetic is duplicated in Python.

## Validation

- `python3.11 -m ruff check nirs4all/pipeline/dagml/native_archive_replay.py tests/unit/pipeline/dagml/test_native_archive_presentation.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py`
- `pytest -q tests/unit/api/test_engine_transition.py tests/unit/pipeline/dagml/test_native_archive_presentation.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/api/test_native_archive_session.py`
- `git diff --check`