### PR TITLE
feat(native): add R2 capability matrix and shadow gate

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,6 +91,10 @@ jobs:
       - name: Install package (editable, no-deps — deps already from requirements-test.txt)
         run: python -m pip install -e . --no-deps
 
+      - name: Run R2 DAG-ML shadow-default gate
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.11' }}
+        run: python -m pytest -q --timeout=300 tests/integration/parity/test_r2_dagml_shadow_default.py
+
       - name: Run unit tests
         shell: bash
         env:

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -250,10 +250,14 @@ Environment switches:
 alias for `engine="dag-ml"`, and it never silently instantiates a legacy
 `PipelineRunner`. The packaged
 `nirs4all.api.native_capabilities.get_native_capability_matrix()` is the
-authoritative machine-readable form: each operation is `native`, requires an
-explicit `plugin`, or is `refused`, and every fallback route is forbidden. The
-table below is its human-readable R2 companion; callers should branch on it
-rather than inferring support from the broader legacy API.
+authoritative machine-readable form. It records operation forms as `native`,
+`plugin`, or `refused`; a plugin form is valid only when it names a callable,
+explicit plugin path. No current native lifecycle form uses that disposition,
+so native explanation remains refused. Every fallback route is forbidden. The
+historical compatibility ledger is a parity-tolerance context only, never a
+semantic authority for these dispositions. The table below is the human-readable
+R2 companion; callers should branch on it rather than inferring support from
+the broader legacy API.
 
 | Lifecycle operation | Native status | Exact boundary |
 | --- | --- | --- |
@@ -263,7 +267,7 @@ rather than inferring support from the broader legacy API.
 | `load_session(path, engine="native")` | Supported, PREDICT-only | Validates Core Archive V2/Package V2 or Archive V3/Package V3 before data/model hydration, then returns `NativeArchiveSession`. It has no train, retrain, save, or legacy fallback capability. |
 | `retrain(source, data, mode="full", engine="native")` | Supported subset | Source must be an in-memory `NativeMethodsRunResult` with a completed selected refit and attested seed. The selected PLS variant is copied exactly and the child outcome persists signed parent lineage. |
 | Native transfer / finetune retrain | Refused | `mode="transfer"`, `mode="finetune"`, archive sources, replacement models, epochs, and legacy retrain kwargs are rejected before native execution. A future plugin must declare its own artifact and lineage contract. |
-| `explain(..., engine="native")` | Refused | SHAP is a host plugin today. A native result or session is rejected at preflight even when no engine argument is supplied; it is never rerouted to legacy implicitly. |
+| `explain(..., engine="native")` | Refused | No callable explicit native plugin path is exposed for SHAP today. A native result or session is rejected at preflight even when no engine argument is supplied; it is never rerouted to legacy implicitly. |
 | `generate(..., engine="native")` | Refused | Synthetic-data generation has no native Methods implementation. The explicit engine is rejected before a builder or dataset is constructed. |
 
 The default remains unchanged during R2: it is not evidence that every legacy

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -248,8 +248,12 @@ Environment switches:
 
 `engine="native"` is a separate, fail-closed Methods lane. It is not an
 alias for `engine="dag-ml"`, and it never silently instantiates a legacy
-`PipelineRunner`. The table below is the executable R2 boundary; callers
-should branch on it rather than inferring support from the broader legacy API.
+`PipelineRunner`. The packaged
+`nirs4all.api.native_capabilities.get_native_capability_matrix()` is the
+authoritative machine-readable form: each operation is `native`, requires an
+explicit `plugin`, or is `refused`, and every fallback route is forbidden. The
+table below is its human-readable R2 companion; callers should branch on it
+rather than inferring support from the broader legacy API.
 
 | Lifecycle operation | Native status | Exact boundary |
 | --- | --- | --- |

--- a/nirs4all/api/native_capabilities.py
+++ b/nirs4all/api/native_capabilities.py
@@ -1,9 +1,9 @@
 """Executable native capability matrix for the stable public lifecycle APIs.
 
 The matrix is descriptive only: it records the fail-closed native profile and
-does not select an execution engine or route a request.  Consumers can use it
-to decide whether to call a native API, explicitly activate a plugin, or stop
-before an unsupported operation reaches a broader runtime.
+does not select an execution engine or route a request. Consumers can use an
+operation form to decide whether to call a native API, use a callable explicit
+plugin, or stop before an unsupported request reaches a broader runtime.
 """
 
 from __future__ import annotations
@@ -38,6 +38,16 @@ _NATIVE_CAPABILITY_MATRIX_SCHEMA: dict[str, Any] = {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": False,
     "properties": {
+        "evidence_sources": {
+            "additionalProperties": False,
+            "properties": {
+                "compatibility_context": {"$ref": "#/$defs/compatibility_context"},
+                "lifecycle_reference": {"$ref": "#/$defs/lifecycle_reference"},
+                "runtime_tests": {"$ref": "#/$defs/runtime_tests"},
+            },
+            "required": ["compatibility_context", "lifecycle_reference", "runtime_tests"],
+            "type": "object",
+        },
         "matrix_id": {"const": "nirs4all.native-capability-matrix"},
         "operations": {
             "additionalProperties": False,
@@ -49,21 +59,21 @@ _NATIVE_CAPABILITY_MATRIX_SCHEMA: dict[str, Any] = {
         },
         "profile": {"const": "native"},
         "schema_version": {"const": 1},
-        "source_ledgers": {
-            "additionalProperties": False,
-            "properties": {
-                "compatibility": {"const": "docs/compatibility.json"},
-                "lifecycle": {"const": "docs/source/reference/public_interfaces.md#native-lifecycle-capability-matrix"},
-            },
-            "required": ["compatibility", "lifecycle"],
-            "type": "object",
-        },
     },
-    "required": ["matrix_id", "operations", "profile", "schema_version", "source_ledgers"],
+    "required": ["evidence_sources", "matrix_id", "operations", "profile", "schema_version"],
     "title": "nirs4all native public API capability matrix",
     "type": "object",
     "$defs": {
-        "operation": {
+        "compatibility_context": {
+            "additionalProperties": False,
+            "properties": {
+                "path": {"const": "docs/compatibility.json"},
+                "role": {"const": "parity_tolerance_context_only"},
+            },
+            "required": ["path", "role"],
+            "type": "object",
+        },
+        "form": {
             "additionalProperties": False,
             "allOf": [
                 {
@@ -83,16 +93,54 @@ _NATIVE_CAPABILITY_MATRIX_SCHEMA: dict[str, Any] = {
                     "additionalProperties": False,
                     "properties": {
                         "activation": {"const": "explicit"},
+                        "callable_api": {"minLength": 1, "pattern": "^nirs4all(?:\\.|$)", "type": "string"},
                         "id": {"minLength": 1, "type": "string"},
                     },
-                    "required": ["activation", "id"],
+                    "required": ["activation", "callable_api", "id"],
                     "type": "object",
                 },
                 "public_api": {"minLength": 1, "pattern": "^nirs4all(?:\\.|$)", "type": "string"},
             },
             "required": ["boundary", "disposition", "fallback", "public_api"],
             "type": "object",
-        }
+        },
+        "lifecycle_reference": {
+            "additionalProperties": False,
+            "properties": {
+                "anchor": {"const": "native-lifecycle-capability-matrix"},
+                "path": {"const": "docs/source/reference/public_interfaces.md"},
+                "role": {"const": "human_readable_companion"},
+            },
+            "required": ["anchor", "path", "role"],
+            "type": "object",
+        },
+        "operation": {
+            "additionalProperties": False,
+            "properties": {
+                "forms": {
+                    "additionalProperties": False,
+                    "minProperties": 1,
+                    "patternProperties": {"^[a-z][a-z0-9_]*$": {"$ref": "#/$defs/form"}},
+                    "type": "object",
+                }
+            },
+            "required": ["forms"],
+            "type": "object",
+        },
+        "runtime_tests": {
+            "additionalProperties": False,
+            "properties": {
+                "paths": {
+                    "items": {"pattern": "^tests/unit/api/test_[a-z0-9_]+\\.py$", "type": "string"},
+                    "minItems": 1,
+                    "type": "array",
+                    "uniqueItems": True,
+                },
+                "role": {"const": "native_lifecycle_verification"},
+            },
+            "required": ["paths", "role"],
+            "type": "object",
+        },
     },
 }
 

--- a/nirs4all/api/native_capabilities.py
+++ b/nirs4all/api/native_capabilities.py
@@ -1,0 +1,146 @@
+"""Executable native capability matrix for the stable public lifecycle APIs.
+
+The matrix is descriptive only: it records the fail-closed native profile and
+does not select an execution engine or route a request.  Consumers can use it
+to decide whether to call a native API, explicitly activate a plugin, or stop
+before an unsupported operation reaches a broader runtime.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from importlib import resources
+from typing import Any, Literal, TypeAlias, cast
+
+from jsonschema import Draft202012Validator
+
+CapabilityDisposition: TypeAlias = Literal["native", "plugin", "refused"]
+
+NATIVE_CAPABILITY_MATRIX_SCHEMA_ID = "https://nirs4all.org/schemas/native-capability-matrix/v1"
+NATIVE_CAPABILITY_MATRIX_FILENAME = "native_capability_matrix.v1.json"
+NATIVE_CAPABILITY_OPERATIONS = (
+    "run",
+    "predict",
+    "session",
+    "load_session",
+    "save",
+    "export",
+    "retrain",
+    "explain",
+    "generate",
+)
+NATIVE_CAPABILITY_DISPOSITIONS: tuple[CapabilityDisposition, ...] = ("native", "plugin", "refused")
+
+
+_NATIVE_CAPABILITY_MATRIX_SCHEMA: dict[str, Any] = {
+    "$id": NATIVE_CAPABILITY_MATRIX_SCHEMA_ID,
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "additionalProperties": False,
+    "properties": {
+        "matrix_id": {"const": "nirs4all.native-capability-matrix"},
+        "operations": {
+            "additionalProperties": False,
+            "properties": {
+                operation: {"$ref": "#/$defs/operation"} for operation in NATIVE_CAPABILITY_OPERATIONS
+            },
+            "required": list(NATIVE_CAPABILITY_OPERATIONS),
+            "type": "object",
+        },
+        "profile": {"const": "native"},
+        "schema_version": {"const": 1},
+        "source_ledgers": {
+            "additionalProperties": False,
+            "properties": {
+                "compatibility": {"const": "docs/compatibility.json"},
+                "lifecycle": {"const": "docs/source/reference/public_interfaces.md#native-lifecycle-capability-matrix"},
+            },
+            "required": ["compatibility", "lifecycle"],
+            "type": "object",
+        },
+    },
+    "required": ["matrix_id", "operations", "profile", "schema_version", "source_ledgers"],
+    "title": "nirs4all native public API capability matrix",
+    "type": "object",
+    "$defs": {
+        "operation": {
+            "additionalProperties": False,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {"disposition": {"const": "plugin"}},
+                        "required": ["disposition"],
+                    },
+                    "then": {"required": ["plugin"]},
+                    "else": {"not": {"required": ["plugin"]}},
+                }
+            ],
+            "properties": {
+                "boundary": {"minLength": 1, "type": "string"},
+                "disposition": {"enum": list(NATIVE_CAPABILITY_DISPOSITIONS)},
+                "fallback": {"const": "forbidden"},
+                "plugin": {
+                    "additionalProperties": False,
+                    "properties": {
+                        "activation": {"const": "explicit"},
+                        "id": {"minLength": 1, "type": "string"},
+                    },
+                    "required": ["activation", "id"],
+                    "type": "object",
+                },
+                "public_api": {"minLength": 1, "pattern": "^nirs4all(?:\\.|$)", "type": "string"},
+            },
+            "required": ["boundary", "disposition", "fallback", "public_api"],
+            "type": "object",
+        }
+    },
+}
+
+
+def native_capability_matrix_schema() -> dict[str, Any]:
+    """Return a detached JSON Schema for the native capability matrix."""
+
+    return cast(dict[str, Any], json.loads(json.dumps(_NATIVE_CAPABILITY_MATRIX_SCHEMA, sort_keys=True)))
+
+
+def validate_native_capability_matrix(payload: Mapping[str, Any]) -> None:
+    """Raise ``ValueError`` unless *payload* satisfies the native matrix contract."""
+
+    if not isinstance(payload, Mapping):
+        raise TypeError("native capability matrix must be a mapping")
+
+    validator = Draft202012Validator(_NATIVE_CAPABILITY_MATRIX_SCHEMA)
+    errors = sorted(
+        validator.iter_errors(payload),
+        key=lambda error: (tuple(str(part) for part in error.absolute_path), error.message),
+    )
+    if errors:
+        rendered = "; ".join(
+            f"{'.'.join(str(part) for part in error.absolute_path) or '<root>'}: {error.message}" for error in errors
+        )
+        raise ValueError(f"invalid native capability matrix: {rendered}")
+
+
+def get_native_capability_matrix() -> dict[str, Any]:
+    """Load and validate the packaged native capability matrix.
+
+    A new decoded mapping is returned for every call so callers cannot mutate a
+    shared authority record in process.
+    """
+
+    text = resources.files("nirs4all").joinpath(NATIVE_CAPABILITY_MATRIX_FILENAME).read_text(encoding="utf-8")
+    payload = cast(dict[str, Any], json.loads(text))
+    validate_native_capability_matrix(payload)
+    return payload
+
+
+__all__ = [
+    "CapabilityDisposition",
+    "NATIVE_CAPABILITY_DISPOSITIONS",
+    "NATIVE_CAPABILITY_MATRIX_FILENAME",
+    "NATIVE_CAPABILITY_MATRIX_SCHEMA_ID",
+    "NATIVE_CAPABILITY_OPERATIONS",
+    "get_native_capability_matrix",
+    "native_capability_matrix_schema",
+    "validate_native_capability_matrix",
+]

--- a/nirs4all/native_capability_matrix.v1.json
+++ b/nirs4all/native_capability_matrix.v1.json
@@ -1,0 +1,69 @@
+{
+  "matrix_id": "nirs4all.native-capability-matrix",
+  "operations": {
+    "explain": {
+      "boundary": "Requires an explicitly declared SHAP host plugin; the native profile alone does not execute explanations.",
+      "disposition": "plugin",
+      "fallback": "forbidden",
+      "plugin": {
+        "activation": "explicit",
+        "id": "shap"
+      },
+      "public_api": "nirs4all.explain"
+    },
+    "export": {
+      "boundary": "Exports a NativeMethodsRunResult as a portable archive after native package validation.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.NativeMethodsRunResult.export"
+    },
+    "generate": {
+      "boundary": "Synthetic-data generation has no native Methods implementation.",
+      "disposition": "refused",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.generate"
+    },
+    "load_session": {
+      "boundary": "PREDICT-only after Core Archive V2 or V3 and Package V2 or V3 validation.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.load_session"
+    },
+    "predict": {
+      "boundary": "Requires an explicitly identified cohort through a native result, trained native session, or validated archive session.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.predict"
+    },
+    "retrain": {
+      "boundary": "Only full refit from an in-memory NativeMethodsRunResult with selected-refit evidence and an attested seed.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.retrain"
+    },
+    "run": {
+      "boundary": "Requires an explicit raw mapping, a portable Methods pipeline, native refit, and no workspace, cache, project, or result-path state.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.run"
+    },
+    "save": {
+      "boundary": "Persists a fitted NativeMethodsSession as a portable archive without refitting.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.NativeMethodsSession.save"
+    },
+    "session": {
+      "boundary": "Creates NativeMethodsSession for native train, identity-bound prediction, archive persistence, close, and selected full refit.",
+      "disposition": "native",
+      "fallback": "forbidden",
+      "public_api": "nirs4all.session"
+    }
+  },
+  "profile": "native",
+  "schema_version": 1,
+  "source_ledgers": {
+    "compatibility": "docs/compatibility.json",
+    "lifecycle": "docs/source/reference/public_interfaces.md#native-lifecycle-capability-matrix"
+  }
+}

--- a/nirs4all/native_capability_matrix.v1.json
+++ b/nirs4all/native_capability_matrix.v1.json
@@ -1,69 +1,183 @@
 {
+  "evidence_sources": {
+    "compatibility_context": {
+      "path": "docs/compatibility.json",
+      "role": "parity_tolerance_context_only"
+    },
+    "lifecycle_reference": {
+      "anchor": "native-lifecycle-capability-matrix",
+      "path": "docs/source/reference/public_interfaces.md",
+      "role": "human_readable_companion"
+    },
+    "runtime_tests": {
+      "paths": [
+        "tests/unit/api/test_engine_transition.py",
+        "tests/unit/api/test_generate.py",
+        "tests/unit/api/test_native_archive_session.py",
+        "tests/unit/api/test_native_session.py"
+      ],
+      "role": "native_lifecycle_verification"
+    }
+  },
   "matrix_id": "nirs4all.native-capability-matrix",
   "operations": {
     "explain": {
-      "boundary": "Requires an explicitly declared SHAP host plugin; the native profile alone does not execute explanations.",
-      "disposition": "plugin",
-      "fallback": "forbidden",
-      "plugin": {
-        "activation": "explicit",
-        "id": "shap"
-      },
-      "public_api": "nirs4all.explain"
+      "forms": {
+        "native_request": {
+          "boundary": "No callable explicit plugin path or native explanation replay is currently exposed.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.explain"
+        }
+      }
     },
     "export": {
-      "boundary": "Exports a NativeMethodsRunResult as a portable archive after native package validation.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.NativeMethodsRunResult.export"
+      "forms": {
+        "archive_v2": {
+          "boundary": "Exports a NativeMethodsRunResult as a Core Archive V2 after native package validation.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.NativeMethodsRunResult.export"
+        },
+        "archive_v3": {
+          "boundary": "Exports a NativeMethodsRefitResult as a strict Core Archive V3 child.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.NativeMethodsRefitResult.export"
+        }
+      }
     },
     "generate": {
-      "boundary": "Synthetic-data generation has no native Methods implementation.",
-      "disposition": "refused",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.generate"
+      "forms": {
+        "native_request": {
+          "boundary": "Synthetic-data generation has no native Methods implementation.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.generate"
+        }
+      }
     },
     "load_session": {
-      "boundary": "PREDICT-only after Core Archive V2 or V3 and Package V2 or V3 validation.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.load_session"
+      "forms": {
+        "archive_v2": {
+          "boundary": "Opens a validated Core Archive V2 and Package V2 as a PREDICT-only NativeArchiveSession.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.load_session"
+        },
+        "archive_v3": {
+          "boundary": "Opens a validated Core Archive V3 and Package V3 as a PREDICT-only NativeArchiveSession.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.load_session"
+        },
+        "non_archive_path": {
+          "boundary": "The native form requires a Core .n4a archive path.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.load_session"
+        }
+      }
     },
     "predict": {
-      "boundary": "Requires an explicitly identified cohort through a native result, trained native session, or validated archive session.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.predict"
+      "forms": {
+        "archive_v2": {
+          "boundary": "Replays a validated Archive V2 with an explicitly identified prediction cohort.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.predict"
+        },
+        "archive_v3": {
+          "boundary": "Replays a validated Archive V3 with an explicitly identified prediction cohort.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.predict"
+        },
+        "in_memory_result_or_session": {
+          "boundary": "Predicts from an attested native result or trained NativeMethodsSession with explicit sample identities.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.predict"
+        },
+        "workspace_publication": {
+          "boundary": "Native prediction does not publish a workspace prediction row.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.predict"
+        }
+      }
     },
     "retrain": {
-      "boundary": "Only full refit from an in-memory NativeMethodsRunResult with selected-refit evidence and an attested seed.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.retrain"
+      "forms": {
+        "archive_source": {
+          "boundary": "A persisted archive cannot be used as a native retrain parent.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.retrain"
+        },
+        "finetune": {
+          "boundary": "mode='finetune' is not a native retrain capability.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.retrain"
+        },
+        "full_in_memory": {
+          "boundary": "Only mode='full' from an in-memory NativeMethodsRunResult with selected-refit evidence and an attested seed.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.retrain"
+        },
+        "transfer": {
+          "boundary": "mode='transfer' is not a native retrain capability.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.retrain"
+        }
+      }
     },
     "run": {
-      "boundary": "Requires an explicit raw mapping, a portable Methods pipeline, native refit, and no workspace, cache, project, or result-path state.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.run"
+      "forms": {
+        "portable_methods": {
+          "boundary": "Requires an explicit raw mapping, a documented portable Methods topology, native refit, and no workspace, cache, project, or result-path state.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.run"
+        },
+        "unsupported_request": {
+          "boundary": "Nonportable topology, nonmapping data, unsupported run options, or generic tuning requests stop before execution.",
+          "disposition": "refused",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.run"
+        }
+      }
     },
     "save": {
-      "boundary": "Persists a fitted NativeMethodsSession as a portable archive without refitting.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.NativeMethodsSession.save"
+      "forms": {
+        "archive_v2": {
+          "boundary": "A fitted NativeMethodsSession persists its V2 training result as a Core Archive V2 without refitting.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.NativeMethodsSession.save"
+        },
+        "archive_v3": {
+          "boundary": "A NativeMethodsSession holding one V3 refit child persists it as a strict Core Archive V3.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.NativeMethodsSession.save"
+        }
+      }
     },
     "session": {
-      "boundary": "Creates NativeMethodsSession for native train, identity-bound prediction, archive persistence, close, and selected full refit.",
-      "disposition": "native",
-      "fallback": "forbidden",
-      "public_api": "nirs4all.session"
+      "forms": {
+        "native_methods": {
+          "boundary": "Creates NativeMethodsSession for native train, identity-bound prediction, archive persistence, close, and one selected full refit.",
+          "disposition": "native",
+          "fallback": "forbidden",
+          "public_api": "nirs4all.session"
+        }
+      }
     }
   },
   "profile": "native",
-  "schema_version": 1,
-  "source_ledgers": {
-    "compatibility": "docs/compatibility.json",
-    "lifecycle": "docs/source/reference/public_interfaces.md#native-lifecycle-capability-matrix"
-  }
+  "schema_version": 1
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ Changelog = "https://github.com/GBeurier/nirs4all/blob/main/CHANGELOG.md"
 include = ["nirs4all*"]
 
 [tool.setuptools.package-data]
-nirs4all = ["py.typed", "compatibility_ledger.json"]
+nirs4all = ["py.typed", "compatibility_ledger.json", "native_capability_matrix.v1.json"]
 
 [tool.setuptools.dynamic]
 version = { attr = "nirs4all.__version__" }

--- a/tests/integration/parity/test_r2_dagml_shadow_default.py
+++ b/tests/integration/parity/test_r2_dagml_shadow_default.py
@@ -1,0 +1,66 @@
+"""Isolated real-runtime gate for the DAG-ML shadow default.
+
+This module is intentionally run in its own pytest process in CI, where the
+fallback meter naturally starts at zero.  The test still snapshots that
+process-local meter so it remains valid when run after selector tests that
+deliberately exercise an explicit legacy rollback.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold
+
+import nirs4all
+from nirs4all.api.result import RunResult
+from nirs4all.operators.transforms import StandardNormalVariate as SNV
+from nirs4all.pipeline.engine import LegacyFallbackWarning, legacy_fallback_metrics, resolve_engine
+from nirs4all.pipeline.runner import PipelineRunner
+
+from ._datasets import dataset_path
+
+pytestmark = [pytest.mark.parity]
+
+
+def _forbid_legacy_runner(*_args: object, **_kwargs: object) -> None:
+    """Fail immediately if a shadow-default run reaches legacy orchestration."""
+
+    raise AssertionError("DAG-ML shadow default constructed a legacy PipelineRunner")
+
+
+def test_dagml_shadow_default_never_constructs_legacy_or_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run one supported public shape through a simulated DAG-ML default.
+
+    The public call deliberately supplies neither ``engine`` nor
+    ``allow_legacy_fallback``.  This proves the candidate default and its
+    ordinary fail-closed policy rather than an explicitly selected fast path.
+    """
+
+    monkeypatch.delenv("N4A_ENGINE", raising=False)
+    engine_module = importlib.import_module("nirs4all.pipeline.engine")
+    monkeypatch.setattr(engine_module, "DEFAULT_ENGINE", "dag-ml")
+
+    assert resolve_engine() == "dag-ml"
+    fallback_metrics_before = legacy_fallback_metrics()
+
+    # Patch the class implementation rather than one imported alias: no path
+    # may instantiate PipelineRunner while the DAG-ML candidate is selected.
+    monkeypatch.setattr(PipelineRunner, "__init__", _forbid_legacy_runner)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", LegacyFallbackWarning)
+        result = nirs4all.run(
+            [SNV(), KFold(n_splits=3, shuffle=True, random_state=42), {"model": PLSRegression(n_components=2)}],
+            dataset_path("regression"),
+            verbose=0,
+            save_artifacts=False,
+            save_charts=False,
+        )
+
+    assert isinstance(result, RunResult)
+    assert result._is_dagml_engine()  # noqa: SLF001
+    assert legacy_fallback_metrics() == fallback_metrics_before

--- a/tests/unit/api/test_native_capabilities.py
+++ b/tests/unit/api/test_native_capabilities.py
@@ -1,0 +1,76 @@
+"""Contract coverage for the fail-closed native lifecycle capability matrix."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from nirs4all.api.native_capabilities import (
+    NATIVE_CAPABILITY_OPERATIONS,
+    get_native_capability_matrix,
+    native_capability_matrix_schema,
+    validate_native_capability_matrix,
+)
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_packaged_native_capability_matrix_is_complete_and_fail_closed() -> None:
+    """The installed authority covers every lifecycle operation without fallback."""
+
+    matrix = get_native_capability_matrix()
+    schema = native_capability_matrix_schema()
+
+    jsonschema.Draft202012Validator.check_schema(schema)
+    jsonschema.validate(matrix, schema)
+
+    assert set(matrix["operations"]) == set(NATIVE_CAPABILITY_OPERATIONS)
+    assert {name: entry["disposition"] for name, entry in matrix["operations"].items()} == {
+        "run": "native",
+        "predict": "native",
+        "session": "native",
+        "load_session": "native",
+        "save": "native",
+        "export": "native",
+        "retrain": "native",
+        "explain": "plugin",
+        "generate": "refused",
+    }
+    assert all(entry["fallback"] == "forbidden" for entry in matrix["operations"].values())
+    assert "legacy" not in json.dumps(matrix).lower()
+
+    compatibility_path = REPOSITORY_ROOT / matrix["source_ledgers"]["compatibility"]
+    lifecycle_reference = matrix["source_ledgers"]["lifecycle"]
+    lifecycle_path, _, lifecycle_anchor = lifecycle_reference.partition("#")
+    lifecycle_text = (REPOSITORY_ROOT / lifecycle_path).read_text(encoding="utf-8")
+
+    assert json.loads(compatibility_path.read_text(encoding="utf-8"))["owner"] == "nirs4all compatibility ledger"
+    assert f"## {lifecycle_anchor.replace('-', ' ')}" in lifecycle_text.lower()
+    assert "get_native_capability_matrix" in lifecycle_text
+
+
+def test_native_capability_matrix_requires_explicit_plugin_and_forbids_fallback() -> None:
+    """A plugin cannot be implied and no operation can add a fallback route."""
+
+    missing_plugin = copy.deepcopy(get_native_capability_matrix())
+    missing_plugin["operations"]["explain"].pop("plugin")
+    with pytest.raises(ValueError, match="plugin"):
+        validate_native_capability_matrix(missing_plugin)
+
+    fallback_route = copy.deepcopy(get_native_capability_matrix())
+    fallback_route["operations"]["generate"]["fallback"] = "legacy"
+    with pytest.raises(ValueError, match="forbidden"):
+        validate_native_capability_matrix(fallback_route)
+
+
+def test_native_capability_matrix_returns_a_detached_document() -> None:
+    """Consumers cannot mutate the packaged authority record in process."""
+
+    first = get_native_capability_matrix()
+    first["operations"]["run"]["boundary"] = "mutated"
+
+    assert get_native_capability_matrix()["operations"]["run"]["boundary"] != "mutated"

--- a/tests/unit/api/test_native_capabilities.py
+++ b/tests/unit/api/test_native_capabilities.py
@@ -9,7 +9,9 @@ from pathlib import Path
 import jsonschema
 import pytest
 
+import nirs4all
 from nirs4all.api.native_capabilities import (
+    NATIVE_CAPABILITY_DISPOSITIONS,
     NATIVE_CAPABILITY_OPERATIONS,
     get_native_capability_matrix,
     native_capability_matrix_schema,
@@ -17,10 +19,40 @@ from nirs4all.api.native_capabilities import (
 )
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXPECTED_FORMS: dict[str, dict[str, str]] = {
+    "run": {"portable_methods": "native", "unsupported_request": "refused"},
+    "predict": {
+        "in_memory_result_or_session": "native",
+        "archive_v2": "native",
+        "archive_v3": "native",
+        "workspace_publication": "refused",
+    },
+    "session": {"native_methods": "native"},
+    "load_session": {"archive_v2": "native", "archive_v3": "native", "non_archive_path": "refused"},
+    "save": {"archive_v2": "native", "archive_v3": "native"},
+    "export": {"archive_v2": "native", "archive_v3": "native"},
+    "retrain": {
+        "full_in_memory": "native",
+        "transfer": "refused",
+        "finetune": "refused",
+        "archive_source": "refused",
+    },
+    "explain": {"native_request": "refused"},
+    "generate": {"native_request": "refused"},
+}
+
+
+def _resolve_public_api(path: str) -> object:
+    """Resolve a matrix public surface from the installed top-level package."""
+
+    target: object = nirs4all
+    for attribute in path.split(".")[1:]:
+        target = getattr(target, attribute)
+    return target
 
 
 def test_packaged_native_capability_matrix_is_complete_and_fail_closed() -> None:
-    """The installed authority covers every lifecycle operation without fallback."""
+    """The installed authority records every concrete lifecycle form."""
 
     matrix = get_native_capability_matrix()
     schema = native_capability_matrix_schema()
@@ -28,49 +60,71 @@ def test_packaged_native_capability_matrix_is_complete_and_fail_closed() -> None
     jsonschema.Draft202012Validator.check_schema(schema)
     jsonschema.validate(matrix, schema)
 
+    assert set(NATIVE_CAPABILITY_DISPOSITIONS) == {"native", "plugin", "refused"}
     assert set(matrix["operations"]) == set(NATIVE_CAPABILITY_OPERATIONS)
-    assert {name: entry["disposition"] for name, entry in matrix["operations"].items()} == {
-        "run": "native",
-        "predict": "native",
-        "session": "native",
-        "load_session": "native",
-        "save": "native",
-        "export": "native",
-        "retrain": "native",
-        "explain": "plugin",
-        "generate": "refused",
-    }
-    assert all(entry["fallback"] == "forbidden" for entry in matrix["operations"].values())
+    assert {
+        operation: {form_name: form["disposition"] for form_name, form in entry["forms"].items()}
+        for operation, entry in matrix["operations"].items()
+    } == EXPECTED_FORMS
+    assert all(
+        form["fallback"] == "forbidden"
+        for entry in matrix["operations"].values()
+        for form in entry["forms"].values()
+    )
+    assert all(
+        form["disposition"] != "plugin"
+        for entry in matrix["operations"].values()
+        for form in entry["forms"].values()
+    )
     assert "legacy" not in json.dumps(matrix).lower()
 
-    compatibility_path = REPOSITORY_ROOT / matrix["source_ledgers"]["compatibility"]
-    lifecycle_reference = matrix["source_ledgers"]["lifecycle"]
-    lifecycle_path, _, lifecycle_anchor = lifecycle_reference.partition("#")
-    lifecycle_text = (REPOSITORY_ROOT / lifecycle_path).read_text(encoding="utf-8")
+    for entry in matrix["operations"].values():
+        for form in entry["forms"].values():
+            assert callable(_resolve_public_api(form["public_api"]))
 
-    assert json.loads(compatibility_path.read_text(encoding="utf-8"))["owner"] == "nirs4all compatibility ledger"
-    assert f"## {lifecycle_anchor.replace('-', ' ')}" in lifecycle_text.lower()
+    evidence = matrix["evidence_sources"]
+    assert "source_ledgers" not in matrix
+    assert evidence["compatibility_context"]["role"] == "parity_tolerance_context_only"
+    assert (REPOSITORY_ROOT / evidence["compatibility_context"]["path"]).is_file()
+    assert all((REPOSITORY_ROOT / path).is_file() for path in evidence["runtime_tests"]["paths"])
+
+    lifecycle = evidence["lifecycle_reference"]
+    lifecycle_text = (REPOSITORY_ROOT / lifecycle["path"]).read_text(encoding="utf-8")
+    assert f"## {lifecycle['anchor'].replace('-', ' ')}" in lifecycle_text.lower()
     assert "get_native_capability_matrix" in lifecycle_text
+    assert "parity-tolerance context only" in lifecycle_text
 
 
-def test_native_capability_matrix_requires_explicit_plugin_and_forbids_fallback() -> None:
-    """A plugin cannot be implied and no operation can add a fallback route."""
+def test_native_capability_matrix_requires_forms_callable_plugins_and_scoped_evidence() -> None:
+    """Unsupported shortcuts cannot turn into implied routes or semantic evidence."""
 
-    missing_plugin = copy.deepcopy(get_native_capability_matrix())
-    missing_plugin["operations"]["explain"].pop("plugin")
-    with pytest.raises(ValueError, match="plugin"):
-        validate_native_capability_matrix(missing_plugin)
+    missing_forms = copy.deepcopy(get_native_capability_matrix())
+    missing_forms["operations"]["run"] = {}
+    with pytest.raises(ValueError, match="forms"):
+        validate_native_capability_matrix(missing_forms)
+
+    missing_callable_plugin = copy.deepcopy(get_native_capability_matrix())
+    explain_form = missing_callable_plugin["operations"]["explain"]["forms"]["native_request"]
+    explain_form["disposition"] = "plugin"
+    explain_form["plugin"] = {"activation": "explicit", "id": "shap"}
+    with pytest.raises(ValueError, match="callable_api"):
+        validate_native_capability_matrix(missing_callable_plugin)
 
     fallback_route = copy.deepcopy(get_native_capability_matrix())
-    fallback_route["operations"]["generate"]["fallback"] = "legacy"
+    fallback_route["operations"]["generate"]["forms"]["native_request"]["fallback"] = "legacy"
     with pytest.raises(ValueError, match="forbidden"):
         validate_native_capability_matrix(fallback_route)
+
+    semantic_compatibility_ledger = copy.deepcopy(get_native_capability_matrix())
+    semantic_compatibility_ledger["evidence_sources"]["compatibility_context"]["role"] = "semantic_authority"
+    with pytest.raises(ValueError, match="parity_tolerance_context_only"):
+        validate_native_capability_matrix(semantic_compatibility_ledger)
 
 
 def test_native_capability_matrix_returns_a_detached_document() -> None:
     """Consumers cannot mutate the packaged authority record in process."""
 
     first = get_native_capability_matrix()
-    first["operations"]["run"]["boundary"] = "mutated"
+    first["operations"]["run"]["forms"]["portable_methods"]["boundary"] = "mutated"
 
-    assert get_native_capability_matrix()["operations"]["run"]["boundary"] != "mutated"
+    assert get_native_capability_matrix()["operations"]["run"]["forms"]["portable_methods"]["boundary"] != "mutated"


### PR DESCRIPTION
## R2 library foundation

Adds an executable, packaged capability matrix for the strict Methods-native lifecycle profile and a real DAG-ML shadow-default CI gate.

- matrices concrete API forms (including V2/V3 archive routes and refusals)
- declares every fallback forbidden
- makes legacy orchestration fail the shadow-default path
- does not change the public default engine or Studio

Validation: targeted capability + shadow tests (4 passed), Ruff, diff check.

Independent Sol reviews accepted both slices before integration; full CI and final integrated review remain required.