### PR TITLE
feat(native): close R2 API safety boundaries

### DIFF
--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -59,7 +59,7 @@ The public Python API runs that contract directly. The CLI currently validates a
 | `nirs4all.get_tuning_space_schema()` | Return the JSON Schema for `inspect_tuning_space(...)` artifacts | None | JSON Schema dict |
 | `nirs4all.tuning_space_schema_json(...)` | Serialize the ordered tuning-space JSON Schema deterministically | Optional JSON indentation | Schema JSON text |
 | `nirs4all.explain(...)` | Generate SHAP explanations | Model/bundle + data | `ExplainResult` |
-| `nirs4all.retrain(..., engine="native")` | Run one fresh target-cohort full refit from an attested in-memory `NativeMethodsRunResult`; CV/SELECT do not repeat | Parent result + exactly `{X, y, sample_ids}` | `NativeMethodsRefitResult`, exportable as target-bound Archive V3; transfer, finetune and archive-parent refit refuse before execution |
+| `nirs4all.retrain(..., engine="native")` | Run one fresh target-cohort full refit from an attested in-memory `NativeMethodsRunResult`; CV/SELECT do not repeat | Parent result + exactly `{X, y, sample_ids}` | `NativeMethodsRefitResult`, exportable as target-bound Archive V3; transfer, finetune, archive-parent refit, and using a V3 child as a new parent refuse before execution |
 | `nirs4all.session(...)` | Share runner/workspace resources across calls | Optional pipeline and runner kwargs | `Session` |
 | `nirs4all.load_session(..., engine="legacy")` | Load an exported legacy `.n4a` bundle for prediction | Bundle path | `Session` |
 | `nirs4all.load_session(..., engine="native")` | Open a portable Archive V2 or V3 Methods PREDICT session without a legacy fallback | Archive path | `NativeArchiveSession` |

--- a/docs/source/user_guide/deployment/retrain_transfer.md
+++ b/docs/source/user_guide/deployment/retrain_transfer.md
@@ -62,9 +62,10 @@ retrained = nirs4all.retrain(
 
 This path never creates a ``PipelineRunner`` or uses a Python HPO objective.
 Archive V2 sources, transfer mode, finetuning, replacing the model, legacy
-runner options and retained sessions are refused before native execution. An
-archive-to-retrain recipe is a separate portable contract and is not inferred
-from prediction-only archive metadata.
+runner options, retained sessions, and a prior ``NativeMethodsRefitResult``
+(Archive V3 child) are refused before native execution. An archive-to-retrain
+recipe and multi-generation native lineage are separate portable contracts and
+are not inferred from prediction-only archive metadata.
 
 A trained ``NativeMethodsSession`` exposes the same full-refit operation as
 ``native_session.retrain({"X": X_new, "y": y_new, "sample_ids": new_ids})``;

--- a/nirs4all/api/generate.py
+++ b/nirs4all/api/generate.py
@@ -247,6 +247,8 @@ def regression(
         ...     random_state=42
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(
@@ -346,6 +348,8 @@ def classification(
         ...     random_state=42
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(
@@ -405,6 +409,8 @@ def builder(
         ...     .build()
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     return SyntheticDatasetBuilder(
@@ -470,6 +476,8 @@ def multi_source(
         ...     ]
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import generate_multi_source as _generate_multi_source
 
     if sources is None:
@@ -530,6 +538,8 @@ def to_folder(
         ...     random_state=42
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(
@@ -581,6 +591,8 @@ def to_csv(
         >>> import nirs4all
         >>> path = nirs4all.generate.to_csv("data.csv", n_samples=500)
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(
@@ -664,6 +676,8 @@ def product(
         generate.category: Generate from multiple product templates.
         list_product_templates: List available templates.
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import ProductGenerator
 
     # Build wavelength kwargs
@@ -750,6 +764,8 @@ def category(
     See Also:
         generate.product: Generate from a single product template.
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import CategoryGenerator
 
     # Build wavelength kwargs
@@ -834,6 +850,8 @@ def from_template(
         ...     wavelengths=wavelengths
         ... )
     """
+    require_legacy_engine("generate")
+
     from nirs4all.synthesis import RealDataFitter, SyntheticDatasetBuilder
 
     builder = SyntheticDatasetBuilder(

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -9,7 +9,6 @@ re-running that workflow through :class:`PipelineRunner` during export.
 from __future__ import annotations
 
 import importlib
-import json
 from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
@@ -466,10 +465,10 @@ def _attach_native_conformal_calibration(
         calibration_relations=replay.calibration_relations,
         truth=replay.truth,
         coverages=calibration["coverages"],
-        # The released DAG-ML facade accepts object values directly but treats
-        # scalar strings as pre-serialized TCV1 JSON contracts.
-        multi_target_policy=json.dumps(calibration["multi_target_policy"]),
-        small_sample_policy=json.dumps(calibration["small_sample_policy"]),
+        # The public DAG-ML facade serializes enum values to strict JSON at
+        # its boundary.  Passing raw enum strings prevents double encoding.
+        multi_target_policy=calibration["multi_target_policy"],
+        small_sample_policy=calibration["small_sample_policy"],
     )
     package_id = _portable_package_id(package)
     estimator.training_outcome_ = getattr(training_result, "outcome", None)

--- a/nirs4all/api/retrain.py
+++ b/nirs4all/api/retrain.py
@@ -35,6 +35,7 @@ from .session import Session
 # Type aliases for clarity
 SourceSpec: TypeAlias = (
     NativeMethodsRunResult  # Native in-memory Methods result
+    | NativeMethodsRefitResult  # Native V3 refit result (not a retrain parent)
     | dict[str, Any]  # Prediction dict from previous run
     | str  # Path to bundle (.n4a) or config
     | Path  # Path to bundle or config
@@ -110,7 +111,7 @@ def retrain(
             - freeze_layers: List of layers to freeze during fine-tuning
             - step_modes: Per-step mode overrides (advanced)
             - engine: the strict in-memory Methods full retrain subset is
-              selected automatically by a ``NativeMethodsRunResult`` source,
+              selected automatically by a native Methods source,
               or explicitly with ``"native"``. It requires a raw ``{"X",
               "y", "sample_ids"}`` dataset and preserves the attested selected
               PLS variant. Archive sources, transfer and finetune remain
@@ -187,7 +188,7 @@ def retrain(
         raise ValueError(f"Invalid mode '{mode}'. Must be one of: {valid_modes}")
 
     engine = kwargs.pop("engine", None)
-    if isinstance(source, NativeMethodsRunResult):
+    if isinstance(source, (NativeMethodsRunResult, NativeMethodsRefitResult)):
         if engine is None:
             # The source is an already-attested native capability. It must not
             # be routed through an environment/default legacy selector.
@@ -196,7 +197,7 @@ def retrain(
             selected_engine = resolve_engine(engine)
         if selected_engine != "native":
             raise ValueError(
-                "a NativeMethodsRunResult selects native retrain; an explicit non-native engine is refused"
+                "a native Methods retrain source selects native retrain; an explicit non-native engine is refused"
             )
     else:
         selected_engine = resolve_engine(engine)
@@ -214,7 +215,7 @@ def retrain(
             extra_kwargs=kwargs,
         )
     require_legacy_engine("retrain", selected_engine)
-    if isinstance(source, NativeMethodsRunResult):
+    if isinstance(source, (NativeMethodsRunResult, NativeMethodsRefitResult)):
         raise RuntimeError("native retrain source escaped native routing")
     # Use session runner if provided, otherwise create new
     runner = session.runner if session is not None else PipelineRunner(verbose=verbose, save_artifacts=save_artifacts)
@@ -257,6 +258,11 @@ def _retrain_native_methods_full(
 
     if mode != "full":
         raise NotImplementedError("engine='native' retrain currently supports only mode='full'")
+    if isinstance(source, NativeMethodsRefitResult):
+        raise NotImplementedError(
+            "engine='native' retrain cannot use a NativeMethodsRefitResult as a new parent; "
+            "retain the original NativeMethodsRunResult or use a future lineage capability"
+        )
     if not isinstance(source, NativeMethodsRunResult):
         raise TypeError("engine='native' retrain requires an in-memory NativeMethodsRunResult source")
     if not isinstance(data, Mapping):

--- a/nirs4all/pipeline/dagml/node_runner.py
+++ b/nirs4all/pipeline/dagml/node_runner.py
@@ -900,9 +900,10 @@ def _ordered_oof_specs(prediction_inputs: dict[str, Any], *, suffix: str | None)
     """The meta-node's base specs in canonical producer order, selecting one delivery kind.
 
     dag-ml keys each base producer's Validation OOF under ``"{producer}.{port}"`` and its off-fold
-    (REFIT-test / PREDICT) block under ``"{producer}.{port}:refit"`` / ``":predict"`` (see runtime
-    ``collect_off_fold_prediction_input``). ``suffix=None`` selects the Validation OOF inputs (FIT_CV
-    training + the REFIT fit pool); ``suffix="refit"`` / ``"predict"`` selects the off-fold inputs.
+    (REFIT-test / PREDICT) block under ``"{producer}.{port}:refit"`` / ``":predict"`` and an
+    outer-fold evaluation block under ``"{producer}.{port}:outer"``. ``suffix=None`` selects only
+    unsuffixed Validation OOF inputs (FIT_CV inner training + the REFIT fit pool); a suffix selects
+    the corresponding delivery class.
 
     Ordering is by the **base OOF key** (the suffix stripped) so the meta-feature columns line up
     one-for-one with the FIT_CV matrix regardless of which delivery kind is selected — the column for
@@ -912,7 +913,11 @@ def _ordered_oof_specs(prediction_inputs: dict[str, Any], *, suffix: str | None)
     selected: dict[str, dict[str, Any]] = {}
     for key, spec in prediction_inputs.items():
         if tag is None:
-            if not (key.endswith(":refit") or key.endswith(":predict")):
+            if not (
+                key.endswith(":outer")
+                or key.endswith(":refit")
+                or key.endswith(":predict")
+            ):
                 selected[key] = spec
         elif key.endswith(tag):
             selected[key[: -len(tag)]] = spec
@@ -933,7 +938,10 @@ def run_meta_model_node(
     (:func:`_ordered_oof_specs`):
 
     * ``"{producer}.{port}"`` — the base producer's **Validation OOF** (the ``requires_oof`` edge
-      refuses any train block, so it is leakage-safe). This is what the meta-learner trains on.
+      refuses any train block, so it is leakage-safe). In FIT_CV this is inner-fold OOF over the
+      outer training universe, and is what the meta-learner trains on.
+    * ``"{producer}.{port}:outer"`` — the base producer's outer-fold validation block. It is used
+      only to evaluate the fitted meta-learner, never as a fit row.
     * ``"{producer}.{port}:refit"`` / ``":predict"`` — the base producer's **off-fold** block (REFIT
       held-out Test / PREDICT new-data Final, ``fold_id=None``), delivered ONLY in REFIT/PREDICT and
       used ONLY to PREDICT the holdout, never to train.
@@ -941,8 +949,8 @@ def run_meta_model_node(
     The meta-feature matrix has one column block per base producer in **deterministic producer order**
     (sorted base key), aligned by ``sample_id``, mirroring dag-ml's ``join_oof_features``.
 
-    * FIT_CV (fold K): build ``X_meta`` from the fold-K Validation OOF, fit the MetaModel on
-      ``(X_meta, y_train)``, predict those rows, emit the meta-model's own OOF
+    * FIT_CV (fold K): build ``X_meta`` from inner-fold OOF, fit the MetaModel on
+      ``(X_meta, y_train)``, then predict the separate ``:outer`` matrix and emit the meta-model's OOF
       (``partition=validation``, ``fold_id=foldK``) + targets. The cross-fold OOF average of the meta
       producer is ``cv_best_score``.
     * REFIT: fit + persist the meta-model on the FULL Validation OOF (all folds), then build the TEST
@@ -980,8 +988,8 @@ def run_meta_model_node(
         regression_targets = [_meta_target_block(sample_ids, [float(value) for value in true_y])]
         return _build_result(task, predictions, [], {}, regression_targets)
 
-    # FIT_CV + REFIT both fit on Validation OOF. The OOF specs (no `:refit`/`:predict` suffix) are the
-    # meta-learner's training features; in FIT_CV they are this fold's OOF, in REFIT the full OOF.
+    # FIT_CV + REFIT both fit on Validation OOF. The unsuffixed OOF specs are the
+    # meta-learner's training features; in FIT_CV they are inner OOF, in REFIT the full OOF.
     oof_specs = _ordered_oof_specs(prediction_inputs, suffix=None)
     if not oof_specs:
         raise ValueError(f"meta-model node {node_id!r} received no Validation OOF inputs to fit on")
@@ -996,10 +1004,20 @@ def run_meta_model_node(
     fold_predictions: list[dict[str, Any]] = []
     fold_targets: list[dict[str, Any]] = []
     if phase == "FIT_CV":
-        # The meta-model's own OOF for this fold's samples (scored → cv_best_score).
-        pred = np.asarray(fit_estimator.predict(x_meta), dtype=float).reshape(len(sample_ids), -1)
-        fold_predictions.append(_meta_prediction_block(node_id, phase, variant_label, fold_label, "validation", task.get("fold_id"), sample_ids, pred))
-        fold_targets.append(_meta_target_block(sample_ids, [float(value) for value in y_meta]))
+        # The outer rows must be distinct from the inner rows just used to fit.
+        # Refuse a direct/old lowering rather than silently emitting optimistic
+        # same-fold predictions.
+        outer_specs = _ordered_oof_specs(prediction_inputs, suffix="outer")
+        if not outer_specs:
+            raise ValueError(
+                f"meta-model node {node_id!r} FIT_CV received no `:outer` OOF evaluation inputs; "
+                "nested scheduler evidence is required"
+            )
+        outer_ids, x_outer = _meta_feature_matrix(outer_specs, node_id)
+        pred = np.asarray(fit_estimator.predict(x_outer), dtype=float).reshape(len(outer_ids), -1)
+        fold_predictions.append(_meta_prediction_block(node_id, phase, variant_label, fold_label, "validation", task.get("fold_id"), outer_ids, pred))
+        outer_y = resolver.resolve_targets(outer_ids)["values"]
+        fold_targets.append(_meta_target_block(outer_ids, [float(value) for value in outer_y]))
 
     artifacts: list[dict[str, Any]] = []
     artifact_handles: dict[str, Any] = {}

--- a/nirs4all/pipeline/dagml/run_paths.py
+++ b/nirs4all/pipeline/dagml/run_paths.py
@@ -1854,31 +1854,13 @@ _META_NODE_ID = "merge:stack"
 
 
 def _run_stacking_branch(pipeline: list[Any], branches: list[list[Any]], meta_learner: Any, spectro: Any, dataset_arg: str, cli: str, venv_python: str, run_dir: Path, metric: str, task_type: str, dataset_pickle: str | None = None, config_name: str = "", random_state: int | None = None) -> RunResult:
-    """Run a duplication branch + ``{"merge": "predictions"}`` + meta-model as ONE native dag-ml run (#10).
+    """Run one scheduler-owned nested-OOF stacking campaign (ADR-26).
 
-    Lowers each inner sub-pipeline to a canonical duplication branch (``mode: "duplication"`` — each base
-    model node gets the FULL fold data view) + a ``merge_model`` meta-node carrying the meta-learner (its
-    FQN as ``operator.class`` so the node runner instantiates it) bound to ``controller:nirs4all.meta_model``
-    (which declares ``consumes_oof_predictions``, so dag-ml's planner permits the base→meta ``requires_oof``
-    edges). dag-ml runs ONE native CV+refit:
-
-    * each base branch model is FIT_CV on the full fold-train and predicts the full fold-validation
-      (held-out Validation OOF);
-    * the meta-node receives the base branches' **Validation OOF** per fold (Option A: the runtime delivers
-      ``prediction_inputs[*].values`` aligned by sample_id, sourced ONLY from Validation blocks — the
-      ``requires_oof`` edge refuses any train block), builds the per-fold meta-feature matrix (columns in
-      deterministic producer order), fits the meta-learner and emits its own scored Validation OOF.
-
-    The meta producer's cross-fold OOF average is ``cv_best_score`` — the stacking ensemble's CV score.
-    ``best_rmse`` (final test) is also native: in REFIT dag-ml delivers each base producer's held-out
-    TEST prediction to the meta-node as a SEPARATE off-fold input keyed ``…oof:refit`` (partition Test,
-    ``fold_id=None``), alongside the full Validation OOF the meta fits on. The refit meta-model predicts
-    the test set from those base TEST meta-features and emits a scored ``(test, fold_id=None)`` block.
-
-    LEAKAGE INVARIANT: the meta-learner is fit on Validation OOF ONLY (the ``requires_oof`` edge +
-    ``collect_oof_prediction_input`` enforce Validation-only); the TEST meta-features come from the base
-    models' TEST predictions (the ``:refit`` off-fold input, phase-gated to REFIT), never their OOF/train,
-    and never enter the FIT_CV meta-features.
+    Each outer fold has two non-interchangeable evidence classes: base models
+    first emit inner OOF over the outer training universe to fit the meta
+    learner, then emit outer-validation predictions used only to score it.
+    The Rust scheduler materializes that split; this lowering merely declares
+    the exact contract and never performs a Python-side CV loop.
     """
     import dag_ml
 
@@ -1890,17 +1872,14 @@ def _run_stacking_branch(pipeline: list[Any], branches: list[list[Any]], meta_le
         raise DagMlUnsupported("engine='dag-ml' requires a cross-validator step (e.g. KFold) in the pipeline")
 
     identity = mint_identity(spectro)
-    # The handled shape rejects any exclude step, so the CV universe is the full train pool.
     pool = spectro.index_column("sample", {"partition": "train"})
     folds = _build_folds(splitter, spectro, pool, set())
     envelope = build_envelope(spectro, identity, sample_ints=pool)
-
-    # Canonical DSL: one duplication branch with N base sub-pipelines (each on the FULL data) + a
-    # merge_model meta-node. The meta-node carries the bare sklearn meta-learner (FQN + params) and the
-    # _META_MODEL_REF (so its dedicated manifest is not a generic model-kind catch-all) and binds to the
-    # meta-model controller via metadata.controller_id.
+    # K=2 is the narrowest non-degenerate nested policy.  It is serialized in
+    # the DSL and constructed/attested by dag-ml, never delegated to sklearn.
     canonical_dsl: dict[str, Any] = {
         "id": "nirs4all-stacking",
+        "inner_cv": {"kind": "kfold", "n_splits": 2, "shuffle": False, "seed": random_state},
         "steps": [
             {"kind": "branch", "mode": "duplication", "branches": [_canonical_branch(branch, index) for index, branch in enumerate(branches)]},
             {
@@ -1910,45 +1889,32 @@ def _run_stacking_branch(pipeline: list[Any], branches: list[list[Any]], meta_le
                 "params": _json_safe_params(meta_learner),
                 "metadata": {
                     "controller_id": _META_MODEL_CONTROLLER_ID,
+                    "stacking_oof_execution": "nested_oof_v1",
                     "stacking_oof_refit_contract": {"policy": "require_full_coverage"},
                 },
             },
         ],
     }
-
     manifests = controller_manifests()
     graph = dag_ml.compile_pipeline_dsl_artifact_with_controllers(canonical_dsl, manifests).graph.to_dict()
     model_ids = [node["id"] for node in graph["nodes"] if node["kind"] == "model"]
     base_model_ids = [model_id for model_id in model_ids if model_id != _META_NODE_ID]
-    if len(base_model_ids) < 2:
-        raise DagMlUnsupported("stacking compile produced fewer than two base model nodes")
-    if _META_NODE_ID not in model_ids:
-        raise DagMlUnsupported("stacking compile produced no meta-model node")
-
-    # One data_binding per BASE model node (each binds its `x` to the full source). The meta-node has NO
-    # data binding: its features are the base branches' OOF, delivered as prediction_inputs (not data).
+    if len(base_model_ids) < 2 or _META_NODE_ID not in model_ids:
+        raise DagMlUnsupported("stacking compile did not produce two base models and one meta-model")
     canonical_dsl["data_bindings"] = data_bindings_for_nodes(base_model_ids, envelope)
     canonical_dsl["split_invocation"] = split_invocation_for(identity, folds, n_splits=len(folds))
 
     outcome = run_cv_refit_bundle(
-        dsl=canonical_dsl, envelope=envelope, graph=graph, dataset_path=dataset_arg, workdir=run_dir, dagml_cli=cli, venv_python=venv_python, selection_metric=metric, dataset_pickle=dataset_pickle, dataset=spectro, random_state=random_state
+        dsl=canonical_dsl, envelope=envelope, graph=graph, dataset_path=dataset_arg,
+        workdir=run_dir, dagml_cli=cli, venv_python=venv_python,
+        selection_metric=metric, dataset_pickle=dataset_pickle, dataset=spectro,
+        random_state=random_state,
     )
     if outcome["returncode"] != 0:
-        _raise_run_failure(outcome, "dag-ml stacking run failed")
-
-    # The meta-node producer's reports carry the full-universe cross-fold OOF average (the stacking
-    # ensemble's `cv_best_score`) AND a `(test, fold_id=None)` block (`best_rmse`): the refit meta-model
-    # predicting the held-out test from the base producers' REFIT-test predictions (`…oof:refit`).
-    model_label = f"MetaModel_{type(meta_learner).__name__}"
+        _raise_run_failure(outcome, "dag-ml nested stacking run failed")
     return _scores_to_run_result(
-        outcome["scores"],
-        spectro.name,
-        model_label,
-        metric,
-        task_type,
-        producer=_META_NODE_ID,
-        config_name=config_name,
-        results=outcome["results"],
-        identity=identity,
+        outcome["scores"], spectro.name, f"MetaModel_{type(meta_learner).__name__}",
+        metric, task_type, producer=_META_NODE_ID, config_name=config_name,
+        results=outcome["results"], identity=identity,
         refit_artifacts=outcome["refit_artifacts"],
     )

--- a/tests/e2e/test_multisource_stacking_replay.py
+++ b/tests/e2e/test_multisource_stacking_replay.py
@@ -20,6 +20,7 @@ from nirs4all.data.config import DatasetConfigs
 from nirs4all.operators.transforms import FirstDerivative
 from nirs4all.operators.transforms import MultiplicativeScatterCorrection as MSC
 from nirs4all.operators.transforms import StandardNormalVariate as SNV
+from nirs4all.pipeline.dagml.identity import mint_identity
 from tests.integration.parity._datasets import dataset_path
 
 SCENARIO_ID = "e2e-multisource-branching-stacking-replay"
@@ -133,6 +134,7 @@ def _branch_specs(pipeline_contract: dict[str, Any]) -> list[dict[str, Any]]:
 def _direct_stacking_oracle(pipeline_contract: dict[str, Any] | None = None) -> dict[str, Any]:
     pipeline_contract = pipeline_contract or _pipeline_contract()
     dataset = _load_multi_dataset()
+    identity = mint_identity(dataset)
     train = dataset.index_column("sample", {"partition": "train"})
     test = dataset.index_column("sample", {"partition": "test"})
     split_params = pipeline_contract["pipeline"][0]["params"]
@@ -142,7 +144,19 @@ def _direct_stacking_oracle(pipeline_contract: dict[str, Any] | None = None) -> 
     folds = [([train[i] for i in tr], [train[i] for i in va]) for tr, va in KFold(**split_params).split(train)]
 
     def x(ids: list[int]) -> np.ndarray:
-        return np.asarray(dataset.x({"sample": [int(sample) for sample in ids]}, layout="2d", concat_source=True))
+        # The dataset preserves storage order when it materializes a selected
+        # sample set. Nested CV deliberately uses canonical wire-ID ordering,
+        # which is not numerical storage order (``…s100`` sorts before
+        # ``…s11``). Reindex the feature rows just as ``y`` does below so the
+        # Python oracle fits each inner estimator on the exact `(X, y)` pairing
+        # that the identity-keyed native resolver receives.
+        requested = [int(sample) for sample in ids]
+        stored = dataset.index_column("sample", {"sample": requested})
+        row_of = {int(sample): row for row, sample in enumerate(stored)}
+        values = np.asarray(
+            dataset.x({"sample": requested}, layout="2d", concat_source=True)
+        )
+        return values[[row_of[sample] for sample in requested]]
 
     def y(ids: list[int]) -> np.ndarray:
         stored = dataset.index_column("sample", {"sample": [int(sample) for sample in ids]})
@@ -166,29 +180,59 @@ def _direct_stacking_oracle(pipeline_contract: dict[str, Any] | None = None) -> 
     fold_summaries: list[dict[str, Any]] = []
 
     for fold_index, (train_ids, val_ids) in enumerate(folds):
+        train_ids = [int(sample) for sample in train_ids]
         val_ids = [int(sample) for sample in val_ids]
-        meta_columns: list[np.ndarray] = []
+        # Mirror ADR-26 exactly: the meta learner is fit on base OOF made
+        # inside the outer training universe, then evaluated on independently
+        # fitted base predictions for the outer validation universe.
+        # `NestedCvSpec::KFold` sorts canonical wire SampleIds then assigns
+        # validation rows round-robin (`index % n_splits`), unlike sklearn's
+        # contiguous no-shuffle KFold blocks. Reproduce that contract exactly.
+        inner_ordered = sorted(train_ids, key=identity.to_wire)
+        inner_folds = [
+            (
+                [sample for index, sample in enumerate(inner_ordered) if index % 2 != fold],
+                [sample for index, sample in enumerate(inner_ordered) if index % 2 == fold],
+            )
+            for fold in range(2)
+        ]
+        inner_columns: list[np.ndarray] = []
+        outer_columns: list[np.ndarray] = []
         base_scores: dict[str, float] = {}
         for spec in branch_specs:
             branch_name = spec["name"]
+            inner_by_sample: dict[int, float] = {}
+            for inner_train_ids, inner_val_ids in inner_folds:
+                fitted = fit_branch(spec, inner_train_ids)
+                inner_predictions = predict_branch(fitted, inner_val_ids)
+                inner_by_sample.update(
+                    {
+                        sample_id: float(prediction)
+                        for sample_id, prediction in zip(inner_val_ids, inner_predictions, strict=True)
+                    }
+                )
+            assert set(inner_by_sample) == set(train_ids)
+            inner_columns.append(np.asarray([inner_by_sample[sample_id] for sample_id in train_ids]))
             fitted = fit_branch(spec, train_ids)
             predictions = predict_branch(fitted, val_ids)
-            meta_columns.append(predictions)
+            outer_columns.append(predictions)
             for position, sample_id in enumerate(val_ids):
                 base_oof[branch_name][sample_id] = float(predictions[position])
             base_scores[branch_name] = float(np.sqrt(mean_squared_error(y(val_ids), predictions)))
 
-        x_meta = np.column_stack(meta_columns)
-        y_meta = y(val_ids)
-        meta_predictions = Ridge(**final_model_params).fit(x_meta, y_meta).predict(x_meta)
+        x_meta = np.column_stack(inner_columns)
+        y_meta = y(train_ids)
+        x_outer = np.column_stack(outer_columns)
+        y_outer = y(val_ids)
+        meta_predictions = Ridge(**final_model_params).fit(x_meta, y_meta).predict(x_outer)
         for position, sample_id in enumerate(val_ids):
-            truth[sample_id] = float(y_meta[position])
+            truth[sample_id] = float(y_outer[position])
             meta_oof[sample_id] = float(meta_predictions[position])
         fold_summaries.append(
             {
                 "fold_id": fold_index,
                 "sample_ids": val_ids,
-                "meta_rmse": float(np.sqrt(mean_squared_error(y_meta, meta_predictions))),
+                "meta_rmse": float(np.sqrt(mean_squared_error(y_outer, meta_predictions))),
                 "base_rmse": base_scores,
             }
         )
@@ -271,7 +315,12 @@ def test_multisource_stacking_replay(artifacts_dir: Path) -> None:
     assert summary["is_dagml"] is True
     cv_best_score_delta = abs(summary["cv_best_score"] - oracle["scores"]["cv_best_score"])
     best_rmse_delta = abs(summary["best_rmse"] - oracle["scores"]["best_rmse"])
-    assert cv_best_score_delta <= SCORE_TOLERANCE
+    assert cv_best_score_delta <= SCORE_TOLERANCE, {
+        "native_cv": summary["cv_best_score"],
+        "oracle_cv": oracle["scores"]["cv_best_score"],
+        "native_meta_rows": summary["rows"],
+        "oracle_folds": oracle["folds"],
+    }
     assert best_rmse_delta <= SCORE_TOLERANCE
 
     native_dir = Path(summary["native_results_dir"])

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -12,6 +12,7 @@ from sklearn.model_selection import KFold
 
 import nirs4all
 from nirs4all.api.explain import explain
+from nirs4all.api.native_refit_result import NativeMethodsRefitResult
 from nirs4all.api.native_result import NativeMethodsRunResult
 from nirs4all.api.native_retrain_lineage import NativeRetrainLineage
 from nirs4all.api.predict import predict
@@ -483,6 +484,30 @@ def test_retrain_native_refits_the_attested_selected_methods_variant_without_leg
 @pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])
 def test_retrain_native_source_refuses_explicit_non_native_engine(engine: str) -> None:
     source = object.__new__(NativeMethodsRunResult)
+    with pytest.raises(ValueError, match="explicit non-native engine"):
+        retrain(source, {"X": [], "y": [], "sample_ids": []}, engine=engine)
+
+
+def test_retrain_native_refit_result_refuses_before_constructing_a_legacy_runner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A V3 child cannot silently become a legacy retrain parent."""
+
+    source = object.__new__(NativeMethodsRefitResult)
+    retrain_module = importlib.import_module("nirs4all.api.retrain")
+    monkeypatch.setattr(
+        retrain_module,
+        "PipelineRunner",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("legacy runner constructed")),
+    )
+
+    with pytest.raises(NotImplementedError, match="NativeMethodsRefitResult as a new parent"):
+        retrain(source, {"X": [], "y": [], "sample_ids": []})
+
+
+@pytest.mark.parametrize("engine", ["legacy", "dag-ml", "dual"])
+def test_retrain_native_refit_result_refuses_explicit_non_native_engine(engine: str) -> None:
+    source = object.__new__(NativeMethodsRefitResult)
     with pytest.raises(ValueError, match="explicit non-native engine"):
         retrain(source, {"X": [], "y": [], "sample_ids": []}, engine=engine)
 

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -221,8 +221,8 @@ def test_run_native_attaches_identity_bound_conformal_calibration_without_legacy
         "calibration_relations": {"records": [{"sample_id": "cal-1"}, {"sample_id": "cal-2"}]},
         "truth": {"sample_ids": ["cal-1", "cal-2"], "values": [[1.5], [2.5]]},
         "coverages": [0.8, 0.95],
-        "multi_target_policy": '"marginal"',
-        "small_sample_policy": '"error"',
+        "multi_target_policy": "marginal",
+        "small_sample_policy": "error",
     }
     assert estimator.predictor_package_ == {"package_id": "package:native", "schema_version": 2, "reexported": True}
     assert result.native_conformal_calibration == {"schema_version": 2, "binding_id": "binding:prediction"}

--- a/tests/unit/api/test_generate.py
+++ b/tests/unit/api/test_generate.py
@@ -34,6 +34,44 @@ class TestGenerateFunction:
         with pytest.raises((NotImplementedError, ValueError), match="nirs4all.generate|dual"):
             nirs4all.generate(n_samples=1, engine=engine)
 
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda api, path: api.regression(n_samples=1),
+            lambda api, path: api.classification(n_samples=1),
+            lambda api, path: api.builder(n_samples=1),
+            lambda api, path: api.multi_source(n_samples=1),
+            lambda api, path: api.to_folder(path / "dataset", n_samples=1),
+            lambda api, path: api.to_csv(path / "dataset.csv", n_samples=1),
+            lambda api, path: api.product("dairy", n_samples=1),
+            lambda api, path: api.category("dairy", n_samples=1),
+            lambda api, path: api.from_template(np.zeros((1, 1)), n_samples=1),
+        ],
+        ids=[
+            "regression",
+            "classification",
+            "builder",
+            "multi_source",
+            "to_folder",
+            "to_csv",
+            "product",
+            "category",
+            "from_template",
+        ],
+    )
+    def test_generate_convenience_paths_refuse_native_default_before_work(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path,
+        call,
+    ) -> None:
+        """Every public generation entry point obeys the engine boundary."""
+        import nirs4all
+
+        monkeypatch.setenv("N4A_ENGINE", "native")
+        with pytest.raises(NotImplementedError, match="nirs4all.generate"):
+            call(nirs4all.generate, tmp_path)
+
     def test_generate_as_arrays(self):
         """Test generation returning arrays."""
         import nirs4all


### PR DESCRIPTION
## Résumé

Complète les garde-fous publics R2 : stacking OOF imbriqué, retrain native full, refus explicites generate, et transport strict des politiques de calibration conformale.

## Compatibilité

Aucun basculement du moteur par défaut ; le chemin legacy reste inchangé et le tag Python pur est conservé.

## Validation ciblée

- E2E stacking OOF
- tests API native retrain/conformal ciblés
- Ruff et `git diff --check`
