### PR TITLE
feat(native): harden public Methods lifecycle

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -159,10 +159,12 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (11)
 
-Shapes the dag-ml host bridge does **not serialize yet**, so `engine="dag-ml"`
-transparently re-runs legacy. These make **no parity claim** — they are pinned by
-the never-xfailed `test_native_fallback_boundary` (`test_conformance_dual_engine.py:375`):
-a fallback off the allowlist = native-coverage **regression → FAIL**; a native
+Shapes the dag-ml host bridge does **not serialize yet**. A normal
+`engine="dag-ml"` request fails closed; the parity harness exercises these rows
+only with the explicit `allow_legacy_fallback=True` diagnostic rollback. They
+make **no parity claim** — they are pinned by the never-xfailed
+`test_native_fallback_boundary` (`test_conformance_dual_engine.py:375`): a
+fallback off the allowlist = native-coverage **regression → FAIL**; a native
 case on the allowlist = **stale entry → FAIL**. **Owner: L5/A3** (host-bridge
 serialization, runtime work — not a tolerance question). When L5 lands native
 coverage, the entry leaves the allowlist and the boundary test then demands

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -252,11 +252,11 @@ should branch on it rather than inferring support from the broader legacy API.
 | --- | --- | --- |
 | `run(..., engine="native")` | Supported subset | Explicit raw mapping `{"X", "y", "sample_ids"}`, portable Methods pipeline, native refit, and no legacy workspace/cache/project/result path. Unsupported shapes stop before a legacy run. |
 | `session(pipeline, engine="native")` | Supported subset | Returns `NativeMethodsSession`: native train, identity-bound prediction, Archive V2 export, close, and one selected full refit that returns a V3 child. It does not create a `PipelineRunner`. |
-| `predict(..., engine="native")` | Supported subset | Requires an explicitly identified cohort. It accepts a trained `NativeMethodsSession`, a V3 refit result, or a validated Methods Archive V2/V3 session and rehydrates the N4MM for that invocation only. |
+| `predict(..., engine="native")` | Supported subset | Requires an explicitly identified cohort. It accepts an in-memory `NativeMethodsRunResult`, a trained `NativeMethodsSession`, a V3 refit result, or a validated Methods Archive V2/V3 session. In-memory results call the already-attested estimator directly; archive/session replay rehydrates N4MM for that invocation only. |
 | `load_session(path, engine="native")` | Supported, PREDICT-only | Validates Core Archive V2/Package V2 or Archive V3/Package V3 before data/model hydration, then returns `NativeArchiveSession`. It has no train, retrain, save, or legacy fallback capability. |
 | `retrain(source, data, mode="full", engine="native")` | Supported subset | Source must be an in-memory `NativeMethodsRunResult` with a completed selected refit and attested seed. The selected PLS variant is copied exactly and the child outcome persists signed parent lineage. |
 | Native transfer / finetune retrain | Refused | `mode="transfer"`, `mode="finetune"`, archive sources, replacement models, epochs, and legacy retrain kwargs are rejected before native execution. A future plugin must declare its own artifact and lineage contract. |
-| `explain(..., engine="native")` | Refused | SHAP is a host plugin today. The request is rejected at engine preflight; it is never rerouted to legacy implicitly. |
+| `explain(..., engine="native")` | Refused | SHAP is a host plugin today. A native result or session is rejected at preflight even when no engine argument is supplied; it is never rerouted to legacy implicitly. |
 | `generate(..., engine="native")` | Refused | Synthetic-data generation has no native Methods implementation. The explicit engine is rejected before a builder or dataset is constructed. |
 
 The default remains unchanged during R2: it is not evidence that every legacy

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -207,21 +207,24 @@ if (run.status !== 0) process.exit(run.status);
 | --- | --- |
 | `None` | Use the package default resolved by `resolve_engine(...)`. |
 | `"legacy"` | Use the in-process Python orchestrator. |
-| `"dag-ml"` | Request the dag-ml backend for covered shapes; catchable unsupported/unavailable cases warn and fall back to legacy. |
+| `"dag-ml"` | Request the dag-ml backend for covered shapes; catchable unsupported/unavailable cases fail closed unless the caller explicitly passes `allow_legacy_fallback=True`. |
 | `"dual"` | Strict no-fallback oracle for exact finite floating NumPy `X` and continuous regression `y`, exact `KFold(shuffle=False)`, and one exact `PLSRegression`; it requires built-in integer `random_state`, `refit=True`, all output flags false, no session/cache/project/runner kwargs/results path/native-results environment, a concrete winner/OOF splits, finite `cv_best_score`, and finite per-fold `val_score` plus declared validation RMSE. The legacy workspace is temporary and removed before return. Its report explicitly marks the current PLS route as `orchestration_parity_only` / `python_sklearn_pls`, not native Methods execution. It raises `DualRunUnsupported` or `DualRunMismatchError`. |
 
-The pipeline language is broader than current dag-ml native coverage. Requesting `engine="dag-ml"` is safe for user workflows because catchable unsupported shapes and unavailable dag-ml runtime dependencies warn and re-run on the legacy engine. A genuine dag-ml runtime/operator bug still propagates as an error.
+The pipeline language is broader than current dag-ml native coverage. Requesting
+`engine="dag-ml"` is fail-closed: a catchable unsupported shape or unavailable
+runtime is returned to the caller before a legacy engine is constructed. A
+genuine dag-ml runtime/operator bug also propagates unchanged.
 
-For migration qualification, set `allow_legacy_fallback=False`. In that mode a
-catchable unavailable or unsupported DAG-ML request is returned to the caller
-as an error before any legacy execution starts:
+`allow_legacy_fallback=True` is the explicit diagnostic/rollback action. It
+emits a warning and re-runs only catchable unsupported or unavailable requests
+on legacy; it is never an implicit substitute for a claimed native execution:
 
 ```python
 result = nirs4all.run(
     pipeline="pipeline.yaml",
     dataset="dataset.yaml",
     engine="dag-ml",
-    allow_legacy_fallback=False,
+    allow_legacy_fallback=True,
     random_state=42,
 )
 ```

--- a/nirs4all/api/explain.py
+++ b/nirs4all/api/explain.py
@@ -23,14 +23,19 @@ import numpy as np
 from nirs4all.data import DatasetConfigs
 from nirs4all.data.dataset import SpectroDataset
 from nirs4all.pipeline import PipelineRunner
-from nirs4all.pipeline.engine import require_legacy_engine
+from nirs4all.pipeline.engine import require_legacy_engine, resolve_engine
 
+from .native_refit_result import NativeMethodsRefitResult
+from .native_result import NativeMethodsRunResult
+from .native_session import NativeMethodsSession
 from .result import ExplainResult
-from .session import Session
+from .session import NativeArchiveSession, Session
 
 # Type aliases for clarity
 ModelSpec: TypeAlias = (
-    dict[str, Any]               # Prediction dict from previous run
+    NativeMethodsRunResult  # In-memory native selected estimator
+    | NativeMethodsRefitResult  # Detached native full-refit result
+    | dict[str, Any]               # Prediction dict from previous run
     | str                          # Path to bundle (.n4a) or config
     | Path                          # Path to bundle or config
 )
@@ -49,7 +54,7 @@ def explain(
     data: DataSpec,
     *,
     name: str = "explain_dataset",
-    session: Session | None = None,
+    session: Session | NativeArchiveSession | NativeMethodsSession | None = None,
     verbose: int = 1,
     plots_visible: bool = True,
     # SHAP-specific parameters
@@ -167,6 +172,17 @@ def explain(
         - :class:`nirs4all.api.result.ExplainResult`: Result class
     """
     engine = shap_params.pop("engine", None)
+    if isinstance(model, (NativeMethodsRunResult, NativeMethodsRefitResult)) or isinstance(
+        session, (NativeArchiveSession, NativeMethodsSession)
+    ):
+        if engine is not None and resolve_engine(engine) != "native":
+            raise ValueError(
+                "a native Methods result or session selects native explanation; an explicit non-native engine is refused"
+            )
+        raise NotImplementedError(
+            "nirs4all.explain requires an explicitly installed native or host explanation plugin for Methods artifacts; "
+            "it refuses before constructing a legacy PipelineRunner"
+        )
     require_legacy_engine("explain", engine)
 
     # Build SHAP params dict

--- a/nirs4all/api/explain.py
+++ b/nirs4all/api/explain.py
@@ -33,9 +33,7 @@ from .session import NativeArchiveSession, Session
 
 # Type aliases for clarity
 ModelSpec: TypeAlias = (
-    NativeMethodsRunResult  # In-memory native selected estimator
-    | NativeMethodsRefitResult  # Detached native full-refit result
-    | dict[str, Any]               # Prediction dict from previous run
+    dict[str, Any]  # Prediction dict from previous run
     | str                          # Path to bundle (.n4a) or config
     | Path                          # Path to bundle or config
 )
@@ -54,7 +52,7 @@ def explain(
     data: DataSpec,
     *,
     name: str = "explain_dataset",
-    session: Session | NativeArchiveSession | NativeMethodsSession | None = None,
+    session: Session | None = None,
     verbose: int = 1,
     plots_visible: bool = True,
     # SHAP-specific parameters

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -44,13 +44,15 @@ from nirs4all.pipeline import PipelineRunner
 from nirs4all.pipeline.engine import require_legacy_engine, resolve_engine
 
 from .native_refit_result import NativeMethodsRefitResult
+from .native_result import NativeMethodsRunResult
 from .native_session import NativeMethodsSession
 from .result import PredictResult
 from .session import NativeArchiveSession, Session
 
 # Type aliases for clarity
 ModelSpec: TypeAlias = (
-    NativeMethodsRefitResult  # Detached native full-refit result
+    NativeMethodsRunResult  # In-memory native selected estimator
+    | NativeMethodsRefitResult  # Detached native full-refit result
     | dict[str, Any]  # Prediction dict from previous run
     | str  # Path to bundle (.n4a) or config
     | Path  # Path to bundle or config
@@ -231,7 +233,7 @@ def predict(
     engine = runner_kwargs.pop("engine", None)
 
     if isinstance(session, (NativeArchiveSession, NativeMethodsSession)) or isinstance(
-        model, NativeMethodsRefitResult
+        model, (NativeMethodsRunResult, NativeMethodsRefitResult)
     ):
         if engine is None:
             # The session itself is an unambiguous, already-selected native
@@ -272,7 +274,7 @@ def predict(
             )
         return result
 
-    if isinstance(model, NativeMethodsRefitResult):
+    if isinstance(model, (NativeMethodsRunResult, NativeMethodsRefitResult)):
         raise AssertionError("native V3 result escaped its required native prediction route")
 
     # The explicit native branch above consumes every NativeArchiveSession.
@@ -481,6 +483,25 @@ def _predict_from_native_archive(
     if not isinstance(data, Mapping) or "X" not in data or "sample_ids" not in data:
         raise TypeError(
             "engine='native' predict requires data={'X': matrix, 'sample_ids': explicit_ids}"
+        )
+    if isinstance(model, NativeMethodsRunResult):
+        if all_predictions or coverage is not None:
+            raise NotImplementedError(
+                "engine='native' in-memory Methods prediction exposes one selected point output without conformal sidecars"
+            )
+        values = np.asarray(
+            model.native_estimator.predict_with_identity(
+                data["X"],
+                sample_ids=data["sample_ids"],
+                groups=data.get("groups"),
+                metadata=data.get("metadata"),
+            )
+        )
+        return PredictResult(
+            y_pred=values,
+            metadata={"engine": "native", "sample_ids": list(data["sample_ids"])},
+            model_name="MethodsN4MM",
+            preprocessing_steps=[],
         )
     if isinstance(model, NativeMethodsRefitResult):
         if all_predictions or coverage is not None:

--- a/nirs4all/api/predict.py
+++ b/nirs4all/api/predict.py
@@ -41,7 +41,7 @@ import numpy as np
 from nirs4all.data import DatasetConfigs
 from nirs4all.data.dataset import SpectroDataset
 from nirs4all.pipeline import PipelineRunner
-from nirs4all.pipeline.engine import require_legacy_engine
+from nirs4all.pipeline.engine import require_legacy_engine, resolve_engine
 
 from .native_refit_result import NativeMethodsRefitResult
 from .native_session import NativeMethodsSession
@@ -237,11 +237,15 @@ def predict(
             # The session itself is an unambiguous, already-selected native
             # capability. Do not route it through the process default or an
             # environment override: neither may construct a legacy runner.
-            engine = "native"
-        elif engine != "native":
+            selected_engine = "native"
+        else:
+            selected_engine = resolve_engine(engine)
+        if selected_engine != "native":
             raise ValueError(
                 "a native Methods result or session selects native prediction; an explicit non-native engine is refused"
             )
+    else:
+        selected_engine = resolve_engine(engine)
 
     # ---- Validate mutually exclusive arguments ----
     if model is not None and chain_id is not None:
@@ -251,7 +255,7 @@ def predict(
     if data is None:
         raise ValueError("'data' is required.")
 
-    if engine == "native":
+    if selected_engine == "native":
         data = _native_data_with_explicit_sample_ids(data, sample_ids)
         result = _predict_from_native_archive(
             model=model,
@@ -300,7 +304,7 @@ def predict(
         )
 
     if coverage is not None and _is_conformal_attached_bundle_request(model):
-        require_legacy_engine("predict", engine)
+        require_legacy_engine("predict", selected_engine)
         result = _predict_from_conformal_attached_model_bundle(
             model=model,
             data=data,
@@ -330,7 +334,7 @@ def predict(
             "conformal sidecar and data={'X': ..., 'sample_ids': ...}."
         )
 
-    require_legacy_engine("predict", engine)
+    require_legacy_engine("predict", selected_engine)
 
     # ---- Store-based path (chain_id) ----
     if chain_id is not None:

--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -24,7 +24,7 @@ import numpy as np
 from nirs4all.data import DatasetConfigs
 from nirs4all.data.dataset import SpectroDataset
 from nirs4all.pipeline import PipelineRunner
-from nirs4all.pipeline.engine import require_legacy_engine
+from nirs4all.pipeline.engine import require_legacy_engine, resolve_engine
 
 from .native_refit_result import NativeMethodsRefitResult
 from .native_result import NativeMethodsRunResult
@@ -191,12 +191,16 @@ def retrain(
         if engine is None:
             # The source is an already-attested native capability. It must not
             # be routed through an environment/default legacy selector.
-            engine = "native"
-        elif engine != "native":
+            selected_engine = "native"
+        else:
+            selected_engine = resolve_engine(engine)
+        if selected_engine != "native":
             raise ValueError(
                 "a NativeMethodsRunResult selects native retrain; an explicit non-native engine is refused"
             )
-    if engine == "native":
+    else:
+        selected_engine = resolve_engine(engine)
+    if selected_engine == "native":
         return _retrain_native_methods_full(
             source,
             data,
@@ -209,7 +213,7 @@ def retrain(
             save_artifacts=save_artifacts,
             extra_kwargs=kwargs,
         )
-    require_legacy_engine("retrain", engine)
+    require_legacy_engine("retrain", selected_engine)
     if isinstance(source, NativeMethodsRunResult):
         raise RuntimeError("native retrain source escaped native routing")
     # Use session runner if provided, otherwise create new

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -692,9 +692,9 @@ def run(
         engine: Execution backend selector. ``None`` (default) resolves to ``"legacy"``: the
             public-maintained nirs4all stays pure-Python by default and runs on the in-process
             orchestrator (interim posture until the planned global refactoring lands). ``"dag-ml"``
-            runs the pipeline natively on the dag-ml backend (Rust, in-process by default), with a
-            TRANSPARENT fallback to the legacy engine (a warning is emitted) when a pipeline shape is
-            not yet covered or the dag-ml backend is not installed. ``"dual"`` is a strict,
+            runs the pipeline natively on the dag-ml backend (Rust, in-process by default) and fails
+            closed when a pipeline shape is not yet covered or the dag-ml backend is not installed.
+            Set ``allow_legacy_fallback=True`` for the sole warning-bearing rollback path. ``"dual"`` is a strict,
             no-fallback oracle for the small explicit-array/KFold/PLSRegression subset; it raises a
             typed error for every other shape or unavailable native capability. Override the default
             per-process with ``$N4A_ENGINE`` (e.g. ``$N4A_ENGINE=dag-ml``).

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -698,10 +698,10 @@ def run(
             no-fallback oracle for the small explicit-array/KFold/PLSRegression subset; it raises a
             typed error for every other shape or unavailable native capability. Override the default
             per-process with ``$N4A_ENGINE`` (e.g. ``$N4A_ENGINE=dag-ml``).
-        allow_legacy_fallback: Transitional policy for ``engine="dag-ml"``.
-            ``None`` preserves the catchable compatibility fallback. ``False``
-            refuses unavailable or unsupported DAG-ML requests before the
-            legacy engine is constructed; ``True`` explicitly permits it.
+        allow_legacy_fallback: Explicit rollback policy for ``engine="dag-ml"``.
+            ``None`` and ``False`` refuse unavailable or unsupported DAG-ML
+            requests before the legacy engine is constructed. ``True`` is the
+            sole opt-in that permits a warning-bearing legacy rollback.
             ``engine='native'`` runs the verified portable Methods subset: a
             raw ``{'X', 'y', 'sample_ids'}`` dataset, one supported linear
             KFold/PLS pipeline, ``refit=True``, ``save_artifacts=True`` and
@@ -1207,16 +1207,22 @@ def run(
     # dag-ml's native scores. A plain `run()` (the legacy default) runs the in-process legacy orchestrator
     # (`_run_legacy`).
     #
-    # TRANSPARENT LEGACY FALLBACK. The default is 100% safe via two catchable signals, both warned:
+    # EXPLICIT LEGACY ROLLBACK.  A native request fails closed through the two
+    # catchable capability signals below.  Only a caller that passes
+    # ``allow_legacy_fallback=True`` can opt into the diagnostic/rollback path;
+    # this prevents a successful legacy result from being misreported as a
+    # successful native execution during the R2 qualification period.
     #   * SHAPE not yet covered — the catchable coverage-boundary shapes (no splitter, .n4a export,
     #     rich stacking, non-default refit/session/cache/project/workspace, …) raise DagMlUnsupported,
     #     a NotImplementedError subclass.
     #   * BACKEND not installed — the dag-ml preflight raises DagMlUnavailable when NEITHER mechanism
     #     is present (no in-process extension AND no dag-ml-cli). dag-ml is a HARD dependency, but a
     #     wheel install missing the native backend still degrades gracefully rather than crashing.
-    # In either case we warn and re-run on the legacy engine (run_via_dagml cleans its own temp dir in
-    # a finally). ONLY DagMlUnsupported/NotImplementedError/DagMlUnavailable are caught — a GENUINE
-    # dag-ml runtime/operator bug propagates untouched (never silently swallowed into legacy).
+    # In either case, an explicit opt-in warns and re-runs on the legacy engine
+    # (run_via_dagml cleans its own temp dir in a finally). ONLY
+    # DagMlUnsupported/NotImplementedError/DagMlUnavailable are caught — a
+    # GENUINE dag-ml runtime/operator bug propagates untouched (never silently
+    # swallowed into legacy).
     if selected_engine == "dag-ml":
         from nirs4all.pipeline.dagml.errors import DagMlUnavailable, DagMlUnsupported
         from nirs4all.pipeline.dagml.run_backend import run_via_dagml
@@ -1229,10 +1235,11 @@ def run(
             #     `{name}_p0_{hash}` named, `_refit` on the refit rows — and carried on the dag-ml
             #     RunResult predictions; a generator pipeline's winner-only projection carries no
             #     config_name rather than a wrong one, #55).
-            #   VALIDATED, fall back if un-honorable — `refit`, `session`, `cache`, `project`, and the
+            #   VALIDATED, refuse if un-honorable — `refit`, `session`, `cache`, `project`, and the
             #     workspace/persistence runner_kwargs are checked against what the scores-only in-memory
             #     dag-ml path can deliver; a non-default value it cannot satisfy raises DagMlUnsupported
-            #     (caught below → legacy fallback), so no user option is ever silently dropped.
+            #     (or, only with an explicit rollback opt-in, caught below →
+            #     legacy fallback), so no user option is ever silently dropped.
             # Defaults are honored natively and never trigger a fallback, so a plain engine='dag-ml' run
             # runs natively. The remaining kwargs are presentation/logging-only for the current
             # score-only path: `save_artifacts=True` (the default) runs natively — the dag-ml run keeps no
@@ -1256,7 +1263,7 @@ def run(
                 local_implementations=local_implementations,
             )
         except DagMlUnavailable as e:
-            if custom_training_loss_requested or allow_legacy_fallback is False:
+            if custom_training_loss_requested or allow_legacy_fallback is not True:
                 raise
             warnings.warn(
                 f"the dag-ml backend is not available ({e}); falling back to the legacy engine",
@@ -1264,7 +1271,7 @@ def run(
             )
             return _run_legacy()
         except (DagMlUnsupported, NotImplementedError) as e:
-            if custom_training_loss_requested or allow_legacy_fallback is False:
+            if custom_training_loss_requested or allow_legacy_fallback is not True:
                 raise
             warnings.warn(
                 f"engine='dag-ml' does not support this pipeline shape ({e}); falling back to the legacy engine",

--- a/nirs4all/api/session.py
+++ b/nirs4all/api/session.py
@@ -227,7 +227,9 @@ class Session:
         native request.
         """
 
-        engine = runner_kwargs.get("engine", "legacy")
+        from nirs4all.pipeline.engine import resolve_engine
+
+        engine = resolve_engine(runner_kwargs.get("engine"))
         if cls is Session and engine == "native":
             if pipeline is None:
                 raise ValueError("engine='native' session requires an explicit portable pipeline")
@@ -602,17 +604,18 @@ class Session:
 def load_session(
     path: str | Path,
     *,
-    engine: str = "legacy",
+    engine: str | None = None,
     methods_library_path: str | Path | None = None,
 ) -> Session | NativeArchiveSession:
     """Load a prediction session from a saved bundle or portable archive.
 
     Args:
         path: Path to a ``.n4a`` bundle or archive file.
-        engine: ``"legacy"`` (default) retains the existing BundleLoader
-            session. ``"native"`` opens the fail-closed Core Archive V2
-            Methods replay session; it never constructs a ``PipelineRunner``
-            or falls back to the legacy loader.
+        engine: Backend selector. ``None`` follows ``$N4A_ENGINE`` and then
+            the process default. ``"legacy"`` retains the existing
+            BundleLoader session. ``"native"`` opens the fail-closed Core
+            Archive V2 Methods replay session; it never constructs a
+            ``PipelineRunner`` or falls back to the legacy loader.
         methods_library_path: Optional explicit path to ``libn4m`` for an
     ``engine="native"`` Archive V2/V3 Methods session. When omitted,
             the bundled ``nirs4all-methods`` runtime is used.
@@ -632,14 +635,17 @@ def load_session(
     if not path.exists():
         raise FileNotFoundError(f"Bundle not found: {path}")
 
-    if engine == "native":
+    from nirs4all.pipeline.engine import resolve_engine
+
+    selected_engine = resolve_engine(engine)
+    if selected_engine == "native":
         if path.suffix.lower() != ".n4a":
             raise ValueError("engine='native' load_session requires a Core Archive V2/V3 .n4a path")
         return load_native_archive_session(path, methods_library_path=methods_library_path)
-    if engine != "legacy":
+    if selected_engine != "legacy":
         from nirs4all.pipeline.engine import require_legacy_engine
 
-        require_legacy_engine("load_session", engine)
+        require_legacy_engine("load_session", selected_engine)
         raise AssertionError("require_legacy_engine unexpectedly accepted a non-legacy engine")
 
     # Load the bundle to get pipeline info
@@ -698,7 +704,9 @@ def session(
         ...     result = s.run("sample_data/regression")
         ...     print(f"Best score: {result.best_score:.4f}")
     """
-    engine = kwargs.pop("engine", "legacy")
+    from nirs4all.pipeline.engine import resolve_engine
+
+    engine = resolve_engine(kwargs.pop("engine", None))
     s: Session | NativeMethodsSession
     if engine == "native":
         from nirs4all.api.native_session import NativeMethodsSession

--- a/nirs4all/pipeline/dagml/cli_runner.py
+++ b/nirs4all/pipeline/dagml/cli_runner.py
@@ -103,20 +103,47 @@ def data_bindings_for_nodes(model_ids: list[str], envelope: dict[str, Any], *, s
     return [_data_binding(model_id, envelope, source_id=source_id) for model_id in model_ids]
 
 
-def split_invocation_for(identity: IdentityMap, folds: list[tuple[list[int], list[int]]], *, n_splits: int, shuffle: bool = True) -> dict[str, Any]:
+def split_invocation_for(
+    identity: IdentityMap,
+    folds: list[tuple[list[int], list[int]]],
+    *,
+    n_splits: int,
+    shuffle: bool = True,
+    refit_sample_ints: list[int] | None = None,
+) -> dict[str, Any]:
     """A split_invocation with an embedded, materialized FoldSet (params alone are inert)."""
     return {
         "id": "split:outer",
         "controller_id": None,
         "params": {"kind": "kfold", "n_splits": n_splits, "shuffle": shuffle},
-        "fold_set": build_fold_set(identity, folds, set_id="folds.outer"),
+        "fold_set": build_fold_set(
+            identity,
+            folds,
+            set_id="folds.outer",
+            refit_sample_ints=refit_sample_ints,
+        ),
     }
 
 
-def assemble_cv_refit_dsl(pipeline: list[Any], identity: IdentityMap, envelope: dict[str, Any], folds: list[tuple[list[int], list[int]]], *, dsl_id: str = "nirs4all-pipeline", n_splits: int, source_id: str = _SOURCE_ID) -> dict[str, Any]:
+def assemble_cv_refit_dsl(
+    pipeline: list[Any],
+    identity: IdentityMap,
+    envelope: dict[str, Any],
+    folds: list[tuple[list[int], list[int]]],
+    *,
+    dsl_id: str = "nirs4all-pipeline",
+    n_splits: int,
+    source_id: str = _SOURCE_ID,
+    refit_sample_ints: list[int] | None = None,
+) -> dict[str, Any]:
     """The executable compat DSL: lowered pipeline + embedded fold_set + model data binding."""
     dsl = pipeline_to_dsl(pipeline, dsl_id)
-    dsl["split_invocation"] = split_invocation_for(identity, folds, n_splits=n_splits)
+    dsl["split_invocation"] = split_invocation_for(
+        identity,
+        folds,
+        n_splits=n_splits,
+        refit_sample_ints=refit_sample_ints,
+    )
     dsl["data_bindings"] = data_bindings_for(model_node_id(pipeline, dsl_id=dsl_id), envelope, source_id=source_id)
     return dsl
 

--- a/nirs4all/pipeline/dagml/envelope.py
+++ b/nirs4all/pipeline/dagml/envelope.py
@@ -536,7 +536,13 @@ def build_envelope(
     return out
 
 
-def build_fold_set(identity: IdentityMap, folds: list[tuple[list[int], list[int]]], *, set_id: str = "nirs4all.folds") -> dict[str, Any]:
+def build_fold_set(
+    identity: IdentityMap,
+    folds: list[tuple[list[int], list[int]]],
+    *,
+    set_id: str = "nirs4all.folds",
+    refit_sample_ints: list[int] | None = None,
+) -> dict[str, Any]:
     """Translate ``(train_ints, validation_ints)`` folds into a dag-ml-data ``FoldSet``.
 
     Pure identity translation — sample ints become stable wire ids. The validation distribution is
@@ -553,13 +559,17 @@ def build_fold_set(identity: IdentityMap, folds: list[tuple[list[int], list[int]
         for sample_int in validation_ints:
             validation_counts[sample_int] = validation_counts.get(sample_int, 0) + 1
     # The CV pool drives the REFIT (FullTrain) materialization ORDER: dag-ml preserves the host order of
-    # fold_set.sample_ids when it materializes the full-train universe (merge.rs). Order the pool by
-    # STORAGE order (ascending sample int == the train partition's storage order), NOT fold-first-seen —
-    # legacy refit trains on `dataset.x(train)` in storage order, so a fold-first-seen pool (sample 0
-    # lands late) would feed a fixed-seed RF/GBR a different bootstrap draw and diverge the refit model.
-    # Same SET as fold-first-seen, just the storage ORDER. Per-fold training uses each fold's own
-    # train_sample_ids (unchanged); OOF coverage reads sample_ids as a set (order-insensitive).
+    # fold_set.sample_ids when it materializes the full-train universe (merge.rs). By default use STORAGE
+    # order (ascending sample int), matching legacy `dataset.x(train)`. Repetition datasets are the one
+    # exception: legacy's grouped refit enumerates each physical-sample group in first-seen storage order,
+    # preserving row order within that group. The caller supplies that already-attested ordering explicitly.
+    # Per-fold training always uses each fold's own train_sample_ids (unchanged); OOF coverage is a set.
     pool: list[int] = sorted(seen)
+    if refit_sample_ints is not None:
+        requested = list(refit_sample_ints)
+        if len(requested) != len(set(requested)) or set(requested) != seen:
+            raise ValueError("refit_sample_ints must be a duplicate-free exact permutation of the CV fold universe")
+        pool = requested
     is_oof_partition = len(validation_counts) == len(pool) and all(count == 1 for count in validation_counts.values())
     fold_set: dict[str, Any] = {
         "id": set_id,

--- a/nirs4all/pipeline/dagml/envelope.py
+++ b/nirs4all/pipeline/dagml/envelope.py
@@ -105,6 +105,36 @@ def _core_relation_fingerprint(relations: dict[str, Any]) -> str:
     return str(fingerprint(json.dumps(relations, sort_keys=True, separators=(",", ":"))))
 
 
+def supports_terminal_prediction_relation_authority() -> bool:
+    """Whether the loaded execution core accepts envelope V2 terminal relations.
+
+    This is capability negotiation, not a package-version heuristic: an older
+    wheel continues to receive the V1 envelope it understands, while a newer
+    core explicitly opts into the extra authority required for held-out final
+    aggregation.
+    """
+    try:
+        import dag_ml
+
+        manifest = json.loads(dag_ml.contract_manifest_json())
+    except (ImportError, AttributeError, TypeError, ValueError):
+        return False
+    contracts = manifest.get("contracts")
+    capabilities = manifest.get("capabilities")
+    if not isinstance(contracts, list) or not isinstance(capabilities, list):
+        return False
+    return (
+        any(
+            isinstance(contract, dict)
+            and contract.get("id") == "coordinator_data_plan_envelope"
+            and isinstance(contract.get("version"), int)
+            and contract["version"] >= 2
+            for contract in contracts
+        )
+        and "terminal_prediction_relation_authority" in capabilities
+    )
+
+
 def _num_wavelengths(dataset: SpectroDataset, source_idx: int = 0) -> int:
     """Feature count of one source. Single-source ``num_features`` is an int; multi-source a list."""
     num_features = dataset.num_features
@@ -396,6 +426,7 @@ def build_envelope(
     tags_by_sample: dict[int, list[str]] | None = None,
     augmentation_by_sample: dict[int, str] | None = None,
     group_by_sample: dict[int, str] | None = None,
+    final_sample_ints: list[int] | None = None,
 ) -> dict[str, Any]:
     """Build the validated ``CoordinatorDataPlanEnvelope``.
 
@@ -425,6 +456,12 @@ def build_envelope(
     value, and dag-ml-data refuses a fold that splits a group across train/validation. For a
     repetition dataset every relation is its own ``sample_id`` (each stored row is scored
     individually at the repetition grain), so the schema's sample axis is one entry per row.
+
+    Pass ``final_sample_ints`` to request the V2 terminal prediction authority.  It must
+    contain every CV ``sample_ints`` entry and may add held-out prediction identities.  The
+    core uses this extra relation set only for emitted ``test``/``final`` prediction blocks;
+    it is never handed to fold validation or model fitting.  A core that has not negotiated
+    the V2 capability is refused here rather than receiving a silently weakened envelope.
 
     The wheel computes all fingerprints and derives ``coordinator_relations``; a successful
     return means the envelope is contract-valid (the materialize-time fingerprint gate
@@ -460,6 +497,40 @@ def build_envelope(
     )
     out = dict(envelope.to_dict())
     out["relation_fingerprint"] = _core_relation_fingerprint(out["coordinator_relations"])
+    if final_sample_ints is not None:
+        if not supports_terminal_prediction_relation_authority():
+            raise RuntimeError(
+                "the installed dag-ml core does not support terminal prediction relation authority V2"
+            )
+        cv_sample_ints = [sample.sample_int for sample in chosen]
+        final_unique = list(dict.fromkeys(final_sample_ints))
+        if not final_unique:
+            raise ValueError("final_sample_ints must not be empty")
+        if not set(cv_sample_ints).issubset(final_unique):
+            raise ValueError("final_sample_ints must contain every CV sample identity")
+        final_chosen = [identity.identities[i] for i in _positions(identity, final_unique)]
+        final_envelope = dag_ml_data.build_coordinator_data_plan_envelope(
+            _dataset_schema(
+                dataset,
+                sources if multi_source else [source_id],
+                list(dict.fromkeys(sample.sample_id for sample in final_chosen)),
+            ),
+            _data_plan(dataset, sources if multi_source else [source_id]),
+            sample_relations(
+                identity,
+                source_id=relation_source_id,
+                sample_ints=final_unique,
+                excluded_sample_ints=excluded_sample_ints,
+                metadata_by_sample=metadata_by_sample,
+                tags_by_sample=tags_by_sample,
+                augmentation_by_sample=augmentation_by_sample,
+                group_by_sample=group_by_sample,
+            ),
+        )
+        final_relations = dict(final_envelope.to_dict())["coordinator_relations"]
+        out["schema_version"] = 2
+        out["final_coordinator_relations"] = final_relations
+        out["final_relation_fingerprint"] = _core_relation_fingerprint(final_relations)
     if multi_source:
         out["plan"]["source_layout"] = _source_layout(dataset, sources)
     return out

--- a/nirs4all/pipeline/dagml/envelope.py
+++ b/nirs4all/pipeline/dagml/envelope.py
@@ -1,11 +1,12 @@
 """Data-plan envelope + fold-set builders for the nirs4all → dag-ml(-data) bridge.
 
-dag-ml-data owns the contract *types* and the fingerprint algorithm; this module only
+dag-ml-data owns the contract *types* and source-relation fingerprint algorithm; this module only
 assembles the JSON inputs from a ``SpectroDataset`` + its :class:`IdentityMap` and hands
 them to the ``dag_ml_data`` wheel, which computes every fingerprint internally and derives
-``coordinator_relations`` from the ``SampleRelationTable``. We never compute a fingerprint
-or hand-build a coordinator relation — that keeps the materialize-time fingerprint gate
-passing by construction.
+``coordinator_relations`` from the ``SampleRelationTable``. The relation table and the
+execution core deliberately fingerprint different contracts: the latter's canonical
+fingerprint is recomputed from the derived coordinator relation set before the envelope
+is emitted, so DataBindings and runtime aggregation share one authority.
 
 Declares **identity only**, never X/y values:
 
@@ -28,6 +29,7 @@ Scope: single-source / no-repetition baseline.
 from __future__ import annotations
 
 import hashlib
+import json
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -89,6 +91,18 @@ def _import_dag_ml_data() -> Any:
     except ImportError as exc:  # pragma: no cover - exercised only without the wheel
         raise ImportError("dag-ml-data is not installed; it is a core dependency — reinstall with `pip install nirs4all`") from exc
     return dag_ml_data
+
+
+def _core_relation_fingerprint(relations: dict[str, Any]) -> str:
+    """Fingerprint coordinator relations through the public execution-core ABI."""
+    try:
+        import dag_ml
+    except ImportError as exc:  # pragma: no cover - exercised only without the wheel
+        raise ImportError("dag-ml is not installed; it is a core dependency — reinstall with `pip install nirs4all`") from exc
+    fingerprint = getattr(dag_ml, "sample_relation_set_fingerprint_json", None)
+    if not callable(fingerprint):
+        raise RuntimeError("dag_ml.sample_relation_set_fingerprint_json is required for native data envelopes")
+    return str(fingerprint(json.dumps(relations, sort_keys=True, separators=(",", ":"))))
 
 
 def _num_wavelengths(dataset: SpectroDataset, source_idx: int = 0) -> int:
@@ -445,6 +459,7 @@ def build_envelope(
         ),
     )
     out = dict(envelope.to_dict())
+    out["relation_fingerprint"] = _core_relation_fingerprint(out["coordinator_relations"])
     if multi_source:
         out["plan"]["source_layout"] = _source_layout(dataset, sources)
     return out

--- a/nirs4all/pipeline/dagml/folds.py
+++ b/nirs4all/pipeline/dagml/folds.py
@@ -98,6 +98,30 @@ def _repetition_groups_for_pool(spectro: Any, pool: list[int]) -> np.ndarray:
     return np.array([group_of_sample[sample_int] for sample_int in pool], dtype=object)
 
 
+def _repetition_refit_order(spectro: Any, pool: list[int]) -> list[int]:
+    """Return legacy's full-train repetition ordering.
+
+    ``SpectroDataset`` refit groups all stored repetitions of one physical
+    sample together, ordering groups by their first stored row and retaining
+    storage order inside each group.  A FoldSet's ``sample_ids`` is the native
+    full-train materialization order; preserving this permutation is essential
+    for deterministic order-sensitive estimators such as random forests.
+    """
+    group_by_sample = _repetition_grain(spectro, pool)
+    first_group_position: dict[str, int] = {}
+    storage_position: dict[int, int] = {}
+    for position, sample_int in enumerate(pool):
+        storage_position[sample_int] = position
+        first_group_position.setdefault(group_by_sample[sample_int], position)
+    return sorted(
+        pool,
+        key=lambda sample_int: (
+            first_group_position[group_by_sample[sample_int]],
+            storage_position[sample_int],
+        ),
+    )
+
+
 def _repetition_grain(spectro: Any, pool: list[int]) -> dict[int, str]:
     """``{sample_int: group_value}`` for ``pool`` — the ``group_id`` emitted onto the relations.
 

--- a/nirs4all/pipeline/dagml/result.py
+++ b/nirs4all/pipeline/dagml/result.py
@@ -378,7 +378,28 @@ def _scores_to_run_result(
     # Key on (variant_id, partition, fold_id): native generation surfaces every variant's reports and
     # ScoreSet.validate guarantees this triple (per producer) is unique, so distinct variants never
     # collide (the pre-#55 (partition, fold_id) key let later variants overwrite earlier ones).
-    by_key = {(report.get("variant_id"), report["partition"], report.get("fold_id")): {name: float(value) for name, value in report["metrics"].items()} for report in reports}
+    # A node may retain the raw row-grain score alongside an aggregate score for
+    # the same terminal block.  The compatibility table intentionally keeps
+    # row-grain validation/OOF evidence (legacy selection semantics), while a
+    # held-out/refit terminal block must expose the native physical-sample
+    # reducer — notably repetition-group classification vote.  Select that
+    # level explicitly instead of relying on report emission order.
+    def _report_priority(report: dict[str, Any]) -> int:
+        level = report.get("level")
+        terminal = report.get("partition") in {"test", "final"}
+        if terminal:
+            return 2 if level in {"group", "target"} else 1
+        return 2 if level == "sample" else 1
+
+    by_key: dict[tuple[Any, str, str | None], dict[str, float]] = {}
+    priorities: dict[tuple[Any, str, str | None], int] = {}
+    for report in reports:
+        key = (report.get("variant_id"), report["partition"], report.get("fold_id"))
+        priority = _report_priority(report)
+        if priority < priorities.get(key, -1):
+            continue
+        priorities[key] = priority
+        by_key[key] = {name: float(value) for name, value in report["metrics"].items()}
 
     predictions = Predictions()
 

--- a/nirs4all/pipeline/dagml/result.py
+++ b/nirs4all/pipeline/dagml/result.py
@@ -549,7 +549,14 @@ def _scores_to_run_result(
         variant_model_name = variant_model_names.get(variant_id, model_name) if variant_model_names is not None else model_name
 
         # The native validation folds for THIS variant, in dag-ml's emitted order (foldN, excluding avg).
-        fold_keys = [fold_id for (other_variant_id, partition, fold_id) in by_key if other_variant_id == variant_id and partition == "validation" and fold_id != "avg"]
+        fold_keys = [
+            fold_id
+            for (other_variant_id, partition, fold_id) in by_key
+            if other_variant_id == variant_id
+            and partition == "validation"
+            and fold_id is not None
+            and fold_id != "avg"
+        ]
         # The cross-fold OOF average for THIS variant. dag-ml emits the avg with `variant_id = None` for
         # the SOLE producer (a single concrete pipeline or a merge node) and for the SWEEP WINNER; a sweep
         # LOSER's avg carries its own variant_id. The portable Methods controller retains `variant:base`

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -256,8 +256,10 @@ def preflight_dagml_backend(cli: str) -> None:
     * the ``dag-ml-cli`` binary exists at ``cli`` (Mechanism A, the subprocess fallback).
 
     Either one available → return (the run proceeds). NEITHER → raise :class:`DagMlUnavailable`, the
-    ONE catchable signal ``run()`` turns into a transparent legacy fallback WITH A WARNING. It is the
-    ONLY place that "backend not installed" is decided — deliberately a narrow up-front probe, NOT a
+    ONE catchable signal ``run()`` propagates by default and turns into a
+    warning-bearing legacy rollback only when callers pass
+    ``allow_legacy_fallback=True``. It is the ONLY place that "backend not
+    installed" is decided — deliberately a narrow up-front probe, NOT a
     blanket ``except ImportError/FileNotFoundError`` around the run, so a genuine dag-ml bug raised
     DURING execution propagates untouched instead of being swallowed into a silent legacy fallback.
     """

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -800,12 +800,6 @@ def _dispatch_run(
     # across train/val (silent leakage). An unhandled composition therefore fails LOUD here (naming #21)
     # rather than taking a non-group path and running wrong.
     if _is_repetition_dataset(spectro):
-        if is_classification and getattr(spectro, "aggregate_method", None) == "vote":
-            raise NotImplementedError(
-                "engine='dag-ml' does not yet support classification repetition datasets with "
-                "sample-level vote aggregation; the final-test surface would be scored at the "
-                "repetition row grain instead of the legacy sample-vote grain (backlog #21)."
-            )
         if (
             augmentation_steps
             or detected is not None

--- a/nirs4all/pipeline/dagml/run_paths.py
+++ b/nirs4all/pipeline/dagml/run_paths.py
@@ -24,7 +24,7 @@ from .cli_runner import assemble_constrained_cv_refit_dsl, assemble_cv_refit_dsl
 from .detect import _is_augmentation_step, _is_constrained_operator_generator, _is_rep_fusion_step, _is_unconstrained_operator_generator
 from .envelope import build_envelope
 from .errors import DagMlUnsupported, _raise_run_failure, _reject_multi_model
-from .folds import _build_folds, _build_group_folds, _repetition_grain, _split_pool
+from .folds import _build_folds, _build_group_folds, _repetition_grain, _repetition_refit_order, _split_pool
 from .identity import mint_identity
 from .in_process_runner import run_cv_refit_bundle_router as run_cv_refit_bundle
 from .result import _frames_by_variant, _native_variant_config_map, _project_operator_sweep, _scores_to_run_result
@@ -669,7 +669,7 @@ def _run_repetition(pipeline: list[Any], spectro: Any, dataset_arg: str, cli: st
 
 
 def _run_repetition_concrete(pipeline: Any, spectro: Any, dataset_arg: str, cli: str, venv_python: str, run_dir: Path, metric: str, task_type: str, dataset_pickle: str | None = None, config_name: str = "", random_state: int | None = None) -> RunResult:
-    """One concrete repetition variant: group-aware folds + a ``group_id``-carrying envelope."""
+    """One concrete repetition variant: group-aware folds and legacy-order refit."""
     steps, splitter = _split_pipeline(pipeline)
     if splitter is None:
         raise DagMlUnsupported("engine='dag-ml' requires a cross-validator step (e.g. KFold) in the pipeline")
@@ -680,8 +680,25 @@ def _run_repetition_concrete(pipeline: Any, spectro: Any, dataset_arg: str, cli:
     pool = spectro.index_column("sample", {"partition": "train"})
     folds = _build_group_folds(splitter, spectro, pool)
     group_by_sample = _repetition_grain(spectro, pool)
-    envelope = build_envelope(spectro, identity, sample_ints=pool, group_by_sample=group_by_sample)
-    dsl = assemble_cv_refit_dsl(steps, identity, envelope, folds, dsl_id="nirs4all-pipeline", n_splits=len(folds))
+    # Legacy's repetition refit materializes every row of a physical sample together.  This is
+    # load-bearing for fixed-seed order-sensitive estimators (RF/GBR bootstrap): the fold universe
+    # itself stays untouched, but FullTrain must reproduce the legacy group-first row order.
+    refit_sample_ints = _repetition_refit_order(spectro, pool)
+    envelope = build_envelope(
+        spectro,
+        identity,
+        sample_ints=pool,
+        group_by_sample=group_by_sample,
+    )
+    dsl = assemble_cv_refit_dsl(
+        steps,
+        identity,
+        envelope,
+        folds,
+        dsl_id="nirs4all-pipeline",
+        n_splits=len(folds),
+        refit_sample_ints=refit_sample_ints,
+    )
 
     import dag_ml
 

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -4,10 +4,15 @@ Seam for the **nirs4all-core → dag-ml** migration. The default production engi
 public-maintained nirs4all stays pure-Python by default, so :func:`nirs4all.run` runs through the
 in-process *legacy* orchestrator (:class:`~nirs4all.pipeline.PipelineRunner`) unless another engine is
 selected. The dag-ml backend (:mod:`nirs4all.pipeline.dagml.run_backend`) — which runs the pipeline
-natively (Rust) and returns a ``RunResult`` of dag-ml's native scores, with a transparent fallback to
-the legacy orchestrator for any shape it cannot yet honor — stays **fully selectable** via
+natively (Rust) and returns a ``RunResult`` of dag-ml's native scores — stays
+**fully selectable** via
 ``engine="dag-ml"`` or ``$N4A_ENGINE=dag-ml``; the whole dag-ml integration (in-process path, native
 generator coverage, conformance pack, hard dependency) is intact and runnable out of the box.
+
+An unavailable or unsupported dag-ml request is fail-closed by default.  A
+legacy rerun is an explicit R2 rollback action through
+``run(..., engine="dag-ml", allow_legacy_fallback=True)``; it is never an
+implicit substitute for a claimed native execution.
 
 This is the interim posture: the maintainer keeps the public Python version as the default until the
 planned global refactoring lands; at that point the legacy-DROP cutover flips the default back to

--- a/tests/integration/parity/_conformance_helpers.py
+++ b/tests/integration/parity/_conformance_helpers.py
@@ -12,9 +12,10 @@ engines and asserted equality — these helpers fill that gap and the
 
 LOAD-BEARING fallback detection
 -------------------------------
-``run(engine="dag-ml")`` transparently re-runs on
-the LEGACY engine for any pipeline shape the dag-ml path cannot honor yet (the
-P1b/P0 reject→fallback), emitting a ``"falling back to the legacy engine"``
+The harness explicitly asks
+``run(engine="dag-ml", allow_legacy_fallback=True)`` to re-run on the LEGACY
+engine for a pipeline shape the dag-ml path cannot honor yet (the P1b/P0
+reject→fallback boundary), emitting a ``"falling back to the legacy engine"``
 warning (:mod:`nirs4all.api.run`). A fallback run is legacy-under-the-hood, so
 asserting "dag-ml == legacy" on it would be a trivially-true legacy-vs-legacy
 claim. :func:`dual_engine_runner` therefore records ``dagml_native`` from TWO
@@ -79,8 +80,8 @@ def make_dataset(case: PipelineCase) -> DatasetConfigs:
 def dual_engine_runner(case: PipelineCase, dataset: DatasetConfigs) -> _DualResult:
     """Run ``case`` on BOTH engines from the SAME dataset config; report native-ness.
 
-    Runs ``engine="legacy"`` then ``engine="dag-ml"`` EXPLICITLY (NOT the
-    default ``engine=None``) on a freshly materialized pipeline per engine (the
+    Runs ``engine="legacy"`` then ``engine="dag-ml"`` with the explicit
+    rollback opt-in on a freshly materialized pipeline per engine (the
     factory yields fresh operator instances, so the two runs never share mutable
     state). The explicit engine is load-bearing: ``resolve_engine`` honors
     ``$N4A_ENGINE``, so under ``N4A_ENGINE=legacy`` an ``engine=None`` dag-ml leg
@@ -110,7 +111,11 @@ def dual_engine_runner(case: PipelineCase, dataset: DatasetConfigs) -> _DualResu
 
 
 def _run_dagml_leg(case: PipelineCase, dataset: DatasetConfigs) -> tuple[Any, bool]:
-    """Run ONLY the dag-ml leg (explicit ``engine="dag-ml"``); return ``(result, native)``.
+    """Run ONLY the dag-ml leg with explicit rollback measurement.
+
+    Returns ``(result, native)``. The opt-in is test-only evidence: production
+    callers must request it themselves when they deliberately want a legacy
+    rollback.
 
     Shared by :func:`dual_engine_runner` and :func:`dagml_native_status` so the
     fallback detection (warning fragment AND the per_dataset engine marker) lives
@@ -119,7 +124,13 @@ def _run_dagml_leg(case: PipelineCase, dataset: DatasetConfigs) -> tuple[Any, bo
     """
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        dagml = nirs4all.run(pipeline=case.pipeline, dataset=dataset, verbose=0, engine="dag-ml")
+        dagml = nirs4all.run(
+            pipeline=case.pipeline,
+            dataset=dataset,
+            verbose=0,
+            engine="dag-ml",
+            allow_legacy_fallback=True,
+        )
         fell_back = any(_FALLBACK_WARNING_FRAGMENT in str(w.message) for w in caught)
     dagml_native = (not fell_back) and bool(dagml._is_dagml_engine())  # noqa: SLF001
     return dagml, dagml_native

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -371,10 +371,6 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     "branch_separation_by_metadata_auto",
     "branch_separation_by_tag",
     "branch_separation_by_filter",
-    # Classification repetition + vote aggregation requires the final-test surface
-    # to be scored at the legacy sample-vote grain; the native repetition path still
-    # scores classification final-test at the repetition-row grain.
-    "aggregation_classification_vote",
     # Legacy Optuna finetuning mutates model parameters before the final run. The
     # native dag-ml path does not serialize/execute `finetune_params` yet, so it must
     # fall back rather than silently run the untuned model.

--- a/tests/integration/parity/test_dagml_dataplane.py
+++ b/tests/integration/parity/test_dagml_dataplane.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from nirs4all.data.config import DatasetConfigs
+from nirs4all.pipeline.dagml import envelope as envelope_module
 from nirs4all.pipeline.dagml.envelope import build_envelope, build_fold_set, sample_relations
 from nirs4all.pipeline.dagml.identity import mint_identity
 from nirs4all.pipeline.dagml.operator_routing import route_graph_node, route_operator
@@ -158,6 +159,55 @@ def test_envelope_builds_and_uses_execution_core_relation_authority(regression_d
         json.dumps(envelope["coordinator_relations"], sort_keys=True, separators=(",", ":"))
     )
     assert envelope["relation_fingerprint"] == core_fingerprint
+
+
+def test_v2_terminal_relations_extend_the_cv_authority(regression_dataset, monkeypatch) -> None:
+    """V2 attaches held-out final identities without widening the fold authority."""
+    pytest.importorskip("dag_ml_data", reason="dag-ml-data not importable (core dependency; broken install?)")
+    dag_ml = pytest.importorskip("dag_ml", reason="dag-ml not importable (core dependency; broken install?)")
+    identity = mint_identity(regression_dataset)
+    cv_sample_ints = regression_dataset.index_column("sample", {"partition": "train"})
+    final_sample_ints = list(
+        dict.fromkeys(
+            cv_sample_ints
+            + regression_dataset.index_column("sample", {"partition": "test"})
+        )
+    )
+    assert set(cv_sample_ints) < set(final_sample_ints)
+
+    monkeypatch.setattr(
+        envelope_module,
+        "supports_terminal_prediction_relation_authority",
+        lambda: True,
+    )
+    envelope = build_envelope(
+        regression_dataset,
+        identity,
+        sample_ints=cv_sample_ints,
+        final_sample_ints=final_sample_ints,
+    )
+    assert envelope["schema_version"] == 2
+    assert len(envelope["coordinator_relations"]["records"]) == len(cv_sample_ints)
+    assert len(envelope["final_coordinator_relations"]["records"]) == len(final_sample_ints)
+    assert envelope["final_relation_fingerprint"] == dag_ml.sample_relation_set_fingerprint_json(
+        json.dumps(
+            envelope["final_coordinator_relations"],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+
+def test_v2_terminal_relations_require_a_negotiated_core(regression_dataset) -> None:
+    identity = mint_identity(regression_dataset)
+    train = regression_dataset.index_column("sample", {"partition": "train"})
+    with pytest.raises(RuntimeError, match="terminal prediction relation authority V2"):
+        build_envelope(
+            regression_dataset,
+            identity,
+            sample_ints=train,
+            final_sample_ints=train,
+        )
 
 
 def test_fold_set_requires_an_oof_partition(regression_dataset) -> None:

--- a/tests/integration/parity/test_dagml_dataplane.py
+++ b/tests/integration/parity/test_dagml_dataplane.py
@@ -17,6 +17,7 @@ import pytest
 from nirs4all.data.config import DatasetConfigs
 from nirs4all.pipeline.dagml import envelope as envelope_module
 from nirs4all.pipeline.dagml.envelope import build_envelope, build_fold_set, sample_relations
+from nirs4all.pipeline.dagml.folds import _repetition_refit_order
 from nirs4all.pipeline.dagml.identity import mint_identity
 from nirs4all.pipeline.dagml.operator_routing import route_graph_node, route_operator
 from nirs4all.pipeline.dagml.resolver import MaterializationResolver
@@ -83,6 +84,55 @@ def test_resolver_targets_restore_request_order(regression_dataset) -> None:
     ground_truth = np.asarray([float(np.asarray(regression_dataset.y({"sample": [s]})).ravel()[0]) for s in picked])
     assert np.allclose(values, ground_truth)
     assert out["sample_ids"] == wire
+
+
+def test_resolver_targets_keep_group_split_order_for_classification() -> None:
+    """A group-aware fold is non-monotonic and must not re-key y via storage order."""
+
+    dataset = DatasetConfigs(
+        dataset_path("classification"),
+        repetition="Sample_ID",
+        aggregate=False,
+        task_type="multiclass_classification",
+    ).get_dataset_at(0)
+    identity = mint_identity(dataset)
+    resolver = MaterializationResolver(dataset, identity)
+    # These are real group-fold positions: the middle member is far beyond the
+    # first one, so an accidental storage-order lookup changes the target join.
+    picked = [23, 90, 30]
+    wire = [identity.to_wire(sample) for sample in picked]
+
+    out = resolver.resolve_targets(wire)
+    expected = np.asarray(
+        [float(np.asarray(dataset.y({"sample": [sample]})).ravel()[0]) for sample in picked]
+    )
+
+    assert np.array_equal(np.asarray(out["values"], dtype=float), expected)
+    assert out["sample_ids"] == wire
+
+
+def test_repetition_refit_order_groups_physical_samples_without_reordering_members() -> None:
+    """The full-train order must match legacy's group-first materialization.
+
+    The classification fixture deliberately interleaves later repetitions, so
+    a storage-only refit order would put sample 12 ahead of its physical peers.
+    """
+
+    dataset = DatasetConfigs(
+        dataset_path("classification"),
+        repetition="Sample_ID",
+        aggregate=True,
+        aggregate_method="vote",
+        task_type="multiclass_classification",
+    ).get_dataset_at(0)
+    pool = dataset.index_column("sample", {"partition": "train"})
+
+    ordered = _repetition_refit_order(dataset, pool)
+
+    # BGE1 first appears at row 0 and later repeats at 12..22, then 92, 103,
+    # …; legacy keeps all of those contiguous before moving to BGE0.
+    assert ordered[:20] == [0, *range(12, 23), 92, 103, 114, 125, 136, 147, 158, 169]
+    assert sorted(ordered) == sorted(pool)
 
 
 def test_resolver_serves_real_spectra_not_a_hash(regression_dataset) -> None:

--- a/tests/integration/parity/test_dagml_dataplane.py
+++ b/tests/integration/parity/test_dagml_dataplane.py
@@ -131,10 +131,16 @@ def test_route_real_compiled_vertical_slice_nodes() -> None:
     assert routed == {"transform": "StandardNormalVariate", "y_transform": "MinMaxScaler", "model": "PLSRegression"}
 
 
-def test_envelope_builds_and_validates_against_live_contract(regression_dataset) -> None:
-    """build_envelope produces a contract-valid CoordinatorDataPlanEnvelope (the wheel
-    derives relations + fingerprints; a successful build is itself the gate)."""
-    dag_ml_data = pytest.importorskip("dag_ml_data", reason="dag-ml-data not importable (core dependency; broken install?)")
+def test_envelope_builds_and_uses_execution_core_relation_authority(regression_dataset) -> None:
+    """The data wheel validates source relations; DAG-ML signs derived relations.
+
+    These are distinct contracts.  ``build_envelope`` first lets dag-ml-data
+    validate/derive the relation set, then replaces only the wire fingerprint
+    with DAG-ML's public coordinator-relation canonicalization.  The latter is
+    what a DataBinding and global aggregation validate at runtime.
+    """
+    pytest.importorskip("dag_ml_data", reason="dag-ml-data not importable (core dependency; broken install?)")
+    dag_ml = pytest.importorskip("dag_ml", reason="dag-ml not importable (core dependency; broken install?)")
     identity = mint_identity(regression_dataset)
 
     envelope = build_envelope(regression_dataset, identity)
@@ -148,8 +154,10 @@ def test_envelope_builds_and_validates_against_live_contract(regression_dataset)
     records = envelope["coordinator_relations"]["records"]
     assert len(records) == len(identity.identities)
     assert all(not record["is_augmented"] for record in records)
-    # Re-validate through the same validator dag-ml-data uses (not a stale local schema).
-    dag_ml_data.validate_coordinator_data_plan_envelope_json(json.dumps(envelope))
+    core_fingerprint = dag_ml.sample_relation_set_fingerprint_json(
+        json.dumps(envelope["coordinator_relations"], sort_keys=True, separators=(",", ":"))
+    )
+    assert envelope["relation_fingerprint"] == core_fingerprint
 
 
 def test_fold_set_requires_an_oof_partition(regression_dataset) -> None:

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -1,13 +1,11 @@
 """The engine selector is wired into the public run() entry point.
 
-These assert the public API resolves the engine before execution — the DEFAULT engine is now legacy
-(interim, pre-refactoring): the public-maintained nirs4all stays pure-Python by default, while the
-dag-ml backend stays fully selectable via ``engine="dag-ml"`` / ``$N4A_ENGINE=dag-ml``. An unknown
-engine is rejected. They also certify the TRANSPARENT legacy fallback on the dag-ml path (selected
-EXPLICITLY here): a supported shape runs NATIVE on dag-ml; a catchable unsupported shape
-(DagMlUnsupported/NotImplementedError) OR an unavailable backend (DagMlUnavailable — neither
-in-process extension nor dag-ml-cli) falls back to legacy (warning + valid result) instead of raising.
-A GENUINE dag-ml bug still propagates untouched.
+These assert the public API resolves the engine before execution — the DEFAULT engine is legacy
+(interim, pre-refactoring), while dag-ml stays fully selectable via
+``engine="dag-ml"`` / ``$N4A_ENGINE=dag-ml``. An unknown engine is rejected.
+Native capability refusals are fail-closed unless callers explicitly request
+``allow_legacy_fallback=True``; that opt-in emits a warning and re-runs on
+legacy. A genuine dag-ml bug still propagates untouched.
 """
 
 from __future__ import annotations
@@ -78,16 +76,18 @@ def test_run_dispatches_to_dagml_engine_native() -> None:
 
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
-def test_run_dagml_falls_back_to_legacy_on_unsupported_shape() -> None:
+def test_run_dagml_explicitly_falls_back_to_legacy_on_unsupported_shape() -> None:
     """`engine="dag-ml"` with a no-splitter shape is a catchable coverage-boundary case
-    (DagMlUnsupported, a NotImplementedError subclass): with the cutover fallback wired it must NOT
-    raise — it warns and re-runs on the legacy engine, returning a valid legacy RunResult."""
+    (DagMlUnsupported, a NotImplementedError subclass): the explicit rollback
+    flag warns and re-runs on the legacy engine, returning a valid legacy
+    RunResult."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         result = nirs4all.run(
             [{"model": PLSRegression(n_components=2)}],
             dataset_path("regression"),
             engine="dag-ml",
+            allow_legacy_fallback=True,
         )
     assert isinstance(result, RunResult)
     assert result.num_predictions > 0
@@ -310,15 +310,13 @@ def test_run_rejects_process_local_losses_on_native_tuning_bypass() -> None:
         )
 
 
-@pytest.mark.parametrize("fallback_policy", [None, True], ids=["default", "explicit"])
+@pytest.mark.parametrize("fallback_policy", [True], ids=["explicit"])
 def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     fallback_policy: bool | None,
 ) -> None:
-    """An explicit ``engine="dag-ml"`` run() transparently falls back to the LEGACY engine WITH A
-    WARNING when the dag-ml backend is unavailable — simulated by the preflight raising
-    DagMlUnavailable. The result is a valid legacy RunResult, never an exception. (dag-ml is selected
-    explicitly: the production DEFAULT is now legacy — interim, pre-refactoring.)"""
+    """An explicit rollback request falls back to legacy with a warning when
+    the dag-ml backend is unavailable."""
     import nirs4all.pipeline.dagml.run_backend as run_backend
     from nirs4all.pipeline.dagml.errors import DagMlUnavailable
 
@@ -350,7 +348,7 @@ def test_dagml_run_falls_back_to_legacy_when_backend_unavailable(
 def test_dagml_run_strict_mode_refuses_unavailable_backend_without_legacy_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """R2 qualification mode propagates a backend refusal before legacy work starts."""
+    """The default R2 policy propagates a backend refusal before legacy work starts."""
     import nirs4all.pipeline.dagml.run_backend as run_backend
     from nirs4all.pipeline.dagml.errors import DagMlUnavailable
 
@@ -363,14 +361,13 @@ def test_dagml_run_strict_mode_refuses_unavailable_backend_without_legacy_fallba
             [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
             dataset_path("regression"),
             engine="dag-ml",
-            allow_legacy_fallback=False,
         )
 
 
 def test_dagml_run_strict_mode_refuses_unsupported_shape_without_legacy_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A declared coverage boundary is not downgraded to a legacy run in strict mode."""
+    """A declared coverage boundary is not downgraded to legacy by default."""
     import nirs4all.pipeline.dagml.run_backend as run_backend
     from nirs4all.pipeline.dagml.errors import DagMlUnsupported
 
@@ -383,7 +380,6 @@ def test_dagml_run_strict_mode_refuses_unsupported_shape_without_legacy_fallback
             [{"model": PLSRegression(n_components=2)}],
             dataset_path("regression"),
             engine="dag-ml",
-            allow_legacy_fallback=False,
         )
 
 
@@ -409,11 +405,8 @@ def test_dagml_run_rejects_non_boolean_fallback_policy_before_dispatch() -> None
 )
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
 def test_dagml_run_unsupported_run_option_falls_back_to_legacy(option: dict[str, object]) -> None:
-    """Under an explicit ``engine="dag-ml"``, run() options the scores-only dag-ml path cannot honor
-    (non-default ``refit``, ``project`` tag, a persistence ``runner_kwarg`` like ``workspace_path``)
-    must REJECT -> fall back to legacy (P1b), warning + valid result. Pins this reject-then-fallback for
-    the non-run-able options on the dag-ml path. (dag-ml is selected explicitly: the production DEFAULT
-    is now legacy — interim, pre-refactoring.)
+    """An explicitly requested rollback handles options the scores-only
+    dag-ml path cannot honor.
 
     A workspace_path of ``None`` (legacy's own default) is still a PRESENT runner_kwarg the dag-ml path
     does not honor, so it triggers the same generic-key fallback — exercising the path without writing a
@@ -424,6 +417,7 @@ def test_dagml_run_unsupported_run_option_falls_back_to_legacy(option: dict[str,
             [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],
             dataset_path("regression"),
             engine="dag-ml",
+            allow_legacy_fallback=True,
             **option,  # type: ignore[arg-type]
         )
     assert isinstance(result, RunResult)

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -11,6 +11,7 @@ legacy. A genuine dag-ml bug still propagates untouched.
 from __future__ import annotations
 
 import contextlib
+import importlib
 import warnings
 from pathlib import Path
 from typing import Any
@@ -356,6 +357,13 @@ def test_dagml_run_strict_mode_refuses_unavailable_backend_without_legacy_fallba
         raise DagMlUnavailable("simulated: strict native backend unavailable")
 
     monkeypatch.setattr(run_backend, "preflight_dagml_backend", _unavailable)
+    monkeypatch.setattr(
+        importlib.import_module("nirs4all.api.run"),
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("default native failure constructed a legacy runner")
+        ),
+    )
     with pytest.raises(DagMlUnavailable, match="strict native backend unavailable"):
         nirs4all.run(
             [SNV(), KFold(n_splits=3), {"model": PLSRegression(n_components=2)}],

--- a/tests/regression/test_public_api_contract.py
+++ b/tests/regression/test_public_api_contract.py
@@ -101,7 +101,7 @@ EXPECTED_SIGNATURES: dict[str, str] = {
         "nirs4all.api.native_refit_result.NativeMethodsRefitResult"
     ),
     "session": ("(pipeline: 'list[Any] | None' = None, name: 'str' = '', **kwargs: 'Any') -> 'Generator[Session | NativeMethodsSession, None, None]'"),
-    "load_session": ("(path: 'str | Path', *, engine: 'str' = 'legacy', methods_library_path: 'str | Path | None' = None) -> 'Session | NativeArchiveSession'"),
+    "load_session": ("(path: 'str | Path', *, engine: 'str | None' = None, methods_library_path: 'str | Path | None' = None) -> 'Session | NativeArchiveSession'"),
     "generate": (
         "(n_samples: 'int' = 1000, *, random_state: 'int | None' = None, "
         "complexity: \"Literal['simple', 'realistic', 'complex']\" = 'simple', "

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -565,6 +565,37 @@ def test_predict_native_refit_result_is_direct_and_never_constructs_a_legacy_run
     assert observed["sample_ids"] == ["p1"]
 
 
+def test_predict_native_run_result_is_direct_and_never_constructs_a_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fresh native run result is immediately usable for identity-bound PREDICT."""
+
+    result = object.__new__(NativeMethodsRunResult)
+    observed: dict[str, object] = {}
+
+    class Estimator:
+        def predict_with_identity(self, X, *, sample_ids, groups=None, metadata=None):  # noqa: ANN001
+            observed.update(X=np.asarray(X), sample_ids=list(sample_ids), groups=groups, metadata=metadata)
+            return np.asarray([[4.0]])
+
+    result._native_estimator = Estimator()  # noqa: SLF001
+    predict_module = importlib.import_module("nirs4all.api.predict")
+    monkeypatch.setattr(
+        predict_module,
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("legacy runner constructed")),
+    )
+
+    prediction = predict(
+        model=result,
+        data={"X": np.asarray([[2.0]]), "sample_ids": ["p1"]},
+    )
+
+    assert prediction.y_pred.tolist() == [[4.0]]
+    assert prediction.metadata == {"engine": "native", "sample_ids": ["p1"]}
+    assert observed["sample_ids"] == ["p1"]
+
+
 def test_predict_native_archive_accepts_raw_matrix_with_explicit_keyword_identities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -596,6 +596,30 @@ def test_predict_native_run_result_is_direct_and_never_constructs_a_legacy_runne
     assert observed["sample_ids"] == ["p1"]
 
 
+def test_explain_native_run_result_refuses_before_constructing_a_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SHAP is plugin-only for native artifacts and must never silently reroute."""
+
+    result = object.__new__(NativeMethodsRunResult)
+    explain_module = importlib.import_module("nirs4all.api.explain")
+    monkeypatch.setattr(
+        explain_module,
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("legacy runner constructed")),
+    )
+
+    with pytest.raises(NotImplementedError, match="explicitly installed native or host explanation plugin"):
+        explain(model=result, data={"X": np.asarray([[2.0]])})
+
+
+@pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])
+def test_explain_native_run_result_refuses_explicit_non_native_engine(engine: str) -> None:
+    result = object.__new__(NativeMethodsRunResult)
+    with pytest.raises(ValueError, match="explicit non-native engine"):
+        explain(model=result, data={"X": np.asarray([[2.0]])}, engine=engine)
+
+
 def test_predict_native_archive_accepts_raw_matrix_with_explicit_keyword_identities(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/api/test_native_archive_session.py
+++ b/tests/unit/api/test_native_archive_session.py
@@ -60,7 +60,7 @@ def test_native_archive_session_replays_explicit_ids_and_closes(
         session.predict(np.asarray([[1.0]]), sample_ids=["p3"])
 
 
-def test_load_session_native_uses_the_portable_session_without_bundle_loader(
+def test_load_session_native_environment_uses_the_portable_session_without_bundle_loader(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,
 ) -> None:
@@ -76,8 +76,9 @@ def test_load_session_native_uses_the_portable_session_without_bundle_loader(
         "nirs4all.pipeline.dagml.native_archive_replay.validate_methods_archive_v2",
         lambda path: None,
     )
+    monkeypatch.setenv("N4A_ENGINE", "native")
 
-    loaded = load_session(archive, engine="native")
+    loaded = load_session(archive)
 
     assert isinstance(loaded, NativeArchiveSession)
     assert loaded.archive_path == archive
@@ -119,6 +120,31 @@ def test_predict_uses_native_archive_session_without_model_or_legacy_runner(
     assert result.metadata["engine"] == "native"
     assert observed["path"] == "portable.n4a"
     assert observed["sample_ids"] == ["p1", "p2"]
+
+
+def test_native_environment_selects_archive_prediction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The process selector reaches native replay without an explicit kwarg."""
+
+    monkeypatch.setenv("N4A_ENGINE", "native")
+    monkeypatch.setattr(
+        "nirs4all.pipeline.dagml.native_archive_replay.predict_methods_archive_v2_raw_result",
+        lambda _path, _X, *, sample_ids, **_kwargs: NativeArchivePrediction(
+            values=np.asarray([[3.0]]),
+            sample_ids=tuple(sample_ids),
+            intervals={},
+            conformal_guarantee_status=None,
+        ),
+    )
+
+    result = predict(
+        model="portable.n4a",
+        data={"X": np.asarray([[1.0]]), "sample_ids": ["p1"]},
+    )
+
+    assert result.y_pred.tolist() == [[3.0]]
+    assert result.metadata["engine"] == "native"
 
 
 def test_load_native_archive_session_refuses_a_bad_package_before_prediction(

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -91,6 +91,20 @@ def test_public_session_constructor_selects_native_or_refuses_before_legacy_runn
         Session(engine="native")
 
 
+def test_native_environment_selects_the_public_session_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """All public session constructors honor the same process selector as run()."""
+
+    monkeypatch.setenv("N4A_ENGINE", "native")
+    pipeline = [{"split": "stub"}, {"model": "stub"}]
+
+    constructed = Session(pipeline, name="native")
+    assert isinstance(constructed, NativeMethodsSession)
+    with session(pipeline, name="native") as contextual:
+        assert isinstance(contextual, NativeMethodsSession)
+
+
 def test_native_session_binds_the_strict_methods_hpo_operation_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """Stateful native training forwards only the explicit HPO request."""
 

--- a/tests/unit/pipeline/dagml/test_result_projection.py
+++ b/tests/unit/pipeline/dagml/test_result_projection.py
@@ -122,3 +122,63 @@ def test_scores_to_run_result_preserves_portable_methods_single_variant_oof_aver
     assert len(avg_rows) == 2
     assert {row["val_score"] for row in avg_rows} == {2.0}
     assert result.cv_best_score == 2.0
+
+
+def test_terminal_group_score_wins_without_replacing_sample_oof_score() -> None:
+    """Repetition vote projects group-grain terminal evidence, not row-grain fallback."""
+
+    scores = {
+        "reports": [
+            {
+                "partition": "validation",
+                "fold_id": "fold0",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "level": "sample",
+                "metrics": {"accuracy": 0.75},
+            },
+            {
+                "partition": "validation",
+                "fold_id": "avg",
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "level": "sample",
+                "metrics": {"accuracy": 0.75},
+            },
+            {
+                "partition": "test",
+                "fold_id": None,
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "level": "sample",
+                "metrics": {"accuracy": 0.50},
+            },
+            {
+                "partition": "test",
+                "fold_id": None,
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "level": "group",
+                "metrics": {"accuracy": 1.0},
+            },
+            {
+                "partition": "final",
+                "fold_id": None,
+                "variant_id": "variant:base",
+                "producer_node": "model:compat.0",
+                "level": "group",
+                "metrics": {"accuracy": 1.0},
+            },
+        ]
+    }
+
+    result = _scores_to_run_result(
+        scores,
+        "dataset:test",
+        "VoteClassifier",
+        metric="accuracy",
+        task_type="classification",
+    )
+
+    assert result.cv_best_score == 0.75
+    assert result.best_accuracy == 1.0


### PR DESCRIPTION
## Résumé

- atteste les relations terminales côté DAG-ML et conserve l’ordre physique des répétitions au REFIT, ce qui stabilise la parité du vote de classification ;
- rend le rollback legacy de `run(engine="dag-ml")` explicitement opt-in ;
- route un `NativeMethodsRunResult` fraîchement entraîné vers la prédiction native avec identités explicites ;
- refuse `explain()` pour les artefacts/session natives avant tout `PipelineRunner`, en attendant un plugin déclaré ;
- aligne la documentation et le contrat de signature `load_session`.

## Validation

- `pytest -q tests/unit/api` — 516 passed
- `pytest -q tests/regression/test_public_api_contract.py tests/unit/api/test_engine_transition.py tests/unit/api/test_explain.py` — 73 passed
- `pytest -q tests/integration/parity/test_conformance_dual_engine.py -k aggregation_classification_vote` — 2 passed
- cycle provisionné : entraînement natif → full-refit → Archive V3 Core → nouveau processus → prédiction identique — passed
- `ruff check` et `git diff --check`

Cette PR ne bascule pas le moteur par défaut et ne publie aucun package.