### PR TITLE
[codex] expose attested Methods HPO resume

### DIFF
--- a/nirs4all/api/native_result.py
+++ b/nirs4all/api/native_result.py
@@ -103,6 +103,33 @@ class NativeMethodsRunResult(RunResult):
             raise DagMLNativeCoverageError("native Methods HPO state is not a structured mapping")
         return dict(state)
 
+    def hpo_resume_package_json(self) -> str:
+        """Return the complete signed package required to resume native HPO.
+
+        The package — not a free checkpoint or a Python trial list — is the
+        portable resume carrier.  Passing its exact JSON back as
+        ``tuning={"engine": "methods-hpo", ..., "resume_package_json": ...}``
+        lets DAG-ML validate the checkpoint, terminal ledger, plan, fold set,
+        identities, influence and SELECT binding before it requests another
+        native trial.  Results without a Methods HPO state cannot be used as a
+        resume parent.
+        """
+
+        if self.native_methods_hpo_resume_state is None:
+            raise ValueError("native result has no Methods HPO resume state")
+        package = getattr(self._native_estimator, "predictor_package_", None)
+        serializer = getattr(package, "json", None)
+        if not callable(serializer):
+            raise DagMLNativeCoverageError(
+                "native Methods HPO result does not retain a strict portable package serializer"
+            )
+        package_json = serializer()
+        if not isinstance(package_json, str) or not package_json:
+            raise DagMLNativeCoverageError(
+                "native Methods HPO package serializer returned an invalid payload"
+            )
+        return package_json
+
     @property
     def native_selected_variant_id(self) -> str | None:
         """Return the scheduler-selected native variant identity, if any."""

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -177,9 +177,12 @@ def run_native_methods(
     ``tuning`` is deliberately a separate, strict native operation rather
     than the older Python objective adapter.  Its V1 shape is
     ``{"engine": "methods-hpo", "trials": N}``, optionally selecting the
-    attested ``random``/``tpe`` sampler and ``none``/``median`` pruner.  DAG-ML
-    owns all trial execution, SELECT, native incumbent attestation, and the
-    single selected rerun/refit.
+    attested ``random``/``tpe`` sampler and ``none``/``median`` pruner.  A
+    later call may add ``resume_package_json`` obtained from
+    :meth:`NativeMethodsRunResult.hpo_resume_package_json`; it is the complete
+    signed package, never a caller-provided checkpoint.  DAG-ML owns all trial
+    execution, resume validation, SELECT, native incumbent attestation, and
+    the single selected rerun/refit.
     """
 
     if not isinstance(dataset, Mapping):
@@ -513,7 +516,7 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
     if not isinstance(tuning, Mapping):
         raise TypeError("engine='native' tuning must be a mapping")
     payload = dict(tuning)
-    allowed = {"engine", "trials", "sampler", "pruner"}
+    allowed = {"engine", "trials", "sampler", "pruner", "resume_package_json"}
     unknown = set(payload) - allowed
     if unknown:
         raise ValueError(f"engine='native' tuning has unsupported keys: {sorted(unknown)}")
@@ -528,8 +531,15 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
         raise ValueError(f"engine='native' Methods HPO sampler is unsupported: {sampler!r}")
     if pruner not in _NATIVE_METHODS_HPO_PRUNERS:
         raise ValueError(f"engine='native' Methods HPO pruner is unsupported: {pruner!r}")
+    resume_package_json = payload.get("resume_package_json")
+    if resume_package_json is not None and (
+        not isinstance(resume_package_json, str) or not resume_package_json.strip()
+    ):
+        raise TypeError(
+            "engine='native' Methods HPO resume_package_json must be a non-empty portable package JSON string"
+        )
     n_startup_trials = 2 if sampler == "tpe" or pruner == "median" else 0
-    return {
+    operation = {
         "operation_id": "hpo:methods",
         "study": {
             "controller_id": "controller:methods.hpo",
@@ -561,6 +571,12 @@ def _native_methods_hpo_operation(tuning: Any, *, seed: int) -> dict[str, Any] |
         "trials": trials,
         "parameter_paths": {"n_components": "n_components"},
     }
+    if resume_package_json is not None:
+        # The complete package is the only resume carrier accepted by DAG-ML.
+        # It contains the opaque N4MOPT checkpoint together with the attested
+        # terminal ledger; Python never decodes, synthesizes, or merges either.
+        operation["resume_package_json"] = resume_package_json
+    return operation
 
 
 def _native_model_name(pipeline: list[Any]) -> str:

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -261,7 +261,12 @@ def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
 ) -> None:
     """The public HPO lane is scheduler metadata, never a Python objective."""
 
+    class Package:
+        def json(self) -> str:
+            return '{"schema_version":2,"package_id":"hpo-resume"}'
+
     class Estimator:
+        predictor_package_ = Package()
         training_outcome_ = {
             "outcome_fingerprint": "b" * 64,
             "selected_variant_id": "hpo:trial:0",
@@ -305,6 +310,7 @@ def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
     assert isinstance(result, NativeMethodsRunResult)
     assert result.native_selected_variant_id == "hpo:trial:0"
     assert result.native_methods_hpo_resume_state == {"schema_version": 1, "checkpoint": {"format": "N4MOPT"}}
+    assert result.hpo_resume_package_json() == '{"schema_version":2,"package_id":"hpo-resume"}'
     operation = observed["methods_hpo_operation"]
     assert operation == {
         "operation_id": "hpo:methods",
@@ -338,6 +344,51 @@ def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
         "trials": 3,
         "parameter_paths": {"n_components": "n_components"},
     }
+
+
+def test_native_methods_hpo_resume_only_forwards_a_complete_package() -> None:
+    """Python carries one signed package; DAG-ML owns all resume validation."""
+
+    from nirs4all.api.native_training import _native_methods_hpo_operation
+
+    package_json = '{"schema_version":2,"package_id":"resume"}'
+    operation = _native_methods_hpo_operation(
+        {
+            "engine": "methods-hpo",
+            "trials": 4,
+            "sampler": "tpe",
+            "pruner": "median",
+            "resume_package_json": package_json,
+        },
+        seed=51,
+    )
+
+    assert operation is not None
+    assert operation["resume_package_json"] == package_json
+    assert set(operation) == {
+        "operation_id",
+        "study",
+        "trials",
+        "parameter_paths",
+        "resume_package_json",
+    }
+
+
+@pytest.mark.parametrize("resume_package_json", ["", "  ", 42, {"checkpoint": "free"}])
+def test_native_methods_hpo_refuses_free_or_empty_resume_state(
+    resume_package_json: object,
+) -> None:
+    from nirs4all.api.native_training import _native_methods_hpo_operation
+
+    with pytest.raises(TypeError, match="resume_package_json"):
+        _native_methods_hpo_operation(
+            {
+                "engine": "methods-hpo",
+                "trials": 4,
+                "resume_package_json": resume_package_json,
+            },
+            seed=51,
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Expose a native HPO continuation only through the complete signed portable package produced by a `NativeMethodsRunResult`.

- add `hpo_resume_package_json()` to return the strict DAG-ML package;
- accept only a non-empty `resume_package_json` in the public `methods-hpo` tuning descriptor;
- forward the opaque JSON unchanged to DAG-ML, which remains sole owner of checkpoint, provenance, ledger, SELECT, and resumed-trial validation.

No free checkpoint, trial list, or Python-side state merging is accepted.

## Validation

- `pytest tests/unit/api/test_engine_transition.py -k native_methods_hpo` — 5 passed

A native stacking coverage probe was also run against DAG-ML 0.3.18. It correctly remains an explicit fallback boundary: the scheduler refuses its non-partitioned outer fold set, so no coverage ledger entry was promoted.
