### PR TITLE
feat(native): lower no-op preprocessing layout

### DIFF
--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -203,11 +203,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_force_layout_2d",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "refit_params_use_all_partitions",
       "shape": "refit_params",
       "owner_lane": "L5"
@@ -358,8 +353,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 15,
-    "native": 80,
+    "fallback": 14,
+    "native": 81,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -178,7 +178,7 @@ Source: `test_conformance_dual_engine.py:310-337`.
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
 | stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
 | by-source / per-source multi-source | `multi_source_by_source_branch_shared_preproc`, `multi_source_per_source_models_stacking` |
-| `preprocessing` policy overrides | `preprocessing_fit_on_all`, `preprocessing_force_layout_2d` |
+| `preprocessing` fit-universe override | `preprocessing_fit_on_all` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -203,11 +203,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_force_layout_2d",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "refit_params_use_all_partitions",
       "shape": "refit_params",
       "owner_lane": "L5"
@@ -358,8 +353,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 15,
-    "native": 80,
+    "fallback": 14,
+    "native": 81,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/nirs4all/pipeline/dagml/steps.py
+++ b/nirs4all/pipeline/dagml/steps.py
@@ -210,7 +210,7 @@ def _assert_supported_operators(steps: list[Any]) -> None:
                 # lowered as a normal X transform.  Policy-bearing variants
                 # remain a bridge boundary and must not bypass this routability
                 # check on their way to a native execution.
-                if set(operator) == {"preprocessing"}:
+                if set(operator) in ({"preprocessing"}, {"preprocessing", "force_layout"}) and operator.get("force_layout", "2d") == "2d":
                     _check_x_operator(operator["preprocessing"])
                 continue
             if "concat_transform" in operator or "feature_augmentation" in operator:

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -1017,10 +1017,17 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             # top-level X transform.  With no companion policy it has exactly
             # the same fold-local fit/transform semantics as the bare operator
             # form already lowered below.  Do not silently erase policy keys:
-            # ``fit_on_all`` changes the fit universe and ``force_layout``
-            # changes the data-plane contract, neither of which the native
-            # runtime can reproduce yet.
-            unsupported = sorted(set(step) - {"preprocessing"})
+            # ``fit_on_all`` changes the fit universe and cannot be erased.
+            # The legacy transformer controller does not consume
+            # ``force_layout`` itself: it always obtains its per-source arrays
+            # in its established 3D representation.  Its documented ``2d``
+            # spelling is therefore a no-op for this transform role and can
+            # lower to the same native X node.  Keep every other companion key
+            # fail-closed rather than guessing at future data-plane semantics.
+            supported = {"preprocessing"}
+            if step.get("force_layout") == "2d":
+                supported.add("force_layout")
+            unsupported = sorted(set(step) - supported)
             if unsupported:
                 raise NotImplementedError(
                     "dag-ml bridge does not lower preprocessing policy key(s) "

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -394,10 +394,9 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_by_source_branch_shared_preproc",
     "multi_source_per_source_models_stacking",
-    # Policy-bearing `preprocessing` forms remain separate from the plain
-    # explicit spelling, which now lowers exactly like its bare transform.
+    # `fit_on_all` changes the fit universe.  The explicit spelling and the
+    # legacy no-op `force_layout='2d'` form lower as their bare transform.
     "preprocessing_fit_on_all",
-    "preprocessing_force_layout_2d",
 })
 
 

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -2283,6 +2283,10 @@ def test_plain_preprocessing_keyword_lowers_as_the_equivalent_x_transform() -> N
     with pytest.raises(NotImplementedError, match="preprocessing policy"):
         _step_to_dsl({"preprocessing": StandardScaler(), "fit_on_all": True})
 
+    assert _step_to_dsl({"preprocessing": StandardScaler(), "force_layout": "2d"}) == dsl
+    with pytest.raises(NotImplementedError, match="preprocessing policy"):
+        _step_to_dsl({"preprocessing": StandardScaler(), "force_layout": "3d"})
+
 
 def test_concat_transform_3d_shapes_fail_loud() -> None:
     """The processing-AXIS shapes raise NotImplementedError naming the data-plane (#29/#31), never silent.


### PR DESCRIPTION
## Summary
- lower the legacy `{"preprocessing": op, "force_layout": "2d"}` spelling to its equivalent native X transform
- preserve explicit refusal for `fit_on_all` and non-equivalent layout values
- remove the now-native parity case from the expected-fallback ledger (15 → 14)

## Validation
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_conformance_dual_engine.py -k 'preprocessing_explicit_keyword or preprocessing_force_layout_2d or preprocessing_fit_on_all'` (6 passed)
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_compatibility_ledger.py`
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_dagml_cli_runner.py -k plain_preprocessing_keyword`
- `ruff check …`
- `git diff --check`