### PR TITLE
fix(release): align DAG-ML coverage contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.7] — 2026-08-27
+
+### Fixed
+
+- Align the published DAG-ML coverage ledger with native classification vote
+  aggregation, and make unsupported tutorial pipelines assert their strict,
+  no-fallback boundary.
+
+---
+
 ## [0.12.6] — 2026-08-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.12.6 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.7 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ If you use NIRS4ALL in your research, please cite:
   author = {Gregory Beurier and Denis Cornet and Lauriane Rouan},
   title = {NIRS4ALL: Open spectroscopy for everyone},
   url = {https://github.com/GBeurier/nirs4all},
-  version = {0.12.6},
+  version = {0.12.7},
   year = {2026},
 }
 ```

--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -168,11 +168,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "aggregation_classification_vote",
-      "shape": "repetition_vote_aggregation",
-      "owner_lane": "L5"
-    },
-    {
       "case": "generator_finetune_params_optuna",
       "shape": "finetune_params",
       "owner_lane": "L5"
@@ -338,8 +333,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 11,
-    "native": 84,
+    "fallback": 10,
+    "native": 85,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -157,7 +157,7 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (11)
+### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (10)
 
 Shapes the dag-ml host bridge does **not serialize yet**. A normal
 `engine="dag-ml"` request fails closed; the parity harness exercises these rows
@@ -176,7 +176,6 @@ Source: `test_conformance_dual_engine.py:310-337`.
 |---|---|
 | branch (duplication) + merge → multi-model | `branch_dup_three_way_merge_predictions`, `branch_dup_named_with_metamodel`, `branch_dup_merge_all` |
 | branch separation by metadata/tag/filter | `branch_separation_by_metadata_auto`, `branch_separation_by_tag`, `branch_separation_by_filter` |
-| classification repetition + vote aggregation | `aggregation_classification_vote` |
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
 | stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
 | by-source / per-source multi-source | `multi_source_per_source_models_stacking` |

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.12.6 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.7 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/docs/source/getting_started/hello_world.md
+++ b/docs/source/getting_started/hello_world.md
@@ -244,7 +244,11 @@ Or set it for the process:
 N4A_ENGINE=dag-ml python train.py
 ```
 
-If the dag-ml backend is unavailable, or the requested pipeline shape is outside current dag-ml coverage, NIRS4ALL warns and falls back to the legacy engine for catchable unsupported cases.
+If the dag-ml backend is unavailable, or the requested pipeline shape is outside
+current dag-ml coverage, the request fails closed before a legacy workspace is
+created. A compatibility rollback is available only when the caller explicitly
+sets `allow_legacy_fallback=True`; it emits a structured warning and a
+process-local fallback metric.
 
 ### Require a native result during migration qualification
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,7 +16,7 @@ The same YAML/JSON contract is the stable user surface across Python and languag
 | R | Portable wrapper pattern | Yes | Through `reticulate` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | Julia | Portable wrapper pattern | Yes | Through `PythonCall` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | JavaScript/TypeScript | Portable process/runtime wrapper pattern | Yes | No native JS API in this repo | Calls a Python/runtime process today | Calls a Python/runtime process today | {doc}`getting_started/hello_world` |
-| dag-ml runtime | Selectable from Python | Yes, for covered shapes | No Python object construction | `engine="dag-ml"` with legacy fallback | Native result artifacts export directly when supported; legacy refit is explicit-only | {doc}`reference/public_interfaces` |
+| dag-ml runtime | Selectable from Python | Yes, for covered shapes | No Python object construction | `engine="dag-ml"` strict by default; legacy rollback is explicit-only | Native result artifacts export directly when supported; legacy refit is explicit-only | {doc}`reference/public_interfaces` |
 
 :::{note}
 The language-independent contract is the pair of config files. Native R, Julia, or JavaScript package APIs can wrap that contract without changing user pipelines.

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -57,7 +57,7 @@ Synthetic Data Generation:
 See examples/ for more usage examples.
 """
 
-__version__ = "0.12.6"
+__version__ = "0.12.7"
 
 # Module-level API (primary interface) - Phase 2
 from .api import (

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -168,11 +168,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "aggregation_classification_vote",
-      "shape": "repetition_vote_aggregation",
-      "owner_lane": "L5"
-    },
-    {
       "case": "generator_finetune_params_optuna",
       "shape": "finetune_params",
       "owner_lane": "L5"
@@ -338,8 +333,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 11,
-    "native": 84,
+    "fallback": 10,
+    "native": 85,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/nirs4all/pipeline/dagml/errors.py
+++ b/nirs4all/pipeline/dagml/errors.py
@@ -60,10 +60,10 @@ class DagMlUnavailable(RuntimeError):
     (:func:`~nirs4all.pipeline.dagml.run_backend.preflight_dagml_backend`) when BOTH mechanisms are
     missing (the in-process PyO3 extension ``dag_ml._dag_ml`` does not import/load AND the ``dag-ml-cli``
     binary does not exist), and the in-process/subprocess router's SUBPROCESS branch when in-process is
-    not selected and ``dag-ml-cli`` is absent. Since the ADR-17 cutover made ``dag-ml``
-    the default engine + a hard dependency, ``run()`` catches THIS (alongside ``DagMlUnsupported`` /
-    ``NotImplementedError``) and falls back to the legacy engine WITH A WARNING — so a wheel install
-    that is somehow missing the native backend degrades transparently instead of hard-failing.
+    not selected and ``dag-ml-cli`` is absent. ``run(engine="dag-ml")`` propagates this condition by
+    default, before a legacy workspace is constructed. The caller may request the separately observable
+    compatibility rollback with ``allow_legacy_fallback=True``; only that opt-in catches this exception
+    (alongside ``DagMlUnsupported`` / ``NotImplementedError``) and emits a structured warning.
 
     Deliberately NARROW: it is raised only by those explicit availability probes, NEVER by
     wrapping a run in a blanket ``except ImportError/FileNotFoundError`` (which would swallow a genuine

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -351,13 +351,14 @@ SAME_WINNER_CASES: frozenset[str] = frozenset({
 })
 
 
-# EXPECTED-FALLBACK allowlist: the cases the dag-ml path LEGITIMATELY rejects
-# today (branch+merge, by-source multi-source, the preprocessing-keyword shapes),
-# so engine="dag-ml" transparently re-runs legacy. A case that falls back but is
-# NOT on this allowlist is a native-coverage REGRESSION (a shape that used to run
-# native now rejects) and MUST FAIL — never silently pass as a boundary. When
-# dag-ml gains native coverage for one of these, it leaves the allowlist (the test
-# then demands native parity). Measured at scope time; see the probe in the PR.
+# EXPECTED-FALLBACK allowlist: shapes that the dag-ml path legitimately rejects
+# today. Production requests fail closed by default; this parity harness supplies
+# its explicit diagnostic rollback opt-in solely to classify native coverage. A
+# case that falls back but is NOT on this allowlist is a native-coverage
+# REGRESSION (a shape that used to run native now rejects) and MUST FAIL — never
+# silently pass as a boundary. When dag-ml gains native coverage for one of these,
+# it leaves the allowlist (the test then demands native parity). Measured at scope
+# time; see the probe in the PR.
 EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # Branch forms whose merge semantics remain outside the native lowering.
     "branch_dup_three_way_merge_predictions",
@@ -372,8 +373,8 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     "branch_separation_by_tag",
     "branch_separation_by_filter",
     # Legacy Optuna finetuning mutates model parameters before the final run. The
-    # native dag-ml path does not serialize/execute `finetune_params` yet, so it must
-    # fall back rather than silently run the untuned model.
+    # native dag-ml path does not serialize/execute `finetune_params` yet, so the
+    # public strict path rejects it rather than silently run the untuned model.
     "generator_finetune_params_optuna",
     # Stateful concat_transform sub-operations (PCA/SVD/scalers) are materialized
     # pre-CV by the Python oracle; dag-ml's current FeatureConcat lowering fits
@@ -382,8 +383,8 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # Legacy `refit_params: {use_all_partitions: True}` can expand the terminal
     # refit universe beyond the CV train/validation pool. dag-ml deliberately
     # enforces `REFIT FullTrain == fold_set.sample_ids` and structurally excludes
-    # held-out test samples from refit, so the transition backend must fall back
-    # rather than ignore the override or emulate the legacy leakage-prone shape.
+    # held-out test samples from refit, so the strict path rejects the override
+    # rather than ignore it or emulate the legacy leakage-prone shape.
     "refit_params_use_all_partitions",
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_per_source_models_stacking",

--- a/tests/integration/parity/test_conformance_examples_smoke.py
+++ b/tests/integration/parity/test_conformance_examples_smoke.py
@@ -1,10 +1,12 @@
-"""CONFORMANCE: the canonical user examples run on BOTH engines.
+"""CONFORMANCE: canonical user examples either run or fail closed by engine.
 
 The shipped ``examples/user/`` tutorials are the public-facing proof that
-``nirs4all.run`` works end to end. This pins that the four canonical examples
-exit cleanly on the legacy engine AND the dag-ml engine — the engine selector is
-honored via ``$N4A_ENGINE`` (precedence: explicit arg > env > default), so a
-plain example script picks up the engine under test without code changes.
+``nirs4all.run`` works end to end. All four examples exit cleanly on the legacy
+engine. The dag-ml engine runs the currently portable hello-world example and
+refuses the three broader legacy tutorials before a legacy fallback can occur.
+The engine selector is honored via ``$N4A_ENGINE`` (precedence: explicit arg >
+env > default), so a plain example script picks up the engine under test without
+code changes.
 
 Each example is run as a SUBPROCESS (the scripts parse argv at import and import
 matplotlib), with ``cwd=examples/`` (the scripts use dataset paths relative to
@@ -38,6 +40,14 @@ _EXAMPLES = (
     "user/01_getting_started/U03_basic_classification.py",
     "user/03_preprocessing/U01_preprocessing_basics.py",
 )
+
+# These tutorials intentionally exercise pipeline shapes outside the current
+# portable DAG-ML subset (multiple model nodes, classification/ShuffleSplit, or
+# ShuffleSplit preprocessing). They must refuse in strict mode; a future native
+# lowering moves an entry out of this set and turns the expected refusal into a
+# test failure until the tutorial's portable contract is updated deliberately.
+_DAGML_STRICT_REFUSALS = frozenset(_EXAMPLES[1:])
+_LEGACY_FALLBACK_MARKER = "falling back to the legacy engine"
 
 # Optional-dependency import errors that should SKIP rather than fail.
 _OPTIONAL_DEP_MARKERS = (
@@ -75,11 +85,17 @@ def test_example_runs_on_engine(example: str, engine: str) -> None:
         timeout=600,
     )
 
+    combined = proc.stderr + proc.stdout
     if proc.returncode != 0:
-        combined = proc.stderr + proc.stdout
         if any(marker in combined for marker in _OPTIONAL_DEP_MARKERS):
             pytest.skip(f"{example} on engine={engine}: optional dependency not installed")
+        if engine == "dag-ml" and example in _DAGML_STRICT_REFUSALS:
+            assert "DagMlUnsupported" in combined
+            assert _LEGACY_FALLBACK_MARKER not in combined
+            return
         pytest.fail(
             f"{example} on engine={engine} exited {proc.returncode}:\n"
             f"--- stderr tail ---\n{proc.stderr[-2000:]}"
         )
+    if engine == "dag-ml" and example in _DAGML_STRICT_REFUSALS:
+        pytest.fail(f"{example} unexpectedly gained dag-ml coverage; update its portable contract")

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -2709,8 +2709,8 @@ def test_repetition_unsupported_composition_fails_loud() -> None:
         run_via_dagml(aug_pipeline, configs, dagml_cli=str(_DAGML_CLI))
 
 
-def test_repetition_classification_vote_aggregation_falls_back_boundary() -> None:
-    """Classification repetition + vote aggregation stays on fallback until sample-vote scoring is native."""
+def test_repetition_classification_vote_aggregation_runs_natively() -> None:
+    """Classification repetition + vote aggregation is a covered dag-ml shape."""
     from sklearn.ensemble import RandomForestClassifier
 
     from nirs4all.pipeline.dagml.run_backend import run_via_dagml
@@ -2726,8 +2726,9 @@ def test_repetition_classification_vote_aggregation_falls_back_boundary() -> Non
         KFold(n_splits=3, shuffle=True, random_state=42),
         {"model": RandomForestClassifier(n_estimators=20, max_depth=6, random_state=42, n_jobs=1)},
     ]
-    with pytest.raises(NotImplementedError, match=r"classification repetition.*vote aggregation.*#21"):
-        run_via_dagml(pipeline, configs, dagml_cli=str(_DAGML_CLI))
+    result = run_via_dagml(pipeline, configs, dagml_cli=str(_DAGML_CLI))
+    assert result._is_dagml_engine()  # noqa: SLF001
+    assert result.num_predictions >= 1
 
 
 def test_adaptive_finetune_params_remain_fail_closed_boundary() -> None:

--- a/tests/integration/parity/test_dagml_operator_generation_phase7.py
+++ b/tests/integration/parity/test_dagml_operator_generation_phase7.py
@@ -665,14 +665,16 @@ def test_runtime_dagml_unsupported_from_outcome_is_not_swallowed_by_inner_fallba
     distinct ``_OperatorLoweringUnsupported`` sentinel, so this RUNTIME ``DagMlUnsupported`` must PROPAGATE
     past the inner branch — it must NOT be silently reclassified as a lowering gap and re-run on the dag-ml
     Python-expand path (which would report ``dagml_native=True`` and hide the runtime boundary). It is the
-    OUTER ``run()`` fallback that then redirects it to LEGACY (the documented contract for ANY unsupported
-    shape), so the run is LEGACY (``dagml_native=False``), NOT a dag-ml Python-expand success.
+    public ``run()`` boundary then propagates it by default: legacy rollback is a
+    separate, caller-authorized ``allow_legacy_fallback=True`` operation. This
+    probe therefore proves a strict request raises instead of silently reporting
+    a dag-ml Python-expand success.
 
     The probe distinguishes the two outcomes: the monkeypatched ``run_cv_refit_bundle`` returns the
     nonzero-unsupported outcome ONLY for the native-operator workdir (``native_op``); the Python-expand path
     uses a different workdir, so if the inner branch WRONGLY swallowed the error and re-ran Python-expand,
-    that leg would run the real bundle and the run would be (incorrectly) dag-ml-native. Asserting LEGACY
-    (fallback warning fired) proves the runtime error propagated past the inner branch.
+    that leg would run the real bundle and the request would (incorrectly) succeed. Asserting the original
+    runtime refusal proves the error propagated past the inner branch.
     """
     import nirs4all.pipeline.dagml.run_paths as run_paths
 
@@ -692,11 +694,10 @@ def test_runtime_dagml_unsupported_from_outcome_is_not_swallowed_by_inner_fallba
     monkeypatch.setattr(run_paths, "run_cv_refit_bundle", nonzero_unsupported_for_native_op)
 
     pipeline = [{"_or_": [SNV, MSC]}, KFold(n_splits=3), {"model": PLSRegression(n_components=10)}]
-    result, native = _run_dagml(pipeline)
-    # The runtime DagMlUnsupported propagated past the inner branch → the OUTER run() fallback redirected to
-    # LEGACY (fallback warning fired), NOT a silent dag-ml Python-expand re-run (which would be native).
-    assert native is False
-    assert result.num_predictions >= 1
+    from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+
+    with pytest.raises(DagMlUnsupported, match="simulated runtime unsupported shape"):
+        nirs4all.run(pipeline=pipeline, dataset=_dataset(), verbose=0, engine="dag-ml")
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- promote native classification vote aggregation in the compatibility ledger
- assert strict no-fallback behaviour for non-portable tutorial pipelines
- align public fallback documentation and cut a 0.12.7 patch release

## Validation

- `python3.11 -m pytest -q tests/integration/parity/test_compatibility_ledger.py tests/integration/parity/test_dagml_cli_runner.py::test_repetition_classification_vote_aggregation_runs_natively tests/integration/parity/test_dagml_operator_generation_phase7.py::test_runtime_dagml_unsupported_from_outcome_is_not_swallowed_by_inner_fallback`
- `python3.11 -m pytest -q tests/integration/parity/test_conformance_examples_smoke.py` (8 passed)
- targeted native vote dual-engine parity
- `ruff check` and JSON/diff validation