### PR TITLE
feat(engine): make native the default lane

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,7 +16,7 @@ The same YAML/JSON contract is the stable user surface across Python and languag
 | R | Portable wrapper pattern | Yes | Through `reticulate` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | Julia | Portable wrapper pattern | Yes | Through `PythonCall` or a binding wrapper | Calls the Python runtime today | Calls the Python runtime today | {doc}`getting_started/hello_world` |
 | JavaScript/TypeScript | Portable process/runtime wrapper pattern | Yes | No native JS API in this repo | Calls a Python/runtime process today | Calls a Python/runtime process today | {doc}`getting_started/hello_world` |
-| dag-ml runtime | Selectable from Python | Yes, for covered shapes | No Python object construction | `engine="dag-ml"` strict by default; legacy rollback is explicit-only | Native result artifacts export directly when supported; legacy refit is explicit-only | {doc}`reference/public_interfaces` |
+| native Methods runtime | Default from Python | Yes, for its covered portable shapes | No Python object construction | Unsupported shapes refuse before legacy; `engine="legacy"` is explicit-only | Native result artifacts export directly when supported; legacy refit is explicit-only | {doc}`reference/public_interfaces` |
 
 :::{note}
 The language-independent contract is the pair of config files. Native R, Julia, or JavaScript package APIs can wrap that contract without changing user pipelines.

--- a/docs/source/reference/api/session.md
+++ b/docs/source/reference/api/session.md
@@ -89,7 +89,9 @@ nirs4all.load_session(
 
 **Parameters:**
 - `path` (str|Path): Path to the `.n4a` bundle file to load
-- `engine`: `"legacy"` (default) preserves the existing `BundleLoader` session.
+- `engine`: `"native"` is the default and opens a validated portable archive
+  session for supported Methods artifacts. `"legacy"` explicitly preserves the
+  existing `BundleLoader` rollback session.
   `"native"` opens a fail-closed Core Archive V2/V3 Methods PREDICT session and
   accepts no legacy fallback. Opening a native session validates the Core
   container and DAG-ML Package V2 or V3 before prediction data or an N4MM runtime is

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -262,10 +262,9 @@ should branch on it rather than inferring support from the broader legacy API.
 | `explain(..., engine="native")` | Refused | SHAP is a host plugin today. A native result or session is rejected at preflight even when no engine argument is supplied; it is never rerouted to legacy implicitly. |
 | `generate(..., engine="native")` | Refused | Synthetic-data generation has no native Methods implementation. The explicit engine is rejected before a builder or dataset is constructed. |
 
-The default remains unchanged during R2: it is not evidence that every legacy
-operation is native. Select the native lane explicitly when qualification is
-required, and use the typed refusal as the integration signal for an
-unsupported capability.
+Native is the R2 default.  The capability table remains authoritative: an
+unsupported operation emits its typed refusal before legacy orchestration.
+Use ``engine="legacy"`` only for an explicit rollback or diagnostic run.
 
 ## CLI Commands
 

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -694,15 +694,13 @@ def run(
             Affects column headers in final summary tables. Internal variable names
             use ML conventions regardless of this setting.
 
-        engine: Execution backend selector. ``None`` (default) resolves to ``"legacy"``: the
-            public-maintained nirs4all stays pure-Python by default and runs on the in-process
-            orchestrator (interim posture until the planned global refactoring lands). ``"dag-ml"``
-            runs the pipeline natively on the dag-ml backend (Rust, in-process by default) and fails
-            closed when a pipeline shape is not yet covered or the dag-ml backend is not installed.
-            Set ``allow_legacy_fallback=True`` for the sole warning-bearing rollback path. ``"dual"`` is a strict,
-            no-fallback oracle for the small explicit-array/KFold/PLSRegression subset; it raises a
-            typed error for every other shape or unavailable native capability. Override the default
-            per-process with ``$N4A_ENGINE`` (e.g. ``$N4A_ENGINE=dag-ml``).
+        engine: Execution backend selector. ``None`` (default) resolves to ``"native"``.  The
+            portable Methods lane runs covered shapes natively and rejects every other shape before
+            legacy orchestration or data consumption.  ``"legacy"`` is the explicit rollback path.
+            ``"dag-ml"`` remains the broader Rust transition path and may use its separately
+            explicit ``allow_legacy_fallback=True`` diagnostic option. ``"dual"`` is a strict,
+            no-fallback oracle for the documented explicit-array/KFold/PLSRegression subset.
+            Override the default per-process with ``$N4A_ENGINE``.
         allow_legacy_fallback: Explicit rollback policy for ``engine="dag-ml"``.
             ``None`` and ``False`` refuse unavailable or unsupported DAG-ML
             requests before the legacy engine is constructed. ``True`` is the
@@ -1205,13 +1203,10 @@ def run(
             legacy_result._dual_run_report = report
         return legacy_result
 
-    # ADR-17 backend selector (nirs4all-core -> dag-ml migration). The DEFAULT engine is LEGACY again
-    # (interim posture: the public-maintained nirs4all stays pure-Python by default until the planned
-    # global refactoring; the legacy-DROP cutover flips it back to dag-ml). dag-ml stays FULLY SELECTABLE
-    # via `engine="dag-ml"` / `$N4A_ENGINE=dag-ml`: it dispatches to the dag-ml backend, which runs the
-    # pipeline natively (Rust, IN-PROCESS by default via the PyO3 extension) and returns a RunResult of
-    # dag-ml's native scores. A plain `run()` (the legacy default) runs the in-process legacy orchestrator
-    # (`_run_legacy`).
+    # R2 backend selector.  The default is the verified native Methods lane;
+    # unsupported shapes are rejected before any legacy runner is built.
+    # ``engine="dag-ml"`` remains an explicit broader transition path and
+    # ``engine="legacy"`` remains the explicit rollback/diagnostic path.
     #
     # EXPLICIT LEGACY ROLLBACK.  A native request fails closed through the two
     # catchable capability signals below.  Only a caller that passes

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -1,29 +1,17 @@
-"""Execution-engine selector for the nirs4all core (interim legacy-default posture).
+"""Execution-engine selector for the R2 native-default boundary.
 
-Seam for the **nirs4all-core → dag-ml** migration. The default production engine is **legacy**: the
-public-maintained nirs4all stays pure-Python by default, so :func:`nirs4all.run` runs through the
-in-process *legacy* orchestrator (:class:`~nirs4all.pipeline.PipelineRunner`) unless another engine is
-selected. The dag-ml backend (:mod:`nirs4all.pipeline.dagml.run_backend`) — which runs the pipeline
-natively (Rust) and returns a ``RunResult`` of dag-ml's native scores — stays
-**fully selectable** via
-``engine="dag-ml"`` or ``$N4A_ENGINE=dag-ml``; the whole dag-ml integration (in-process path, native
-generator coverage, conformance pack, hard dependency) is intact and runnable out of the box.
+The ordinary public call now selects the verified native Methods lane.  A
+shape outside that portable capability fails before legacy orchestration or
+data consumption.  ``engine="legacy"`` remains an explicit, user-visible
+rollback and diagnostic path; it is never chosen implicitly.
 
-An unavailable or unsupported dag-ml request is fail-closed by default.  A
-legacy rerun is an explicit R2 rollback action through
-``run(..., engine="dag-ml", allow_legacy_fallback=True)``; it is never an
-implicit substitute for a claimed native execution.
+``engine="dag-ml"`` retains its broader transition integration and its
+separately explicit ``allow_legacy_fallback=True`` diagnostic option.  The
+side-by-side ``"dual"`` oracle remains limited to its documented
+:func:`nirs4all.run` subset.
 
-This is the interim posture: the maintainer keeps the public Python version as the default until the
-planned global refactoring lands; at that point the legacy-DROP cutover flips the default back to
-dag-ml (the ADR-17 end state). The side-by-side comparison mode (``"dual"``) is intentionally
-limited to the strict :func:`nirs4all.run` oracle subset; other public operations reject it.
-
-Selection precedence: explicit argument > ``$N4A_ENGINE`` env var > :data:`DEFAULT_ENGINE`
-(``legacy``, interim). Pass ``engine="dag-ml"`` (or ``$N4A_ENGINE=dag-ml``) to run on the dag-ml
-    backend. ``engine="native"`` separately exposes the verified, fail-closed
-    Methods subset: raw-array PLS run/session/predict and Archive V2 replay.
-    See ``dag-ml/docs/migration-nirs4all/``.
+Selection precedence is explicit argument > ``$N4A_ENGINE`` >
+:data:`DEFAULT_ENGINE` (``native``).
 """
 
 from __future__ import annotations
@@ -36,7 +24,7 @@ from typing import Any, Literal, cast
 
 Engine = Literal["legacy", "dag-ml", "dual", "native"]
 
-DEFAULT_ENGINE: Engine = "legacy"
+DEFAULT_ENGINE: Engine = "native"
 ENGINE_ENV_VAR = "N4A_ENGINE"
 ENGINES: tuple[Engine, ...] = ("legacy", "dag-ml", "dual", "native")
 
@@ -131,19 +119,18 @@ class DualRunMismatchError(RuntimeError):
 
 
 def resolve_engine(engine: str | None = None) -> Engine:
-    """Resolve the requested execution engine, defaulting to ``legacy`` (interim, pre-refactoring).
+    """Resolve the requested execution engine, defaulting to ``native``.
 
-    The default is the pure-Python ``legacy`` orchestrator: the public-maintained nirs4all stays
-    pure-Python by default until the planned global refactoring lands (then the legacy-DROP cutover
-    flips the default back to ``dag-ml``). The dag-ml backend stays fully selectable here via
-    ``engine="dag-ml"`` or ``$N4A_ENGINE=dag-ml``.
+    Native is intentionally fail-closed: unsupported public operations must
+    report their capability boundary, rather than instantiate the legacy
+    runner.  ``legacy`` stays available only when requested explicitly.
 
     Args:
         engine: Explicit engine name. When ``None``, falls back to the
             ``$N4A_ENGINE`` environment variable, then :data:`DEFAULT_ENGINE`.
 
     Returns:
-        The validated engine name. ``"legacy"`` (the default), ``"dag-ml"`` and the narrow
+        The validated engine name. ``"native"`` (the default), ``"legacy"``, ``"dag-ml"`` and the narrow
         ``"dual"`` oracle mode are dispatched by :func:`nirs4all.run`. ``"native"`` is a
         fail-closed Methods subset for raw-array training, sessions, prediction, and Archive V2
         replay; unsupported operations refuse it before execution.

--- a/nirs4all/pipeline/engine.py
+++ b/nirs4all/pipeline/engine.py
@@ -154,12 +154,12 @@ def require_legacy_engine(operation: str, engine: str | None = None) -> Engine:
             raise NotImplementedError(
                 f"nirs4all.{operation} does not have a dag-ml execution path yet; it does not "
                 "have an execution path under dag-ml. Use "
-                "engine='legacy' for this transition release. nirs4all.run supports "
+                "engine='legacy' only as the explicit rollback path. nirs4all.run supports "
                 "engine='dag-ml' with documented fallback boundaries."
             )
         raise NotImplementedError(
-            f"nirs4all.{operation} does not have an execution path for engine='{selected}' yet; use "
-            "engine='legacy' for this transition release. nirs4all.run supports "
+            f"nirs4all.{operation} does not have an execution path for engine='{selected}' yet; "
+            "use engine='legacy' only as the explicit rollback path. nirs4all.run supports "
             "engine='dag-ml' with documented fallback boundaries."
         )
     return selected

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,13 @@ from typing import cast
 _TEST_WORKSPACE_DIR = tempfile.mkdtemp(prefix="nirs4all_test_")
 os.environ["NIRS4ALL_WORKSPACE"] = _TEST_WORKSPACE_DIR
 
+# Most of the historical suite is a regression oracle for the retained
+# pure-Python implementation.  Select that rollback lane deliberately rather
+# than relying on the product default; native-default tests delete this value
+# before asserting the public boundary.
+_PRE_TEST_N4A_ENGINE = os.environ.get("N4A_ENGINE")
+os.environ["N4A_ENGINE"] = "legacy"
+
 # Now safe to import other modules
 from pathlib import Path
 
@@ -67,6 +74,10 @@ def pytest_unconfigure(config):
             pass  # Best effort cleanup
     if "NIRS4ALL_WORKSPACE" in os.environ:
         del os.environ["NIRS4ALL_WORKSPACE"]
+    if _PRE_TEST_N4A_ENGINE is None:
+        os.environ.pop("N4A_ENGINE", None)
+    else:
+        os.environ["N4A_ENGINE"] = _PRE_TEST_N4A_ENGINE
 
 # =============================================================================
 # Lazy imports for synthetic module (avoid import errors if module missing)
@@ -672,4 +683,3 @@ def csv_all_variations(tmp_path, base_synthetic_data, csv_variation_generator) -
             random_state=42,
         ),
     )
-

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -50,7 +50,8 @@ if "torch" in globals():
             return self.linear(features)
 
 
-def test_resolve_engine_default_is_native() -> None:
+def test_resolve_engine_default_is_native(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("N4A_ENGINE", raising=False)
     assert resolve_engine(None) == "native"
     assert resolve_engine("dag-ml") == "dag-ml"
     assert resolve_engine("legacy") == "legacy"

--- a/tests/integration/parity/test_dagml_run_selector.py
+++ b/tests/integration/parity/test_dagml_run_selector.py
@@ -1,8 +1,7 @@
 """The engine selector is wired into the public run() entry point.
 
-These assert the public API resolves the engine before execution — the DEFAULT engine is legacy
-(interim, pre-refactoring), while dag-ml stays fully selectable via
-``engine="dag-ml"`` / ``$N4A_ENGINE=dag-ml``. An unknown engine is rejected.
+These assert the public API resolves the engine before execution — the DEFAULT engine is native,
+while dag-ml stays selectable via ``engine="dag-ml"`` / ``$N4A_ENGINE=dag-ml``. An unknown engine is rejected.
 Native capability refusals are fail-closed unless callers explicitly request
 ``allow_legacy_fallback=True``; that opt-in emits a warning and re-runs on
 legacy. A genuine dag-ml bug still propagates untouched.
@@ -51,9 +50,8 @@ if "torch" in globals():
             return self.linear(features)
 
 
-def test_resolve_engine_default_is_legacy() -> None:
-    # default is legacy (interim, pre-refactoring). dag-ml stays fully selectable via engine="dag-ml".
-    assert resolve_engine(None) == "legacy"
+def test_resolve_engine_default_is_native() -> None:
+    assert resolve_engine(None) == "native"
     assert resolve_engine("dag-ml") == "dag-ml"
     assert resolve_engine("legacy") == "legacy"
 
@@ -163,8 +161,8 @@ def test_fail_closed_dagml_refusal_does_not_increment_fallback_counter(monkeypat
 def test_dagml_run_uses_in_process(monkeypatch: pytest.MonkeyPatch) -> None:
     """An explicit ``engine="dag-ml"`` run() routes to the dag-ml backend, in-process by default
     (unset N4A_DAGML_INPROCESS). Asserted by capturing the dag-ml dispatch + the in-process selection,
-    so no real campaign/CLI is needed. (dag-ml is selected explicitly: the production DEFAULT is now
-    legacy — interim, pre-refactoring — so a plain run() would route to legacy instead.)"""
+    so no real campaign/CLI is needed. Dag-ml is selected explicitly because
+    the production default is the narrower Methods-native lane."""
     import nirs4all.pipeline.dagml.run_backend as run_backend
     from nirs4all.data.predictions import Predictions
     from nirs4all.pipeline.dagml.in_process_runner import in_process_enabled

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -36,6 +36,9 @@ def test_run_native_executes_the_methods_subset_without_constructing_a_legacy_ru
 ) -> None:
     """The default and explicit native lanes never construct ``PipelineRunner``."""
 
+    if engine is None:
+        monkeypatch.delenv("N4A_ENGINE", raising=False)
+
     def legacy_runner(*_args, **_kwargs):  # noqa: ANN002, ANN003
         raise AssertionError("run(engine='native') constructed a legacy PipelineRunner")
 

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -29,10 +29,12 @@ def test_require_legacy_engine_accepts_legacy() -> None:
     assert require_legacy_engine("predict", "legacy") == "legacy"
 
 
+@pytest.mark.parametrize("engine", [None, "native"], ids=["default", "explicit-native"])
 def test_run_native_executes_the_methods_subset_without_constructing_a_legacy_runner(
     monkeypatch: pytest.MonkeyPatch,
+    engine: str | None,
 ) -> None:
-    """The public native lane never constructs ``PipelineRunner``."""
+    """The default and explicit native lanes never construct ``PipelineRunner``."""
 
     def legacy_runner(*_args, **_kwargs):  # noqa: ANN002, ANN003
         raise AssertionError("run(engine='native') constructed a legacy PipelineRunner")
@@ -89,7 +91,7 @@ def test_run_native_executes_the_methods_subset_without_constructing_a_legacy_ru
     result = run(
         [{"split": "stub"}, {"model": "stub"}],
         {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["s1", "s2"]},
-        engine="native",
+        engine=engine,
         save_charts=False,
     )
 

--- a/tests/unit/api/test_generate.py
+++ b/tests/unit/api/test_generate.py
@@ -6,13 +6,6 @@ import numpy as np
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _select_legacy_for_legacy_generation_examples(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep the historical generator checks on the explicit rollback lane."""
-
-    monkeypatch.setenv("N4A_ENGINE", "legacy")
-
-
 class TestGenerateFunction:
     """Tests for the main generate() function."""
 

--- a/tests/unit/api/test_generate.py
+++ b/tests/unit/api/test_generate.py
@@ -6,6 +6,13 @@ import numpy as np
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _select_legacy_for_legacy_generation_examples(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the historical generator checks on the explicit rollback lane."""
+
+    monkeypatch.setenv("N4A_ENGINE", "legacy")
+
+
 class TestGenerateFunction:
     """Tests for the main generate() function."""
 
@@ -18,6 +25,25 @@ class TestGenerateFunction:
         from nirs4all.data import SpectroDataset
         assert isinstance(dataset, SpectroDataset)
         assert dataset.num_samples == 100
+
+    def test_default_native_generation_is_refused_before_constructing_a_dataset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A missing generator capability cannot select legacy implicitly."""
+
+        import nirs4all
+        import nirs4all.synthesis
+
+        monkeypatch.delenv("N4A_ENGINE", raising=False)
+        monkeypatch.setattr(
+            nirs4all.synthesis,
+            "SyntheticDatasetBuilder",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("generator was constructed")),
+        )
+
+        with pytest.raises(NotImplementedError, match="nirs4all.generate"):
+            nirs4all.generate(n_samples=1)
 
     @pytest.mark.parametrize("engine", ["native", "dag-ml", "dual"])
     def test_non_legacy_engine_is_refused_before_constructing_a_dataset(self, monkeypatch: pytest.MonkeyPatch, engine: str):
@@ -68,7 +94,7 @@ class TestGenerateFunction:
         """Every public generation entry point obeys the engine boundary."""
         import nirs4all
 
-        monkeypatch.setenv("N4A_ENGINE", "native")
+        monkeypatch.delenv("N4A_ENGINE", raising=False)
         with pytest.raises(NotImplementedError, match="nirs4all.generate"):
             call(nirs4all.generate, tmp_path)
 

--- a/tests/unit/pipeline/test_engine_selector.py
+++ b/tests/unit/pipeline/test_engine_selector.py
@@ -1,4 +1,4 @@
-"""Unit tests for the backend-engine selector (default is legacy (interim, pre-refactoring))."""
+"""Unit tests for the R2 native-default backend selector."""
 
 from __future__ import annotations
 
@@ -7,12 +7,10 @@ import pytest
 from nirs4all.pipeline.engine import DEFAULT_ENGINE, ENGINE_ENV_VAR, DualRunUnsupported, require_legacy_engine, resolve_engine
 
 
-def test_defaults_to_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
-    # default is legacy (interim, pre-refactoring): the public-maintained nirs4all stays pure-Python
-    # by default; dag-ml stays fully selectable via engine="dag-ml" / $N4A_ENGINE=dag-ml.
+def test_defaults_to_native(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv(ENGINE_ENV_VAR, raising=False)
-    assert DEFAULT_ENGINE == "legacy"
-    assert resolve_engine() == "legacy"
+    assert DEFAULT_ENGINE == "native"
+    assert resolve_engine() == "native"
 
 
 def test_explicit_legacy_case_insensitive() -> None:


### PR DESCRIPTION
## R2 native-default transition

Makes the DAG-ML native lane the public default while retaining `engine="legacy"` as an explicit rollback path.

Depends on merged R2 session integration and released `dag-ml>=0.3.19`.

Validation before PR: 156 targeted tests passed; full CI required before merge.