### PR TITLE
feat(native): retain conformal calibration in sessions

### DIFF
--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -30,6 +30,7 @@ class NativeMethodsSession:
         name: str = "",
         random_state: int | None = None,
         tuning: Mapping[str, Any] | None = None,
+        calibration: Mapping[str, Any] | None = None,
     ) -> None:
         if not isinstance(pipeline, list):
             raise TypeError("engine='native' session requires a list pipeline")
@@ -37,10 +38,13 @@ class NativeMethodsSession:
             raise TypeError("engine='native' session random_state must be an integer or None")
         if tuning is not None and not isinstance(tuning, Mapping):
             raise TypeError("engine='native' session tuning must be a mapping")
+        if calibration is not None and not isinstance(calibration, Mapping):
+            raise TypeError("engine='native' session calibration must be a mapping")
         self._pipeline = pipeline
         self._name = name
         self._random_state = random_state
         self._tuning = None if tuning is None else dict(tuning)
+        self._calibration = None if calibration is None else dict(calibration)
         self._result: NativeMethodsRunResult | NativeMethodsRefitResult | None = None
         self._closed = False
 
@@ -69,6 +73,12 @@ class NativeMethodsSession:
         return None if self._tuning is None else dict(self._tuning)
 
     @property
+    def calibration(self) -> dict[str, Any] | None:
+        """Return the explicit identity-bound conformal calibration request."""
+
+        return None if self._calibration is None else dict(self._calibration)
+
+    @property
     def is_trained(self) -> bool:
         """Whether this session owns a fitted native result."""
 
@@ -94,6 +104,7 @@ class NativeMethodsSession:
             save_charts=False,
             random_state=self._random_state,
             tuning=self._tuning,
+            calibration=self._calibration,
         )
         return self._result
 

--- a/tests/unit/api/test_native_session.py
+++ b/tests/unit/api/test_native_session.py
@@ -57,6 +57,7 @@ def test_native_session_runs_predicts_saves_and_closes_without_legacy_runner(mon
         "save_charts": False,
         "random_state": 7,
         "tuning": None,
+        "calibration": None,
     }
     with pytest.raises(RuntimeError, match="closed"):
         native.run({"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]})
@@ -71,6 +72,8 @@ def test_native_session_refuses_missing_pipeline_and_legacy_runner_kwargs() -> N
             pass
     with pytest.raises(TypeError, match="tuning must be a mapping"):
         NativeMethodsSession([], tuning=["methods-hpo"])  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="calibration must be a mapping"):
+        NativeMethodsSession([], calibration=["conformal"])  # type: ignore[arg-type]
 
 
 def test_public_session_constructor_selects_native_or_refuses_before_legacy_runner() -> None:
@@ -124,6 +127,37 @@ def test_native_session_binds_the_strict_methods_hpo_operation_once(monkeypatch:
     assert native.tuning == {"engine": "methods-hpo", "trials": 3}
     assert native.run({"X": [[1.0]], "y": [1.0], "sample_ids": ["s1"]}) is result
     assert observed["tuning"] == {"engine": "methods-hpo", "trials": 3}
+
+
+def test_native_session_binds_the_explicit_conformal_calibration_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stateful native training retains the caller's calibration request boundary."""
+
+    result = _Result()
+    observed: dict[str, object] = {}
+    calibration = {
+        "X": [[1.0]],
+        "y": [1.0],
+        "sample_ids": ["cal-1"],
+        "coverages": [0.9],
+    }
+
+    def native_run(_pipeline, _dataset, **kwargs):  # noqa: ANN001
+        observed.update(kwargs)
+        return result
+
+    monkeypatch.setattr("nirs4all.api.native_session.run_native_methods", native_run)
+    native = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}], calibration=calibration)
+
+    assert native.calibration == calibration
+    calibration["coverages"] = [0.8]
+    assert native.calibration == {
+        "X": [[1.0]],
+        "y": [1.0],
+        "sample_ids": ["cal-1"],
+        "coverages": [0.9],
+    }
+    assert native.run({"X": [[2.0]], "y": [2.0], "sample_ids": ["s1"]}) is result
+    assert observed["calibration"] == native.calibration
 
 
 def test_native_run_delegates_to_the_matching_native_session(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- retain validated conformal calibration metadata in `NativeArchiveSession`
- forward it through native replay execution
- keep a shallow defensive copy and reject non-mapping input

## Validation
- targeted native session tests passed before rebase
- full PR CI is authoritative after the rebase