### PR TITLE
[codex] Run shared by-source preprocessing natively

### DIFF
--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -183,11 +183,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "multi_source_by_source_branch_shared_preproc",
-      "shape": "multi_source",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -157,7 +157,7 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (12)
+### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (11)
 
 Shapes the dag-ml host bridge does **not serialize yet**, so `engine="dag-ml"`
 transparently re-runs legacy. These make **no parity claim** — they are pinned by
@@ -177,7 +177,7 @@ Source: `test_conformance_dual_engine.py:310-337`.
 | classification repetition + vote aggregation | `aggregation_classification_vote` |
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
 | stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
-| by-source / per-source multi-source | `multi_source_by_source_branch_shared_preproc`, `multi_source_per_source_models_stacking` |
+| by-source / per-source multi-source | `multi_source_per_source_models_stacking` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**
@@ -261,8 +261,8 @@ gate.
 | Registered `PipelineCase`s | **95** | `cases_*.py` `register()` calls |
 | Non-runnable (`skip_reason` set) | **0** | no fixture/unknown/legacy-bug skips in the registry |
 | Runnable | **95** | 95 − 0 |
-| → fall back to legacy (`EXPECTED_FALLBACK`) | **12** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
-| → run native on dag-ml | **83** | full parity asserted or parity-note pinned |
+| → fall back to legacy (`EXPECTED_FALLBACK`) | **11** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
+| → run native on dag-ml | **84** | full parity asserted or parity-note pinned |
 | Strict-xfail (documented divergence) | **0** | `KNOWN_DIVERGENCES` is empty; no `legacy_bug` rows in the current registry |
 | `pytest.skip` (fixture) | **0** | fixture skips retired |
 | `NUM_PREDICTIONS_DIVERGENCE` parity-notes (PASS) | **2** | counts pinned |
@@ -272,7 +272,7 @@ gate.
 > **Correction to prior counts:** the current machine-readable ledger and live
 > registry have no `legacy_bug`, `unknown_semantics`, or fixture skip rows. The
 > verified meter is **0** non-runnable / **95** runnable. `EXPECTED_FALLBACK` is
-> now **12** because the remaining shapes retain native-incompatible semantics:
+> now **11** because the remaining shapes retain native-incompatible semantics:
 > native, `finetune_params` is an explicit coverage boundary, and stateful
 > `concat_transform` now falls back until dag-ml preserves the Python oracle's
 > pre-CV materialization semantics.

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -183,11 +183,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "multi_source_by_source_branch_shared_preproc",
-      "shape": "multi_source",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"

--- a/nirs4all/pipeline/dagml/detect.py
+++ b/nirs4all/pipeline/dagml/detect.py
@@ -889,13 +889,14 @@ def _detect_by_source_branch(pipeline: list[Any], n_sources: int) -> tuple[list[
     return body, aggregate
 
 
-def _detect_by_source_distinct_preproc_concat(pipeline: list[Any], n_sources: int) -> tuple[dict[str, list[Any]], list[Any]] | None:
-    """Detect per-source by_source preprocessing + concat features + one downstream model.
+def _detect_by_source_distinct_preproc_concat(pipeline: list[Any], n_sources: int) -> tuple[dict[str, list[Any]] | list[Any], list[Any]] | None:
+    """Detect by-source preprocessing + concat features + one downstream model.
 
     Admits ONLY the target feature-concat shape:
 
     * a multi-source dataset (``n_sources >= 2``);
-    * one by_source branch whose ``steps`` body is a DICT of per-source preprocessing lists;
+    * one by_source branch whose ``steps`` body is either a shared preprocessing LIST or a DICT of
+      per-source preprocessing lists;
     * no model/y_processing inside any per-source body;
     * one ``{"merge": "concat"}`` followed immediately by one downstream model step;
     * no other top-level step except the splitter.
@@ -923,6 +924,13 @@ def _detect_by_source_distinct_preproc_concat(pipeline: list[Any], n_sources: in
     if set(criterion) - _HANDLED_BY_SOURCE_KEYS:
         return None
     body = criterion.get("steps")
+    if isinstance(body, list):
+        if not body or any(
+            isinstance(substep, dict) and ("model" in substep or "y_processing" in substep)
+            for substep in body
+        ):
+            return None
+        return body, [model_step]
     if not isinstance(body, dict) or len(body) != n_sources or not all(isinstance(key, str) for key in body):
         return None
 

--- a/nirs4all/pipeline/dagml/run_paths.py
+++ b/nirs4all/pipeline/dagml/run_paths.py
@@ -1550,7 +1550,7 @@ def _repeat_by_source_merge_projection(result: RunResult, n_sources: int) -> Run
 
 def _run_by_source_distinct_preproc_concat(
     pipeline: list[Any],
-    source_steps: dict[str, list[Any]],
+    source_steps: dict[str, list[Any]] | list[Any],
     downstream_body: list[Any],
     n_sources: int,
     spectro: Any,
@@ -1564,12 +1564,13 @@ def _run_by_source_distinct_preproc_concat(
     config_name: str = "",
     random_state: int | None = None,
 ) -> RunResult:
-    """Run by_source DICT preprocessing + concat + downstream model as one native model node.
+    """Run by-source preprocessing + concat + downstream model as one native model node.
 
-    Each source's transform chain is cloned and fit on that source's fold-train block, the
-    transformed blocks are hstacked in ``source_layout.source_order``, and the downstream
-    model is fit on that concatenated matrix. Validation/test use the fitted per-source
-    chains, so preprocessing is fold-local and never fit on early-fused concat.
+    A dict carries one transform chain per source.  A list is the legacy shared-body spelling and is
+    expanded only after the envelope supplies its authoritative ``source_layout.source_order``.  In both
+    cases each chain is cloned and fit on that source's fold-train block, then the transformed blocks are
+    hstacked before the downstream model is fit.  Validation/test use those fitted chains, so no
+    preprocessing is fit on an early-fused matrix.
     """
     import dag_ml
 
@@ -1592,6 +1593,20 @@ def _run_by_source_distinct_preproc_concat(
     folds = _build_folds(splitter, spectro, pool, set())
     envelope = build_envelope(spectro, identity, sample_ints=pool)
     source_layout = (envelope.get("plan") or {}).get("source_layout")
+    if isinstance(source_steps, list):
+        if not isinstance(source_layout, dict) or not isinstance(source_layout.get("source_order"), list):
+            raise DagMlUnsupported(
+                "by_source shared preprocessing requires envelope plan.source_layout.source_order"
+            )
+        source_steps = {
+            source_name: list(source_steps)
+            for source_name in source_layout["source_order"]
+            if isinstance(source_name, str)
+        }
+        if len(source_steps) != n_sources:
+            raise DagMlUnsupported(
+                "by_source shared preprocessing source layout does not contain one unique name per source"
+            )
     source_preprocessing = _source_preprocessing_metadata(source_steps, source_layout)
     if len(source_preprocessing["sources"]) != n_sources:
         raise DagMlUnsupported(

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -390,7 +390,6 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # rather than ignore the override or emulate the legacy leakage-prone shape.
     "refit_params_use_all_partitions",
     # by-source separation / per-source models / source-concat multi-source shapes.
-    "multi_source_by_source_branch_shared_preproc",
     "multi_source_per_source_models_stacking",
 })
 

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -3933,7 +3933,24 @@ def test_by_source_branch_detection() -> None:
     assert set(source_steps) == {"source_0", "source_1", "source_2"}
     assert downstream == [{"model": distinct_concat[-1]["model"]}]
     assert _detect_by_source_branch(distinct_concat, n_sources=3) is None
-    assert _detect_by_source_distinct_preproc_concat([splitter, {"branch": {"by_source": True, "steps": [StandardNormalVariate()]}}, {"merge": "concat"}, {"model": PLSRegression()}], n_sources=3) is None
+
+    # The shared LIST spelling carries one preprocessing chain per source.  It reaches the same
+    # source-layout-aware native materializer as the explicit dict form; the runner expands the list only
+    # after reading the envelope's attested source order.
+    shared_concat = [
+        splitter,
+        {"branch": {"by_source": True, "steps": [StandardNormalVariate()]}},
+        {"merge": "concat"},
+        {"model": PLSRegression()},
+    ]
+    shared_detected = _detect_by_source_distinct_preproc_concat(shared_concat, n_sources=3)
+    assert shared_detected is not None
+    shared_steps, downstream = shared_detected
+    assert shared_steps == [shared_concat[1]["branch"]["steps"][0]]
+    assert downstream == [{"model": shared_concat[-1]["model"]}]
+    # A model belongs after the feature concat.  Allowing it inside the shared body would change the
+    # branch topology, so it must remain a fail-loud boundary.
+    assert _detect_by_source_distinct_preproc_concat([splitter, {"branch": {"by_source": True, "steps": [{"model": PLSRegression()}]}}, {"merge": "concat"}, {"model": PLSRegression()}], n_sources=3) is None
     assert _detect_by_source_distinct_preproc_concat([splitter, {"branch": {"by_source": True, "steps": {"source_0": [StandardNormalVariate()]}}}, {"merge": "concat"}, {"model": PLSRegression()}], n_sources=3) is None
 
 


### PR DESCRIPTION
## Summary

- lowers the shared `by_source` preprocessing-list + `merge: concat` shape through the existing per-source native materialization path
- expands the shared chain only after reading the attested envelope source order
- removes the now-proven case from the fallback ledger (12 → 11)

## Validation

- `python3.11 -m ruff check nirs4all/pipeline/dagml/detect.py nirs4all/pipeline/dagml/run_paths.py tests/integration/parity/test_conformance_dual_engine.py`
- `python3.11 -m pytest -q tests/integration/parity/test_conformance_dual_engine.py -k multi_source_by_source_branch_shared_preproc --tb=short`
- `python3.11 -m pytest -q tests/integration/parity/test_conformance_export_roundtrip.py --tb=short`
- `python3.11 -m mypy nirs4all/pipeline/dagml/detect.py nirs4all/pipeline/dagml/run_paths.py --follow-imports=silent`
- `git diff --check`