### PR TITLE
feat(native): attach conformal presentation to predictions

### DIFF
--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -516,6 +516,10 @@ def _predict_from_native_archive(
             "archive_path": str(archive_path),
             "sample_ids": list(prediction_sample_ids),
         }
+        if native_prediction.conformal_presentation is not None:
+            metadata["conformal_presentation"] = dict(
+                native_prediction.conformal_presentation
+            )
     selected_coverages = _normalize_requested_coverages(coverage)
     if selected_coverages is not None:
         intervals = _select_native_archive_intervals(intervals, selected_coverages)

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -101,6 +101,10 @@ class NativeArchiveSession:
             result_metadata["selected_interval_coverages"] = sorted(
                 native_prediction.intervals
             )
+        if native_prediction.conformal_presentation is not None:
+            result_metadata["conformal_presentation"] = dict(
+                native_prediction.conformal_presentation
+            )
         return PredictResult(
             y_pred=native_prediction.values,
             metadata=result_metadata,

--- a/nirs4all/pipeline/dagml/native_archive_replay.py
+++ b/nirs4all/pipeline/dagml/native_archive_replay.py
@@ -59,6 +59,7 @@ class NativeArchivePrediction:
     sample_ids: tuple[str, ...]
     intervals: dict[float, NativeArchiveConformalInterval]
     conformal_guarantee_status: dict[str, Any] | None
+    conformal_presentation: dict[str, Any] | None = None
 
 
 def write_methods_archive_v2(
@@ -268,10 +269,25 @@ def predict_methods_archive_v2_raw_result(
             raise NativeArchiveReplayError(
                 "DAG-ML Methods Archive V2 replay was refused"
             ) from error
-        return _decode_exact_raw_prediction(
+        raw_prediction = _decode_exact_raw_prediction(
             outcome,
             identity.sample_ids,
             package_document,
+        )
+        presentation = _project_conformal_presentation_if_scalar(
+            dag_ml,
+            package,
+            replay.request,
+            outcome,
+            package_document=package_document,
+            sample_ids=identity.sample_ids,
+        )
+        return NativeArchivePrediction(
+            values=raw_prediction.values,
+            sample_ids=raw_prediction.sample_ids,
+            intervals=raw_prediction.intervals,
+            conformal_guarantee_status=raw_prediction.conformal_guarantee_status,
+            conformal_presentation=presentation,
         )
     except (MethodsPortableReplayError, RawArrayMethodsReplayError) as error:
         raise NativeArchiveReplayError(str(error)) from error
@@ -340,19 +356,19 @@ def project_methods_archive_v2_conformal_presentation(
             raise NativeArchiveReplayError(
                 "DAG-ML Methods Archive V2 conformal replay was refused"
             ) from error
-        projector = getattr(dag_ml, "build_conformal_presentation_v1", None)
-        if not callable(projector):
-            raise NativeArchiveReplayError(
-                "installed DAG-ML lacks the native conformal presentation projector; upgrade DAG-ML"
-            )
-        presentation = projector(package, replay.request, outcome)
-        _validate_conformal_presentation_transport(
-            presentation,
+        presentation = _project_conformal_presentation_if_scalar(
+            dag_ml,
+            package,
+            replay.request,
+            outcome,
             package_document=package_document,
-            outcome=outcome,
             sample_ids=identity.sample_ids,
         )
-        return dict(presentation)
+        if presentation is None:
+            raise NativeArchiveReplayError(
+                "native conformal presentation requires a scalar calibrated output and a DAG-ML presentation projector"
+            )
+        return presentation
     except (MethodsPortableReplayError, RawArrayMethodsReplayError) as error:
         raise NativeArchiveReplayError(str(error)) from error
     finally:
@@ -551,6 +567,50 @@ def _validate_conformal_presentation_transport(
                 for value in (point, lower_value, upper_value)
             ) or float(lower_value) > float(point) or float(point) > float(upper_value):
                 raise NativeArchiveReplayError("DAG-ML conformal presentation interval does not contain its point")
+
+
+def _project_conformal_presentation_if_scalar(
+    dag_ml: Any,
+    package: Any,
+    request: Any,
+    outcome: Any,
+    *,
+    package_document: dict[str, Any],
+    sample_ids: tuple[str, ...],
+) -> dict[str, Any] | None:
+    """Ask the DAG-ML owner for a presentation only when its V1 scope applies."""
+
+    if package_document.get("conformal_calibration") is None:
+        return None
+    document = outcome.to_dict() if hasattr(outcome, "to_dict") else outcome
+    outputs = document.get("outputs") if isinstance(document, dict) else None
+    if (
+        not isinstance(outputs, list)
+        or len(outputs) != 1
+        or not isinstance(outputs[0], dict)
+        or not isinstance(outputs[0].get("predictions"), list)
+        or len(outputs[0]["predictions"]) != 1
+        or not isinstance(outputs[0]["predictions"][0], dict)
+    ):
+        raise NativeArchiveReplayError(
+            "DAG-ML conformal presentation requires one selected replay prediction block"
+        )
+    values = outputs[0]["predictions"][0].get("values")
+    if not isinstance(values, list) or any(
+        not isinstance(row, list) or len(row) != 1 for row in values
+    ):
+        return None
+    projector = getattr(dag_ml, "build_conformal_presentation_v1", None)
+    if not callable(projector):
+        return None
+    presentation = projector(package, request, outcome)
+    _validate_conformal_presentation_transport(
+        presentation,
+        package_document=package_document,
+        outcome=outcome,
+        sample_ids=sample_ids,
+    )
+    return dict(presentation)
 
 
 def _decode_native_conformal_intervals(

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -31,6 +31,11 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
             sample_ids=("p1", "p2"),
             intervals={},
             conformal_guarantee_status=None,
+            conformal_presentation={
+                "schema_version": 1,
+                "sample_ids": ["p1", "p2"],
+                "point_predictions": [4.0, 5.0],
+            },
         )
 
     monkeypatch.setattr(
@@ -46,6 +51,7 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
         )
         assert result.y_pred.tolist() == [[4.0], [5.0]]
         assert result.metadata["engine"] == "native"
+        assert result.metadata["conformal_presentation"]["sample_ids"] == ["p1", "p2"]
     assert session.closed
     assert observed["sample_ids"] == ["p1", "p2"]
     assert observed["methods_library_path"] == "/native/libn4m.so"

--- a/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
+++ b/tests/unit/pipeline/dagml/test_raw_replay_lowerer.py
@@ -406,7 +406,16 @@ def test_raw_archive_projects_dagml_owned_scalar_conformal_presentation(
     runtime = _install_fake_runtime(monkeypatch)
     package = _package()
     package["package_fingerprint"] = "a" * 64
-    package["conformal_calibration"] = {"calibration_fingerprint": "b" * 64}
+    package["conformal_calibration"] = {
+        "calibration_fingerprint": "b" * 64,
+        "multi_target_policy": "marginal",
+        "quantiles": [
+            {
+                "coverage": 0.9,
+                "radii": [{"status": "finite", "value": 0.5}],
+            }
+        ],
+    }
 
     class _Package:
         def __init__(self, raw: str) -> None:
@@ -424,6 +433,23 @@ def test_raw_archive_projects_dagml_owned_scalar_conformal_presentation(
                     {
                         "sample_ids": ["sample.one", "sample.two"],
                         "values": [[1.5], [2.5]],
+                    }
+                ],
+            }
+        ],
+        "conformal_intervals": [
+            {
+                "binding_id": "binding:prediction",
+                "sample_ids": ["sample.one", "sample.two"],
+                "calibration_fingerprint": "b" * 64,
+                "point_prediction_fingerprint": "e" * 64,
+                "intervals": [
+                    {
+                        "coverage": 0.9,
+                        "cells": [
+                            [{"status": "finite", "lower": 1.0, "upper": 2.0}],
+                            [{"status": "finite", "lower": 2.0, "upper": 3.0}],
+                        ],
                     }
                 ],
             }
@@ -464,6 +490,15 @@ def test_raw_archive_projects_dagml_owned_scalar_conformal_presentation(
             read_portable_predictor_package_v2=lambda _path: json.dumps(package).encode()
         ),
     )
+
+    prediction = predict_methods_archive_v2_raw_result(
+        "portable.n4a",
+        np.asarray([[1.0], [2.0]]),
+        sample_ids=["sample.one", "sample.two"],
+        methods_library_path="/native/libn4m.so",
+    )
+    assert prediction.conformal_presentation is not None
+    assert prediction.conformal_presentation["point_predictions"] == [1.5, 2.5]
 
     presentation = project_methods_archive_v2_conformal_presentation(
         "portable.n4a",


### PR DESCRIPTION
## Summary

- attach the owner-validated scalar conformal presentation to native archive prediction metadata
- preserve the existing multi-target interval contract without fabricating a scalar presentation
- exercise public session metadata and direct native prediction transport

## Validation

- `python3.11 -m ruff check nirs4all/pipeline/dagml/native_archive_replay.py nirs4all/api/session.py nirs4all/api/predict.py tests/unit/pipeline/dagml/test_native_archive_presentation.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/api/test_native_archive_session.py`
- `pytest -q tests/unit/api/test_engine_transition.py tests/unit/pipeline/dagml/test_native_archive_presentation.py tests/unit/pipeline/dagml/test_raw_replay_lowerer.py tests/unit/api/test_native_archive_session.py`
- `git diff --check`