### PR TITLE
feat(engine): record explicit legacy rollback events

### DIFF
--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -32,7 +32,12 @@ from nirs4all.data import DatasetConfigs
 from nirs4all.data.dataset import SpectroDataset
 from nirs4all.data.predictions import Predictions
 from nirs4all.pipeline import PipelineConfigs, PipelineRunner
-from nirs4all.pipeline.engine import DualRunMismatchError, DualRunUnsupported, resolve_engine
+from nirs4all.pipeline.engine import (
+    DualRunMismatchError,
+    DualRunUnsupported,
+    record_legacy_fallback,
+    resolve_engine,
+)
 
 from .native_session import NativeMethodsSession
 from .result import RunResult
@@ -1265,18 +1270,12 @@ def run(
         except DagMlUnavailable as e:
             if custom_training_loss_requested or allow_legacy_fallback is not True:
                 raise
-            warnings.warn(
-                f"the dag-ml backend is not available ({e}); falling back to the legacy engine",
-                stacklevel=2,
-            )
+            warnings.warn(record_legacy_fallback(reason="backend_unavailable", detail=str(e)), stacklevel=2)
             return _run_legacy()
         except (DagMlUnsupported, NotImplementedError) as e:
             if custom_training_loss_requested or allow_legacy_fallback is not True:
                 raise
-            warnings.warn(
-                f"engine='dag-ml' does not support this pipeline shape ({e}); falling back to the legacy engine",
-                stacklevel=2,
-            )
+            warnings.warn(record_legacy_fallback(reason="unsupported_shape", detail=str(e)), stacklevel=2)
             return _run_legacy()
 
     return _run_legacy()

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -29,7 +29,9 @@ Selection precedence: explicit argument > ``$N4A_ENGINE`` env var > :data:`DEFAU
 from __future__ import annotations
 
 import os
+from collections import Counter
 from collections.abc import Mapping
+from threading import Lock
 from typing import Any, Literal, cast
 
 Engine = Literal["legacy", "dag-ml", "dual", "native"]
@@ -37,6 +39,73 @@ Engine = Literal["legacy", "dag-ml", "dual", "native"]
 DEFAULT_ENGINE: Engine = "legacy"
 ENGINE_ENV_VAR = "N4A_ENGINE"
 ENGINES: tuple[Engine, ...] = ("legacy", "dag-ml", "dual", "native")
+
+LegacyFallbackReason = Literal["backend_unavailable", "unsupported_shape"]
+
+
+class LegacyFallbackWarning(RuntimeWarning):
+    """Structured evidence that an explicit native-to-legacy rollback occurred.
+
+    This warning can only be emitted for ``engine="dag-ml"`` when the caller
+    supplied ``allow_legacy_fallback=True``.  It deliberately carries no input
+    data or pipeline representation: diagnostics must remain safe to collect
+    without disclosing scientific data.
+    """
+
+    engine: Literal["dag-ml"] = "dag-ml"
+
+    def __init__(self, *, reason: LegacyFallbackReason, detail: str) -> None:
+        self.reason = reason
+        self.detail = detail
+        if reason == "backend_unavailable":
+            message = f"the dag-ml backend is not available ({detail}); falling back to the legacy engine"
+        else:
+            message = f"engine='dag-ml' does not support this pipeline shape ({detail}); falling back to the legacy engine"
+        super().__init__(message)
+
+    def as_dict(self) -> dict[str, str]:
+        """Return the safe, structured diagnostic payload for this rollback.
+
+        ``detail`` is deliberately omitted: backend exception text may include
+        user-supplied configuration.  Callers that display the warning already
+        receive that text through the ordinary warning channel.
+        """
+
+        return {"engine": self.engine, "reason": self.reason}
+
+
+_legacy_fallback_counts: Counter[LegacyFallbackReason] = Counter()
+_legacy_fallback_lock = Lock()
+
+
+def record_legacy_fallback(*, reason: LegacyFallbackReason, detail: str) -> LegacyFallbackWarning:
+    """Record one caller-authorized rollback and return its warning payload.
+
+    This intentionally has no persistence or telemetry side effect.  Product
+    callers decide whether to inspect :func:`legacy_fallback_metrics`; the
+    counter merely makes the opt-in rollback observable in the current process.
+    """
+
+    with _legacy_fallback_lock:
+        _legacy_fallback_counts[reason] += 1
+    return LegacyFallbackWarning(reason=reason, detail=detail)
+
+
+def legacy_fallback_metrics() -> dict[str, int]:
+    """Return process-local counts for explicit legacy rollback events.
+
+    The returned mapping is a snapshot with a stable ``total`` plus one count
+    per declared rollback reason.  No run that failed closed contributes here.
+    """
+
+    with _legacy_fallback_lock:
+        unavailable = _legacy_fallback_counts["backend_unavailable"]
+        unsupported = _legacy_fallback_counts["unsupported_shape"]
+    return {
+        "total": unavailable + unsupported,
+        "backend_unavailable": unavailable,
+        "unsupported_shape": unsupported,
+    }
 
 
 class DualRunUnsupported(NotImplementedError):

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -25,7 +25,7 @@ import nirs4all
 from nirs4all.api.result import RunResult
 from nirs4all.config import CacheConfig
 from nirs4all.operators.transforms import StandardNormalVariate as SNV
-from nirs4all.pipeline.engine import resolve_engine
+from nirs4all.pipeline.engine import LegacyFallbackWarning, legacy_fallback_metrics, resolve_engine
 
 pytestmark = [pytest.mark.parity]
 
@@ -106,6 +106,58 @@ def test_run_dagml_propagates_non_catchable_error(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setattr(run_backend, "run_via_dagml", _boom)
     with pytest.raises(RuntimeError, match="genuine dag-ml backend bug"):
         nirs4all.run([{"model": PLSRegression(n_components=2)}], dataset_path("regression"), engine="dag-ml")
+
+
+def test_explicit_dagml_fallback_is_structured_and_counted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only caller-authorized fallback emits safe structured evidence and increments its counter."""
+    import nirs4all.pipeline.dagml.run_backend as run_backend
+    from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+
+    before = legacy_fallback_metrics()
+
+    def _unsupported(*_args: object, **_kwargs: object) -> RunResult:
+        raise DagMlUnsupported("unsupported test shape")
+
+    monkeypatch.setattr(run_backend, "run_via_dagml", _unsupported)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = nirs4all.run(
+            [{"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            allow_legacy_fallback=True,
+        )
+
+    assert isinstance(result, RunResult)
+    event = next(w.message for w in caught if isinstance(w.message, LegacyFallbackWarning))
+    assert event.as_dict() == {
+        "engine": "dag-ml",
+        "reason": "unsupported_shape",
+    }
+    after = legacy_fallback_metrics()
+    assert after["total"] == before["total"] + 1
+    assert after["unsupported_shape"] == before["unsupported_shape"] + 1
+
+
+def test_fail_closed_dagml_refusal_does_not_increment_fallback_counter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A capability refusal is not a rollback event unless the caller explicitly opted in."""
+    import nirs4all.pipeline.dagml.run_backend as run_backend
+    from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+
+    before = legacy_fallback_metrics()
+
+    def _unsupported(*_args: object, **_kwargs: object) -> RunResult:
+        raise DagMlUnsupported("unsupported test shape")
+
+    monkeypatch.setattr(run_backend, "run_via_dagml", _unsupported)
+    with pytest.raises(DagMlUnsupported, match="unsupported test shape"):
+        nirs4all.run(
+            [{"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            engine="dag-ml",
+            allow_legacy_fallback=False,
+        )
+    assert legacy_fallback_metrics() == before
 
 
 def test_dagml_run_uses_in_process(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- emit structured warnings only for caller-authorized DAG-ML to legacy rollback
- expose process-local rollback counters without telemetry or data payloads
- prove strict refusals do not increment rollback evidence

## Validation
- `python3.11 -m pytest -q tests/integration/parity/test_dagml_run_selector.py`
- `ruff check nirs4all/pipeline/engine.py nirs4all/api/run.py tests/integration/parity/test_dagml_run_selector.py`
- `git diff --check`