### PR TITLE
feat(native): lower plain preprocessing keyword

### DIFF
--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -198,11 +198,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_explicit_keyword",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "preprocessing_fit_on_all",
       "shape": "preprocessing_keyword",
       "owner_lane": "L5"
@@ -363,8 +358,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 16,
-    "native": 79,
+    "fallback": 15,
+    "native": 80,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -178,7 +178,7 @@ Source: `test_conformance_dual_engine.py:310-337`.
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
 | stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
 | by-source / per-source multi-source | `multi_source_by_source_branch_shared_preproc`, `multi_source_per_source_models_stacking` |
-| explicit `preprocessing` keyword + `fit_on_all` + `force_layout` | `preprocessing_explicit_keyword`, `preprocessing_fit_on_all`, `preprocessing_force_layout_2d` |
+| `preprocessing` policy overrides | `preprocessing_fit_on_all`, `preprocessing_force_layout_2d` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -198,11 +198,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_explicit_keyword",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "preprocessing_fit_on_all",
       "shape": "preprocessing_keyword",
       "owner_lane": "L5"
@@ -363,8 +358,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 16,
-    "native": 79,
+    "fallback": 15,
+    "native": 80,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/nirs4all/pipeline/dagml/steps.py
+++ b/nirs4all/pipeline/dagml/steps.py
@@ -205,6 +205,14 @@ def _assert_supported_operators(steps: list[Any]) -> None:
             # A keyword dict the bridge handles structurally (model / y_processing / …) is validated by its
             # own lowering path; but concat_transform / feature_augmentation CARRY X-side transforms that
             # FeatureConcat fits — recurse into those.
+            if "preprocessing" in operator:
+                # The plain legacy alias ``{"preprocessing": transform}`` is
+                # lowered as a normal X transform.  Policy-bearing variants
+                # remain a bridge boundary and must not bypass this routability
+                # check on their way to a native execution.
+                if set(operator) == {"preprocessing"}:
+                    _check_x_operator(operator["preprocessing"])
+                continue
             if "concat_transform" in operator or "feature_augmentation" in operator:
                 for nested in _nested_x_operators(operator):
                     _check_x_operator(nested)

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -1012,6 +1012,22 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             if generators:
                 dsl_step["generators"] = generators
             return dsl_step
+        if "preprocessing" in step:
+            # ``{"preprocessing": transformer}`` is the legacy spelling of a
+            # top-level X transform.  With no companion policy it has exactly
+            # the same fold-local fit/transform semantics as the bare operator
+            # form already lowered below.  Do not silently erase policy keys:
+            # ``fit_on_all`` changes the fit universe and ``force_layout``
+            # changes the data-plane contract, neither of which the native
+            # runtime can reproduce yet.
+            unsupported = sorted(set(step) - {"preprocessing"})
+            if unsupported:
+                raise NotImplementedError(
+                    "dag-ml bridge does not lower preprocessing policy key(s) "
+                    f"{unsupported}; only the plain {{'preprocessing': transform}} spelling is native"
+                )
+            op = step["preprocessing"]
+            return {"class": _qualname(op), "params": _json_safe_params(op)}
         if "y_processing" in step:
             op = step["y_processing"]
             return {"y_processing": {"class": _qualname(op), "params": _json_safe_params(op)}}

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -394,8 +394,8 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_by_source_branch_shared_preproc",
     "multi_source_per_source_models_stacking",
-    # the explicit `preprocessing` keyword + fit_on_all + force_layout shapes.
-    "preprocessing_explicit_keyword",
+    # Policy-bearing `preprocessing` forms remain separate from the plain
+    # explicit spelling, which now lowers exactly like its bare transform.
     "preprocessing_fit_on_all",
     "preprocessing_force_layout_2d",
 })

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -2268,6 +2268,22 @@ def test_concat_transform_bridge_lowers_to_feature_concat() -> None:
     assert [op["class"] for op in ops] == ["sklearn.preprocessing._data.StandardScaler", "sklearn.preprocessing._data.MinMaxScaler"]
 
 
+def test_plain_preprocessing_keyword_lowers_as_the_equivalent_x_transform() -> None:
+    """The legacy explicit spelling is native only when it carries no policy."""
+    from sklearn.preprocessing import StandardScaler
+
+    from nirs4all.pipeline.dagml_bridge import _step_to_dsl
+
+    dsl = _step_to_dsl({"preprocessing": StandardScaler()})
+    assert dsl == {
+        "class": "sklearn.preprocessing._data.StandardScaler",
+        "params": {"copy": True, "with_mean": True, "with_std": True},
+    }
+
+    with pytest.raises(NotImplementedError, match="preprocessing policy"):
+        _step_to_dsl({"preprocessing": StandardScaler(), "fit_on_all": True})
+
+
 def test_concat_transform_3d_shapes_fail_loud() -> None:
     """The processing-AXIS shapes raise NotImplementedError naming the data-plane (#29/#31), never silent.
 


### PR DESCRIPTION
## Summary
- lower the plain legacy `{"preprocessing": transform}` spelling as its equivalent fold-local native X transform
- retain explicit failures for `fit_on_all` and `force_layout`, whose semantics are not yet native
- remove the now-native parity case from the expected-fallback ledger (16 → 15)

## Validation
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_conformance_dual_engine.py -k preprocessing_explicit_keyword`
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_compatibility_ledger.py`
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_dagml_cli_runner.py`
- `ruff check …`
- `git diff --check`