### PR TITLE
fix(release): repair native 0.12.9 transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.9] — 2026-08-27
+
+### Fixed
+
+- Require DAG-ML 0.3.18 so native stacking uses its attested nested-OOF
+  scheduler rather than an unsupported execution path.
+- Make the conformance-example subprocess reader explicitly UTF-8 on Windows,
+  and update the frozen retrain public signature for its native refit result.
+
+---
+
 ## [0.12.8] — 2026-08-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.12.8 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.9 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ If you use NIRS4ALL in your research, please cite:
   author = {Gregory Beurier and Denis Cornet and Lauriane Rouan},
   title = {NIRS4ALL: Open spectroscopy for everyone},
   url = {https://github.com/GBeurier/nirs4all},
-  version = {0.12.8},
+  version = {0.12.9},
   year = {2026},
 }
 ```

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.12.8 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.9 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -57,7 +57,7 @@ Synthetic Data Generation:
 See examples/ for more usage examples.
 """
 
-__version__ = "0.12.8"
+__version__ = "0.12.9"
 
 # Module-level API (primary interface) - Phase 2
 from .api import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.17",
+    "dag-ml>=0.3.18",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.17",
+    "dag-ml>=0.3.18",
     "dag-ml-data>=0.2.9",
     # Archive V3 replay is exposed by the Core Python facade starting in 0.3.22.
     "nirs4all-core[methods]>=0.3.22",

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.17
+dag-ml>=0.3.18
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.17
+dag-ml>=0.3.18
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.17
+dag-ml>=0.3.18
 dag-ml-data>=0.2.8

--- a/tests/integration/parity/test_conformance_examples_smoke.py
+++ b/tests/integration/parity/test_conformance_examples_smoke.py
@@ -82,6 +82,13 @@ def test_example_runs_on_engine(example: str, engine: str) -> None:
         env=env,
         capture_output=True,
         text=True,
+        # The child is explicitly UTF-8 (PYTHONIOENCODING above), but Windows
+        # otherwise decodes captured pipes with the runner's cp1252 locale.
+        # Keep the parent-side contract equally explicit so an informational
+        # non-ASCII byte cannot turn a successful example into a reader-thread
+        # failure before its real exit status is evaluated.
+        encoding="utf-8",
+        errors="replace",
         timeout=600,
     )
 

--- a/tests/regression/test_public_api_contract.py
+++ b/tests/regression/test_public_api_contract.py
@@ -90,7 +90,7 @@ EXPECTED_SIGNATURES: dict[str, str] = {
         "nirs4all.api.result.ExplainResult"
     ),
     "retrain": (
-        "(source: nirs4all.api.native_result.NativeMethodsRunResult | dict[str, typing.Any] | str | pathlib.Path, "
+        "(source: nirs4all.api.native_result.NativeMethodsRunResult | nirs4all.api.native_refit_result.NativeMethodsRefitResult | dict[str, typing.Any] | str | pathlib.Path, "
         "data: str | pathlib.Path | numpy.ndarray | tuple[numpy.ndarray, ...] | "
         "dict[str, typing.Any] | nirs4all.data.dataset.SpectroDataset | "
         "nirs4all.data.config.DatasetConfigs, *, mode: str = 'full', "


### PR DESCRIPTION
## Summary

- require published `dag-ml>=0.3.18` for the native nested-stacking scheduler
- make Windows conformance subprocess decoding explicitly UTF-8
- refresh the frozen public retrain signature for native refit results

## Validation

- DAG-ML 0.3.18 is published on PyPI; nirs4all CI is the single full verification gate for this release patch.
- `git diff --check` passes locally.