### PR TITLE
feat(native): admit stateless fit-on-all preprocessing

### DIFF
--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -198,11 +198,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_fit_on_all",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "refit_params_use_all_partitions",
       "shape": "refit_params",
       "owner_lane": "L5"
@@ -353,8 +348,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 14,
-    "native": 81,
+    "fallback": 13,
+    "native": 82,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -178,7 +178,6 @@ Source: `test_conformance_dual_engine.py:310-337`.
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
 | stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
 | by-source / per-source multi-source | `multi_source_by_source_branch_shared_preproc`, `multi_source_per_source_models_stacking` |
-| `preprocessing` fit-universe override | `preprocessing_fit_on_all` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -198,11 +198,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "preprocessing_fit_on_all",
-      "shape": "preprocessing_keyword",
-      "owner_lane": "L5"
-    },
-    {
       "case": "refit_params_use_all_partitions",
       "shape": "refit_params",
       "owner_lane": "L5"
@@ -353,8 +348,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 14,
-    "native": 81,
+    "fallback": 13,
+    "native": 82,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/nirs4all/pipeline/dagml/steps.py
+++ b/nirs4all/pipeline/dagml/steps.py
@@ -210,7 +210,7 @@ def _assert_supported_operators(steps: list[Any]) -> None:
                 # lowered as a normal X transform.  Policy-bearing variants
                 # remain a bridge boundary and must not bypass this routability
                 # check on their way to a native execution.
-                if set(operator) in ({"preprocessing"}, {"preprocessing", "force_layout"}) and operator.get("force_layout", "2d") == "2d":
+                if set(operator) <= {"preprocessing", "force_layout", "fit_on_all"} and operator.get("force_layout", "2d") == "2d":
                     _check_x_operator(operator["preprocessing"])
                 continue
             if "concat_transform" in operator or "feature_augmentation" in operator:

--- a/nirs4all/pipeline/dagml_bridge.py
+++ b/nirs4all/pipeline/dagml_bridge.py
@@ -1016,8 +1016,11 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             # ``{"preprocessing": transformer}`` is the legacy spelling of a
             # top-level X transform.  With no companion policy it has exactly
             # the same fold-local fit/transform semantics as the bare operator
-            # form already lowered below.  Do not silently erase policy keys:
-            # ``fit_on_all`` changes the fit universe and cannot be erased.
+            # form already lowered below.  ``fit_on_all`` changes the fit
+            # universe for a learned transform and cannot be erased.  A
+            # transform proved stateless is the narrow exception: fitting it
+            # on every row or per-fold has exactly the same result.  The proof
+            # is shared with the augmentation leakage guard and fails closed.
             # The legacy transformer controller does not consume
             # ``force_layout`` itself: it always obtains its per-source arrays
             # in its established 3D representation.  Its documented ``2d``
@@ -1027,6 +1030,19 @@ def _step_to_dsl(step: Any) -> dict[str, Any]:
             supported = {"preprocessing"}
             if step.get("force_layout") == "2d":
                 supported.add("force_layout")
+            if "fit_on_all" in step:
+                fit_on_all = step["fit_on_all"]
+                if fit_on_all is False:
+                    supported.add("fit_on_all")
+                elif fit_on_all is True:
+                    from nirs4all.pipeline.dagml.run_paths import _operator_is_stateless
+
+                    if _operator_is_stateless(step["preprocessing"]):
+                        supported.add("fit_on_all")
+                    else:
+                        raise NotImplementedError(
+                            "dag-ml bridge cannot lower fit_on_all for a transform with data-dependent fit state"
+                        )
             unsupported = sorted(set(step) - supported)
             if unsupported:
                 raise NotImplementedError(

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -394,9 +394,6 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_by_source_branch_shared_preproc",
     "multi_source_per_source_models_stacking",
-    # `fit_on_all` changes the fit universe.  The explicit spelling and the
-    # legacy no-op `force_layout='2d'` form lower as their bare transform.
-    "preprocessing_fit_on_all",
 })
 
 

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -2280,12 +2280,26 @@ def test_plain_preprocessing_keyword_lowers_as_the_equivalent_x_transform() -> N
         "params": {"copy": True, "with_mean": True, "with_std": True},
     }
 
-    with pytest.raises(NotImplementedError, match="preprocessing policy"):
+    with pytest.raises(NotImplementedError, match="data-dependent fit state"):
         _step_to_dsl({"preprocessing": StandardScaler(), "fit_on_all": True})
 
     assert _step_to_dsl({"preprocessing": StandardScaler(), "force_layout": "2d"}) == dsl
     with pytest.raises(NotImplementedError, match="preprocessing policy"):
         _step_to_dsl({"preprocessing": StandardScaler(), "force_layout": "3d"})
+
+
+def test_fit_on_all_lowers_only_for_provably_stateless_preprocessing() -> None:
+    """A full-universe fit is equivalent to fold-local fitting only without learned state."""
+    from sklearn.preprocessing import StandardScaler
+
+    from nirs4all.operators.transforms.scalers import StandardNormalVariate
+    from nirs4all.pipeline.dagml_bridge import _step_to_dsl
+
+    dsl = _step_to_dsl({"preprocessing": StandardNormalVariate(), "fit_on_all": True})
+    assert dsl["class"] == "nirs4all.operators.transforms.scalers.StandardNormalVariate"
+
+    with pytest.raises(NotImplementedError, match="data-dependent fit state"):
+        _step_to_dsl({"preprocessing": StandardScaler(), "fit_on_all": True})
 
 
 def test_concat_transform_3d_shapes_fail_loud() -> None:


### PR DESCRIPTION
## Summary
- lower `fit_on_all=True` only when the transform is conservatively proven stateless
- retain fail-closed refusal for data-dependent fit state
- remove the verified SNV parity case from the expected-fallback ledger (14 → 13)

## Validation
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_dagml_cli_runner.py -k 'plain_preprocessing_keyword or fit_on_all_lowers'`
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_conformance_dual_engine.py -k preprocessing_fit_on_all`
- `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_compatibility_ledger.py`
- `ruff check …`
- `git diff --check`