### PR TITLE
docs(native): update fallback coverage count

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -157,7 +157,7 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (15)
+### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (13)
 
 Shapes the dag-ml host bridge does **not serialize yet**, so `engine="dag-ml"`
 transparently re-runs legacy. These make **no parity claim** — they are pinned by
@@ -261,7 +261,7 @@ gate.
 | Registered `PipelineCase`s | **95** | `cases_*.py` `register()` calls |
 | Non-runnable (`skip_reason` set) | **0** | no fixture/unknown/legacy-bug skips in the registry |
 | Runnable | **95** | 95 − 0 |
-| → fall back to legacy (`EXPECTED_FALLBACK`) | **15** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
+| → fall back to legacy (`EXPECTED_FALLBACK`) | **13** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
 | → run native on dag-ml | **80** | full parity asserted or parity-note pinned |
 | Strict-xfail (documented divergence) | **0** | `KNOWN_DIVERGENCES` is empty; no `legacy_bug` rows in the current registry |
 | `pytest.skip` (fixture) | **0** | fixture skips retired |


### PR DESCRIPTION
Align the narrative compatibility table with the validated fallback ledger (13 remaining cases).\n\nValidation: `PYTHONPATH=. python3.11 -m pytest -q tests/integration/parity/test_compatibility_ledger.py`, `git diff --check`.