### PR TITLE
chore(release): prepare 0.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.12.10] — 2026-08-27
+
+### Fixed
+
+- Persist the attested native Methods HPO checkpoint and trial evidence so a
+  resume request is validated and restored by DAG-ML rather than reconstructed
+  from free-form Python fields.
+- Preflight native nested stacking against its partitioned-outer-fold contract;
+  resampled outer CV remains on the explicit compatibility boundary instead of
+  failing after native execution begins.
+- Make the native export boundary strict: legacy refit is available only through
+  the explicit compatibility option and is never a silent export fallback.
+
+---
+
 ## [0.12.9] — 2026-08-27
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # nirs4all — Python NIRS Analysis Library
 
-**Version**: 0.12.9 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
+**Version**: 0.12.10 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; GPL-3.0/CeCILL-2.1 variants + commercial — see LICENSE)
 
 Since **0.9.0** the public API (`run/predict/explain/retrain/session/generate`), result objects (`RunResult/PredictResult/ExplainResult`), workspace SQLite/Parquet schemas, run manifest layout, and `.n4a` bundle format are **stable contracts** within the 0.9.x line (used by the nirs4all webapp). Avoid breaking those signatures or on-disk schemas without a major bump.
 

--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ If you use NIRS4ALL in your research, please cite:
   author = {Gregory Beurier and Denis Cornet and Lauriane Rouan},
   title = {NIRS4ALL: Open spectroscopy for everyone},
   url = {https://github.com/GBeurier/nirs4all},
-  version = {0.12.9},
+  version = {0.12.10},
   year = {2026},
 }
 ```

--- a/docs/source/ai_onboarding.md
+++ b/docs/source/ai_onboarding.md
@@ -15,7 +15,7 @@ This guide is intentionally narrow. It covers:
 
 It does **not** cover SHAP, synthetic data generation, retraining, session internals, or architecture.
 
-**Version**: 0.12.9 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
+**Version**: 0.12.10 | **Python**: 3.11+ | **License**: AGPL-3.0-or-later (dual; see LICENSE)
 
 ---
 

--- a/nirs4all/__init__.py
+++ b/nirs4all/__init__.py
@@ -57,7 +57,7 @@ Synthetic Data Generation:
 See examples/ for more usage examples.
 """
 
-__version__ = "0.12.9"
+__version__ = "0.12.10"
 
 # Module-level API (primary interface) - Phase 2
 from .api import (


### PR DESCRIPTION
Corrective release after the cancelled 0.12.9 publication.

Includes only version metadata and changelog entries for the already-merged native HPO resume and strict stacking/export boundaries.

Validation:
- `python3.11 scripts/check_doc_metadata.py`
- `git diff --check`