### PR TITLE
[codex] preflight nonpartitioned native stacking

### DIFF
--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -253,7 +253,7 @@ should branch on it rather than inferring support from the broader legacy API.
 
 | Lifecycle operation | Native status | Exact boundary |
 | --- | --- | --- |
-| `run(..., engine="native")` | Supported subset | Explicit raw mapping `{"X", "y", "sample_ids"}`, portable Methods pipeline, native refit, and no legacy workspace/cache/project/result path. Unsupported shapes stop before a legacy run. |
+| `run(..., engine="native")` | Supported subset | Explicit raw mapping `{"X", "y", "sample_ids"}`, portable Methods pipeline, native refit, and no legacy workspace/cache/project/result path. Nested stacking requires a partitioned outer CV (for example `KFold`): repeated or overlapping validation such as `ShuffleSplit` is refused before execution because it cannot provide one outer-OOF row per sample. Unsupported shapes stop before a legacy run. |
 | `session(pipeline, engine="native")` | Supported subset | Returns `NativeMethodsSession`: native train, identity-bound prediction, Archive V2 export, close, and one selected full refit that returns a V3 child. It does not create a `PipelineRunner`. |
 | `predict(..., engine="native")` | Supported subset | Requires an explicitly identified cohort. It accepts an in-memory `NativeMethodsRunResult`, a trained `NativeMethodsSession`, a V3 refit result, or a validated Methods Archive V2/V3 session. In-memory results call the already-attested estimator directly; archive/session replay rehydrates N4MM for that invocation only. |
 | `load_session(path, engine="native")` | Supported, PREDICT-only | Validates Core Archive V2/Package V2 or Archive V3/Package V3 before data/model hydration, then returns `NativeArchiveSession`. It has no train, retrain, save, or legacy fallback capability. |

--- a/nirs4all/api/result.py
+++ b/nirs4all/api/result.py
@@ -495,7 +495,7 @@ def _lineage_by_feature(feature_lineage: Mapping[str, Any], feature: str | int) 
 # backend: a ``.joblib`` (or any UNRECOGNIZED extension, whose ``format_map.get(ext, 'joblib')`` default is
 # joblib). The non-joblib extensions (``.pkl``/``.pickle`` → cloudpickle, ``.h5``/``.hdf5`` → keras_h5,
 # ``.keras`` → tensorflow_keras, ``.pt``/``.pth`` → pytorch_state_dict) are the ones that MUST route through
-# the legacy ``to_bytes`` path instead of the joblib-only native helper.
+# the explicit legacy ``to_bytes`` compatibility path rather than the joblib-only native helper.
 _NON_JOBLIB_EXTENSIONS = frozenset({".pkl", ".pickle", ".h5", ".hdf5", ".keras", ".pt", ".pth"})
 _DAGML_LEGACY_REFIT_COMPATIBILITY = "legacy-refit"
 
@@ -507,8 +507,9 @@ def _request_is_joblib(output_path: str | Path, format: str | None) -> bool:
     (joblib only when it is the literal ``"joblib"``); with ``format=None`` the extension decides (a
     ``.joblib`` or any unrecognized extension defaults to joblib via ``format_map.get(ext, 'joblib')``, while
     the framework extensions in :data:`_NON_JOBLIB_EXTENSIONS` resolve to cloudpickle / keras / torch). Any
-    non-joblib request returns ``False`` so :meth:`RunResult._dagml_native_export_model` defers to the legacy
-    ``to_bytes`` path that actually produces the requested format (no silent joblib-under-foreign-extension).
+    non-joblib request returns ``False`` so :meth:`RunResult._dagml_native_export_model` declines it. The
+    public caller then refuses by default or invokes the named ``legacy-refit`` compatibility path; it never
+    silently writes joblib under a foreign extension.
     """
     if format is not None:
         return format == "joblib"
@@ -829,7 +830,7 @@ class RunResult:
     # ``artifacts/`` model tree. P3 Slice 2c-ii uses it for a NATIVE ``export_model``: a dag-ml run with
     # EXACTLY ONE concrete model artifact exports that captured (verify-then-load) estimator DIRECTLY — no
     # legacy refit, no stochastic warning. Multi-model / branch / stacking runs (≠1 artifact) and the .n4a
-    # ``export()`` still defer to the P1c legacy-refit bridge.
+    # ``export()`` refuse by default; ``legacy-refit`` remains a named transition path only.
     _dagml_results_dir: Path | None = field(default=None, repr=False)
 
     # Native full-DAG tuning evidence. This is populated by the tuning
@@ -1640,17 +1641,18 @@ class RunResult:
 
         try:
             artifacts = read_native_results(self._dagml_results_dir)["artifacts"]
-        except Exception as exc:  # noqa: BLE001 -- fallback contract: ANY native-read failure → legacy bridge
+        except Exception as exc:  # noqa: BLE001 -- native read is unavailable; public caller decides refusal/compatibility
             # A tampered/edited manifest (verify-then-load ValueError), a missing/malformed native dir
             # (FileNotFoundError/KeyError/parquet error), OR a fingerprint-valid but UNLOADABLE artifact
             # (EOFError/UnpicklingError/ModuleNotFoundError/ImportError/AttributeError from joblib.load —
-            # bytes that hash correctly but cannot be unpickled/imported in this environment) → fall back to
-            # the legacy bridge. The native fast-path is best-effort; the bridge is the guaranteed export.
+            # bytes that hash correctly but cannot be unpickled/imported in this environment) → this native
+            # fast path is unavailable. The public export method refuses unless its named compatibility opt-in
+            # asks for the legacy bridge.
             # The broad catch is SCOPED to the read+rehydrate only, so a real bug in the write below escapes.
-            logger.debug("native dag-ml export_model fell back to the legacy bridge: %s", exc)
+            logger.debug("native dag-ml export_model is unavailable: %s", exc)
             return None
         # EXACTLY ONE concrete artifact only (D4): a multi-model / branch / stacking run captures several
-        # REFIT artifacts and is NOT cleanly a single exportable model → defer to the legacy bridge.
+        # REFIT artifacts and is NOT cleanly a single exportable model → caller must refuse or opt in.
         if len(artifacts) != 1:
             return None
 

--- a/nirs4all/pipeline/dagml/run_paths.py
+++ b/nirs4all/pipeline/dagml/run_paths.py
@@ -22,7 +22,7 @@ from nirs4all.pipeline.dagml_bridge import controller_manifests
 
 from .cli_runner import assemble_constrained_cv_refit_dsl, assemble_cv_refit_dsl
 from .detect import _is_augmentation_step, _is_constrained_operator_generator, _is_rep_fusion_step, _is_unconstrained_operator_generator
-from .envelope import build_envelope
+from .envelope import build_envelope, build_fold_set
 from .errors import DagMlUnsupported, _raise_run_failure, _reject_multi_model
 from .folds import _build_folds, _build_group_folds, _repetition_grain, _repetition_refit_order, _split_pool
 from .identity import mint_identity
@@ -1853,6 +1853,23 @@ def _run_duplication_branch(pipeline: list[Any], branches: list[list[Any]], aggr
 _META_NODE_ID = "merge:stack"
 
 
+def _require_partitioned_outer_stacking(identity: Any, folds: list[tuple[list[int], list[int]]]) -> None:
+    """Reject nested stacking over repeated or incomplete validation folds.
+
+    A regular native CV campaign can aggregate repeated ``ShuffleSplit``
+    predictions per sample.  Nested stacking cannot: its meta learner needs
+    one unambiguous outer-OOF feature row per sample.  Refuse before graph
+    compilation or scheduler execution instead of relying on a later runtime
+    validation error (or, worse, changing the legacy repeated-row semantics).
+    """
+    fold_set = build_fold_set(identity, folds, set_id="folds.stacking.outer")
+    if fold_set.get("partition_mode") == "resampled":
+        raise DagMlUnsupported(
+            "native nested stacking requires an outer CV partition with exactly one validation prediction "
+            "per sample (for example KFold); ShuffleSplit and repeated CV are not portable yet"
+        )
+
+
 def _run_stacking_branch(pipeline: list[Any], branches: list[list[Any]], meta_learner: Any, spectro: Any, dataset_arg: str, cli: str, venv_python: str, run_dir: Path, metric: str, task_type: str, dataset_pickle: str | None = None, config_name: str = "", random_state: int | None = None) -> RunResult:
     """Run one scheduler-owned nested-OOF stacking campaign (ADR-26).
 
@@ -1874,6 +1891,7 @@ def _run_stacking_branch(pipeline: list[Any], branches: list[list[Any]], meta_le
     identity = mint_identity(spectro)
     pool = spectro.index_column("sample", {"partition": "train"})
     folds = _build_folds(splitter, spectro, pool, set())
+    _require_partitioned_outer_stacking(identity, folds)
     envelope = build_envelope(spectro, identity, sample_ints=pool)
     # K=2 is the narrowest non-degenerate nested policy.  It is serialized in
     # the DSL and constructed/attested by dag-ml, never delegated to sklearn.

--- a/tests/integration/parity/test_conformance_export_roundtrip.py
+++ b/tests/integration/parity/test_conformance_export_roundtrip.py
@@ -11,11 +11,11 @@ how ``RunResult.export_model`` actually behaves:
   ``y_pred`` EXACTLY (asserted within 1e-6; measured 0.0). The captured model
   embeds the preprocessing, so it predicts on RAW test X.
 
-* **Multi-model / branch dag-ml run** (branch + merge) — the dag-ml path falls
-  back to the legacy-refit bridge (≠1 captured artifact), and ``export_model``
-  produces a model via that bridge. The merged feature space means predict on
-  raw test X is not architecturally meaningful, so the contract here is the
-  weaker "still round-trips": ``export_model`` writes a loadable artifact.
+* **Feature-merge branch dag-ml run** — this shape has one downstream native
+  model after its branch-local transforms, so it exports directly when that one
+  artifact is captured. Multi-model / stacking shapes with ≠1 artifact are
+  covered separately: they refuse by default and require the deliberate
+  ``legacy-refit`` compatibility opt-in.
 
 The legacy engine's ``export_model`` returns the BARE estimator at the model
 step (no preprocessing wrapper), so its ``predict`` on raw X does not reproduce
@@ -148,7 +148,7 @@ def test_native_dagml_export_reproduces_final_test_pred(case_name: str, tmp_path
     if not result._is_dagml_engine():  # noqa: SLF001
         pytest.skip(f"{case_name}: dag-ml ran legacy fallback on this build; native export N/A")
     if len(result._dagml_refit_artifacts) != 1:  # noqa: SLF001
-        pytest.skip(f"{case_name}: not a single-artifact native run; covered by the bridge round-trip test")
+        pytest.skip(f"{case_name}: not a single-artifact native run; explicit-bridge coverage is separate")
 
     ids, x_test = _test_x(case.dataset_key)
     reloaded = H.round_trip_export_reload_predict(result, x_test, tmp_path / "model.joblib")
@@ -165,13 +165,12 @@ def test_native_dagml_export_reproduces_final_test_pred(case_name: str, tmp_path
     )
 
 
-def test_branch_merge_export_round_trips_via_bridge(tmp_path: Path) -> None:
-    """A branch/merge run (multi-model → legacy-refit bridge) still round-trips.
+def test_branch_feature_merge_export_uses_the_native_downstream_artifact(tmp_path: Path) -> None:
+    """A feature merge with one downstream model remains a direct native export.
 
-    The branch+merge shape falls back to the legacy engine (≠1 native artifact),
-    so ``export_model`` produces a model via the bridge. Its raw-X predict is not
-    meaningful (the model expects the merged feature space), so the contract is
-    that the export WRITES a loadable artifact on both engines.
+    This is not multi-model stacking: its branch transforms feed one native
+    downstream model. The DAG-ML result therefore has exactly one captured
+    artifact and must not be unnecessarily routed through the transition bridge.
     """
     case: PipelineCase = get(_BRANCH_MERGE)
     dataset = H.make_dataset(case)
@@ -184,7 +183,12 @@ def test_branch_merge_export_round_trips_via_bridge(tmp_path: Path) -> None:
             results_path=str(tmp_path / f"res_{engine}"),
         )
         out = tmp_path / f"model_{engine}.joblib"
-        path = result.export_model(out)
+        if engine == "dag-ml":
+            assert len(result._dagml_refit_artifacts) == 1  # noqa: SLF001
+            path = result.export_model(out)
+            assert result._dagml_legacy_result is None  # noqa: SLF001
+        else:
+            path = result.export_model(out)
         assert Path(path).exists(), f"{_BRANCH_MERGE} (engine={engine!r}): export_model wrote no file"
         loaded = joblib.load(path)
         assert hasattr(loaded, "predict"), (

--- a/tests/integration/parity/test_dagml_cli_runner.py
+++ b/tests/integration/parity/test_dagml_cli_runner.py
@@ -23,6 +23,7 @@ from sklearn.model_selection import KFold
 from nirs4all.data.config import DatasetConfigs
 from nirs4all.pipeline.dagml.cli_runner import assemble_cv_refit_dsl, run_cv_refit_bundle
 from nirs4all.pipeline.dagml.envelope import build_envelope
+from nirs4all.pipeline.dagml.errors import DagMlExportRefusal
 from nirs4all.pipeline.dagml.identity import mint_identity
 from nirs4all.pipeline.dagml.in_process_runner import in_process_enabled
 
@@ -4640,13 +4641,12 @@ def test_subprocess_error_classification_host_propagates_vs_falls_back_by_struct
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
 def test_dagml_result_export_roundtrip(tmp_path: Path) -> None:
-    """`.export()` / `.export_model()` on a dag-ml RunResult SUCCEED via the legacy-refit bridge (P1c).
+    """DAG-ML exports refuse by default and use the legacy bridge only when explicitly requested.
 
     The dag-ml backend returns native scores with NO workspace (no SQLite store / artifacts), so a `.n4a`
-    export has nothing of its own to bundle. P1c bridges this: `RunResult.export()` re-runs the SAME
-    pipeline through the LEGACY engine on demand (`save_artifacts=True` → a real workspace + chain +
-    artifacts), then delegates to the existing export path. So export now SUCCEEDS — it no longer raises
-    the pre-P1c catchable `NotImplementedError` (the fallback for an unsupported shape).
+    export has nothing of its own to bundle. It therefore fails closed until the caller explicitly requests
+    `compatibility="legacy-refit"`; that transitional path re-runs the frozen pipeline through the legacy
+    engine and delegates to the old export path.
 
     Round-trip: the exported `.n4a` loads and predicts finite values on held-out data, and the exported
     model is a real sklearn estimator. The two engines are at numerical parity (the dag-ml backend's
@@ -4660,13 +4660,23 @@ def test_dagml_result_export_roundtrip(tmp_path: Path) -> None:
         dataset_path("regression"),
         engine="dag-ml",
     )
-    # This must be a native dag-ml result (no silent legacy fallback) for the bridge to be exercised.
+    # This must be a native dag-ml result for the refusal and opt-in bridge to be exercised.
     assert [info.get("engine") for info in result.per_dataset.values()] == ["dag-ml"]
 
-    bundle = result.export(tmp_path / "model.n4a")
+    bundle_path = tmp_path / "model.n4a"
+    with pytest.raises(DagMlExportRefusal, match="legacy .n4a writer"):
+        result.export(bundle_path)
+    assert not bundle_path.exists()
+
+    bundle = result.export(bundle_path, compatibility="legacy-refit")
     assert bundle.exists() and bundle.stat().st_size > 0
 
-    model_path = result.export_model(tmp_path / "model.joblib")
+    model_path = tmp_path / "model.joblib"
+    with pytest.raises(DagMlExportRefusal, match="single replayable native model"):
+        result.export_model(model_path)
+    assert not model_path.exists()
+
+    model_path = result.export_model(model_path, compatibility="legacy-refit")
     import joblib
 
     assert model_path.exists() and isinstance(joblib.load(model_path), PLSRegression)

--- a/tests/integration/parity/test_dagml_native_export_model.py
+++ b/tests/integration/parity/test_dagml_native_export_model.py
@@ -11,13 +11,12 @@ for the single-model case:
   warning (the P1c bridge warned).
 * (2) a ``y_processing`` variant → the inverse ``y_transform`` is applied (exported predict is in the
   original target space).
-* (3) export_model on a dag-ml run WITHOUT a native results dir → still uses the legacy bridge
-  (unchanged behavior).
-* (4) a branch (duplication) run WITH a native dir → falls back to the bridge (≠1 captured artifact).
+* (3) export_model on a dag-ml run WITHOUT a native results dir refuses by default; the legacy bridge is
+  available only through the explicit ``compatibility="legacy-refit"`` transition switch.
+* (4) a branch (duplication) run WITH a native dir similarly refuses by default (≠1 captured artifact).
 * (5) MUST-FIX 1 — a native dir whose artifact bytes are present + fingerprint-VALID but UNLOADABLE (the
-  payload fails to unpickle) → export_model falls back to the bridge (returns a valid model, no crash).
-* (6) MUST-FIX 2 — export_model(..., format=<non-joblib>) on a native single-artifact run uses the legacy
-  bridge (which honors the requested format), NOT a silent joblib write under a foreign format.
+  payload fails to unpickle) must not cause an implicit legacy refit.
+* (6) MUST-FIX 2 — a non-joblib request must not silently write a joblib wrapper under a foreign format.
 """
 
 from __future__ import annotations
@@ -37,6 +36,7 @@ from sklearn.preprocessing import MinMaxScaler
 from nirs4all.api.result import _DagmlExportedModel
 from nirs4all.data.config import DatasetConfigs
 from nirs4all.operators.transforms.scalers import StandardNormalVariate as SNV
+from nirs4all.pipeline.dagml.errors import DagMlExportRefusal
 from nirs4all.pipeline.dagml.native_results import _bytes_fingerprint
 from nirs4all.pipeline.dagml.run_backend import run_via_dagml
 
@@ -147,14 +147,13 @@ def test_native_export_model_applies_y_inverse(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# (3) NO native dir → legacy bridge (unchanged behavior).
+# (3) NO native dir → refusal by default; bridge only with explicit compatibility.
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
-def test_no_native_dir_uses_legacy_bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """export_model on a dag-ml run WITHOUT a native results dir falls back to the P1c legacy-refit bridge
-    (it materializes a legacy result + warns on the unseeded run) — the native path is skipped."""
+def test_no_native_dir_requires_explicit_legacy_bridge(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No captured native artifact refuses first; the former bridge is a visible opt-in only."""
     monkeypatch.delenv("N4A_NATIVE_RESULTS", raising=False)
     pipeline = [SNV(), KFold(n_splits=_N_SPLITS, shuffle=True, random_state=42), {"model": PLSRegression(n_components=5)}]
     result = run_via_dagml(
@@ -165,23 +164,28 @@ def test_no_native_dir_uses_legacy_bridge(tmp_path: Path, monkeypatch: pytest.Mo
     assert result._dagml_results_dir is None  # noqa: SLF001 -- no native dir was written
 
     out = tmp_path / "model_bridge.joblib"
-    with pytest.warns(UserWarning, match="nondeterministic"):
+    with pytest.raises(DagMlExportRefusal, match="no single replayable native model artifact"):
         result.export_model(out)
+    assert not out.exists()
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+    with pytest.warns(UserWarning, match="nondeterministic"):
+        result.export_model(out, compatibility="legacy-refit")
     assert out.exists()
-    # The legacy bridge WAS materialized (the fallback path ran), proving the native path was skipped.
+    # The bridge was materialized only after its explicit compatibility request.
     assert result._dagml_legacy_result is not None  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
-# (4) branch run WITH native dir → falls back to the bridge (≠1 captured artifact).
+# (4) branch run WITH native dir → refusal by default (≠1 captured artifact).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
-def test_branch_run_falls_back_to_bridge(tmp_path: Path) -> None:
+def test_branch_run_requires_explicit_legacy_bridge(tmp_path: Path) -> None:
     """A duplication-branch + merge-predictions (stacking) run captures MULTIPLE REFIT artifacts (≠1), so
-    even WITH a native dir the native single-artifact export is NOT applicable → it defers to the legacy
-    bridge (Codex D4: multi-model / branch / stacking defer to the bridge)."""
+    even WITH a native dir the native single-artifact export is NOT applicable → it refuses unless the
+    caller deliberately requests the transitional legacy bridge."""
     from sklearn.linear_model import Ridge
 
     from nirs4all.operators.transforms import MultiplicativeScatterCorrection as MSC
@@ -209,16 +213,19 @@ def test_branch_run_falls_back_to_bridge(tmp_path: Path) -> None:
     assert result._dagml_results_dir is not None  # noqa: SLF001 -- a native dir WAS written
     assert len(result._dagml_refit_artifacts) != 1, "a branch/stacking run captures ≠1 REFIT artifact"  # noqa: SLF001
 
-    # The native single-artifact export is not applicable (≠1 artifact) → it returns None and the export
-    # falls back to the legacy bridge (which materializes a legacy result).
     out = tmp_path / "model_branch.joblib"
-    result.export_model(out)
+    with pytest.raises(DagMlExportRefusal, match="no single replayable native model artifact"):
+        result.export_model(out)
+    assert not out.exists()
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+    result.export_model(out, compatibility="legacy-refit")
     assert out.exists()
-    assert result._dagml_legacy_result is not None, "≠1 artifact → the legacy bridge backs the export"  # noqa: SLF001
+    assert result._dagml_legacy_result is not None, "the explicit bridge backs the transitional export"  # noqa: SLF001
 
 
 # ---------------------------------------------------------------------------
-# (5) MUST-FIX 1 — fingerprint-VALID but UNLOADABLE artifact → fall back to the bridge.
+# (5) MUST-FIX 1 — fingerprint-VALID but UNLOADABLE artifact → refusal by default.
 # ---------------------------------------------------------------------------
 
 
@@ -242,10 +249,10 @@ class _UnloadablePayload:
 
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
-def test_unloadable_artifact_falls_back_to_bridge(tmp_path: Path) -> None:
+def test_unloadable_artifact_requires_explicit_legacy_bridge(tmp_path: Path) -> None:
     """MUST-FIX 1: a native dir whose artifact bytes are present + fingerprint-VALID but UNLOADABLE (the
-    payload raises on unpickle) → export_model falls back to the legacy bridge and returns a valid model,
-    no crash. The broad except around the native read makes this a fallback, not an escaped exception."""
+    payload raises on unpickle) → the default export rejects it without an implicit legacy refit. The
+    transitional bridge remains explicit and returns a valid model."""
     results_root = tmp_path / "results"
     pipeline = [SNV(), KFold(n_splits=_N_SPLITS, shuffle=True, random_state=42), {"model": PLSRegression(n_components=5)}]
     result = run_via_dagml(
@@ -275,26 +282,27 @@ def test_unloadable_artifact_falls_back_to_bridge(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="simulated unloadable artifact"):
         read_native_results(run_dir)
 
-    # export_model must NOT crash: the broad catch falls back to the legacy bridge, which materializes a
-    # legacy result and writes a loadable model.
     out = tmp_path / "model_unloadable.joblib"
-    result.export_model(out)
+    with pytest.raises(DagMlExportRefusal, match="no single replayable native model artifact"):
+        result.export_model(out)
+    assert not out.exists()
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+    result.export_model(out, compatibility="legacy-refit")
     assert out.exists()
-    assert result._dagml_legacy_result is not None, "an unloadable native artifact → the legacy bridge backs the export"  # noqa: SLF001
+    assert result._dagml_legacy_result is not None, "the explicit bridge backs the transitional export"  # noqa: SLF001
     loaded = joblib.load(out)
     assert hasattr(loaded, "predict"), "the bridge produced a predict-capable model despite the native-read failure"
 
 
 # ---------------------------------------------------------------------------
-# (6) MUST-FIX 2 — a non-joblib requested format routes through the legacy bridge (not a silent joblib write).
+# (6) MUST-FIX 2 — non-joblib requests require an explicit bridge (never a silent joblib write).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(not _DAGML_CLI.exists(), reason=f"dag-ml-cli binary not built at {_DAGML_CLI}")
-def test_non_joblib_format_uses_legacy_bridge(tmp_path: Path) -> None:
-    """MUST-FIX 2: export_model(format="cloudpickle") on a native single-artifact run does NOT take the
-    joblib-only native path — it falls back to the legacy bridge (which honors the requested format), so the
-    output is the bridge's legacy model (NOT the native _DagmlExportedModel wrapper written as joblib)."""
+def test_non_joblib_format_requires_explicit_legacy_bridge(tmp_path: Path) -> None:
+    """A foreign format cannot silently trigger a legacy refit or a disguised joblib export."""
     results_root = tmp_path / "results"
     pipeline = [SNV(), KFold(n_splits=_N_SPLITS, shuffle=True, random_state=42), {"model": PLSRegression(n_components=5)}]
     result = run_via_dagml(
@@ -306,12 +314,15 @@ def test_non_joblib_format_uses_legacy_bridge(tmp_path: Path) -> None:
     assert result._dagml_results_dir is not None and len(result._dagml_refit_artifacts) == 1  # noqa: SLF001
 
     out = tmp_path / "model_cloudpickle.pkl"
-    result.export_model(out, format="cloudpickle")
+    with pytest.raises(DagMlExportRefusal, match="no single replayable native model artifact"):
+        result.export_model(out, format="cloudpickle")
+    assert not out.exists()
+    assert result._dagml_legacy_result is None  # noqa: SLF001
+
+    result.export_model(out, format="cloudpickle", compatibility="legacy-refit")
     assert out.exists()
-    # The native path was SKIPPED (non-joblib request) → the legacy bridge was materialized.
-    assert result._dagml_legacy_result is not None, "a non-joblib format → the legacy bridge backs the export"  # noqa: SLF001
-    # The export is the bridge's legacy model, NOT the native wrapper — proving no silent joblib-as-wrapper
-    # write happened under the non-joblib request.
+    assert result._dagml_legacy_result is not None, "the explicit bridge backs the non-joblib export"  # noqa: SLF001
+    # The export is the transitional bridge's model, not the native wrapper.
     loaded = joblib.load(out)  # cloudpickle bytes load fine via joblib/pickle; the TYPE is what matters
     assert not isinstance(loaded, _DagmlExportedModel), "a non-joblib request must not write the native wrapper"
     assert hasattr(loaded, "predict")

--- a/tests/unit/pipeline/dagml/test_stacking_contract.py
+++ b/tests/unit/pipeline/dagml/test_stacking_contract.py
@@ -1,0 +1,43 @@
+"""Native nested-stacking admission tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from nirs4all.pipeline.dagml.errors import DagMlUnsupported
+from nirs4all.pipeline.dagml.identity import IdentityMap, SampleIdentity
+from nirs4all.pipeline.dagml.run_paths import _require_partitioned_outer_stacking
+
+
+def _identity(sample_count: int = 4) -> IdentityMap:
+    identities = tuple(
+        SampleIdentity(
+            sample_int=index,
+            origin_int=index,
+            observation_id=f"fixture.s{index}",
+            sample_id=f"fixture.s{index}",
+            augmented=False,
+        )
+        for index in range(sample_count)
+    )
+    return IdentityMap(
+        fingerprint="fixture",
+        identities=identities,
+        _to_int={identity.observation_id: identity.sample_int for identity in identities},
+        _to_wire={identity.sample_int: identity.observation_id for identity in identities},
+    )
+
+
+def test_nested_stacking_accepts_partitioned_outer_folds() -> None:
+    _require_partitioned_outer_stacking(
+        _identity(),
+        [([2, 3], [0, 1]), ([0, 1], [2, 3])],
+    )
+
+
+def test_nested_stacking_refuses_resampled_outer_folds_before_execution() -> None:
+    with pytest.raises(DagMlUnsupported, match="requires an outer CV partition"):
+        _require_partitioned_outer_stacking(
+            _identity(),
+            [([2, 3], [0, 1]), ([0, 3], [1, 2])],
+        )


### PR DESCRIPTION
## Summary

- refuse nested native stacking over resampled outer folds before compilation or scheduler execution
- document the KFold/OOF requirement in the public native capability matrix
- enforce and regression-test the export boundary: native artifact export when exactly one artifact exists; otherwise a typed refusal, with `compatibility="legacy-refit"` as the only transition switch

## Validation

- `ruff check nirs4all/api/result.py nirs4all/pipeline/dagml/run_paths.py tests/unit/pipeline/dagml/test_stacking_contract.py tests/integration/parity/test_dagml_native_export_model.py tests/integration/parity/test_dagml_cli_runner.py tests/integration/parity/test_conformance_export_roundtrip.py`
- `pytest -q tests/unit/pipeline/dagml/test_stacking_contract.py tests/integration/parity/test_dagml_native_export_model.py tests/integration/parity/test_dagml_cli_runner.py -k "dagml_result_export_roundtrip or stacking_contract or native_export_model"` (9 passed)
- `pytest -q tests/integration/parity/test_conformance_export_roundtrip.py::test_branch_feature_merge_export_uses_the_native_downstream_artifact` (1 passed)
- `pytest -q tests/unit/api/test_native_session.py tests/unit/api/test_native_archive_session.py tests/unit/api/test_native_result.py` (29 passed)
- `git diff --check`