### PR TITLE
chore(native): require released replay dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.13",
+    "dag-ml>=0.3.15",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,12 +121,12 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.13",
+    "dag-ml>=0.3.15",
     "dag-ml-data>=0.2.9",
-    # Archive V3 writing is exposed by the Core Python facade starting in 0.3.21.
-    "nirs4all-core[methods]>=0.3.21",
-    # ABI 2.2 carries the optimizer symbols required by DAG-ML Methods training.
-    "nirs4all-methods>=1.0.10",
+    # Archive V3 replay is exposed by the Core Python facade starting in 0.3.22.
+    "nirs4all-core[methods]>=0.3.22",
+    # 1.0.13 is the pinned Methods ABI/runtime used by the released DAG-ML replay path.
+    "nirs4all-methods>=1.0.13",
 ]
 
 # Transition-release workspace converter wrapper. The runtime detects legacy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.15",
+    "dag-ml>=0.3.16",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.15",
+    "dag-ml>=0.3.16",
     "dag-ml-data>=0.2.9",
     # Archive V3 replay is exposed by the Core Python facade starting in 0.3.22.
     "nirs4all-core[methods]>=0.3.22",

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.15
+dag-ml>=0.3.16
 dag-ml-data>=0.2.8

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.13
+dag-ml>=0.3.15
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.15
+dag-ml>=0.3.16
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.13
+dag-ml>=0.3.15
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.13
+dag-ml>=0.3.15
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.15
+dag-ml>=0.3.16
 dag-ml-data>=0.2.8


### PR DESCRIPTION
Aligns the public native optional dependency floor with the released replay stack: DAG-ML 0.3.15, Core 0.3.22, and Methods 1.0.13. This prevents V3 archive/replay APIs from resolving against older packages.

Validation:
- 54 targeted native export/engine transition tests
- Ruff on touched Python surface
- sdist + wheel build; wheel metadata inspected
- diff check