### PR TITLE
feat(native): attest live Methods execution

### DIFF
--- a/.github/workflows/methods-installed.yml
+++ b/.github/workflows/methods-installed.yml
@@ -5,6 +5,11 @@ on:
     paths:
       - "nirs4all/operators/methods/**"
       - "tests/unit/operators/methods/**"
+      - "nirs4all/api/run.py"
+      - "nirs4all/api/native_*.py"
+      - "nirs4all/pipeline/dagml/**"
+      - "tests/unit/api/test_native_witness.py"
+      - "tests/integration/api/test_native_methods_witness.py"
       - "pyproject.toml"
       - ".github/workflows/methods-installed.yml"
   workflow_dispatch:
@@ -12,7 +17,7 @@ on:
       methods_package:
         description: "Package spec to install for nirs4all-methods"
         required: false
-        default: "nirs4all-methods"
+        default: "nirs4all-methods==1.0.13"
 
 jobs:
   n4m-binding:
@@ -31,21 +36,36 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install -e ".[dev]"
 
-      - name: Install nirs4all-methods binding
+      - name: Install released DAG-ML and nirs4all-methods wheels
         env:
-          METHODS_PACKAGE: ${{ inputs.methods_package || 'nirs4all-methods' }}
-        run: python -m pip install "$METHODS_PACKAGE"
+          METHODS_PACKAGE: ${{ inputs.methods_package || 'nirs4all-methods==1.0.13' }}
+        run: python -m pip install "dag-ml==0.3.19" "$METHODS_PACKAGE"
 
-      - name: Verify n4m binding loads
+      - name: Verify published DAG-ML and n4m runtime
         run: |
           python - <<'PY'
+          from importlib.metadata import version
+          from pathlib import Path
+
+          import dag_ml
           import n4m
 
+          assert version("dag-ml") == "0.3.19"
+          assert version("nirs4all-methods") == "1.0.13"
+          assert dag_ml.version() == "0.3.19"
+          abi = tuple(n4m.abi_version())
+          assert len(abi) == 3 and abi[0] == 2 and abi[1] >= 2
+          library = Path(n4m.library_path()).resolve(strict=True)
+          assert library.is_absolute() and library.is_file()
+          print("dag-ml:", dag_ml.version())
           print("n4m abi:", n4m.abi_version())
-          print("n4m lib:", n4m.library_path())
+          print("n4m lib:", library)
           PY
 
       - name: Run methods parity gate
         env:
           NIRS4ALL_REQUIRE_N4M: "1"
-        run: python -m pytest -m methods tests/unit/operators/methods/test_n4m_ops.py -q
+        run: >-
+          python -m pytest -m methods
+          tests/unit/operators/methods/test_n4m_ops.py
+          tests/integration/api/test_native_methods_witness.py -q

--- a/.github/workflows/methods-installed.yml
+++ b/.github/workflows/methods-installed.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install nirs4all test environment
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install -e ".[dev]"
+          python -m pip install -e ".[dev,native]"
 
       - name: Install released DAG-ML and nirs4all-methods wheels
         env:
@@ -65,7 +65,6 @@ jobs:
       - name: Run methods parity gate
         env:
           NIRS4ALL_REQUIRE_N4M: "1"
-        run: >-
-          python -m pytest -m methods
-          tests/unit/operators/methods/test_n4m_ops.py
-          tests/integration/api/test_native_methods_witness.py -q
+        run: |
+          env -u N4M_LIB_PATH python -m pytest -m methods tests/unit/operators/methods/test_n4m_ops.py -q
+          env -u N4M_LIB_PATH python -m pytest -m methods tests/integration/api/test_native_methods_witness.py -q

--- a/nirs4all/api/native_result.py
+++ b/nirs4all/api/native_result.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, SupportsIndex
 
 from nirs4all.api.result import RunResult
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
@@ -19,6 +19,9 @@ from nirs4all.pipeline.dagml.result import _scores_to_run_result
 
 from .native_retrain_lineage import DIAGNOSTIC_KEY as RETRAIN_LINEAGE_DIAGNOSTIC_KEY
 from .native_retrain_lineage import NativeRetrainLineage
+from .native_witness import NativeMethodsExecutionClaim, _LiveMethodsWitness
+
+_RESULT_FACTORY_CAPABILITY = object()
 
 
 class NativeMethodsRunResult(RunResult):
@@ -30,9 +33,21 @@ class NativeMethodsRunResult(RunResult):
     :attr:`native_estimator` with explicit sample identities.
     """
 
-    def __init__(self, projected: RunResult, estimator: DagMLPipelineEstimator, *, archive_id: str) -> None:
+    def __init__(
+        self,
+        projected: RunResult,
+        estimator: DagMLPipelineEstimator,
+        *,
+        archive_id: str,
+        live_witness: _LiveMethodsWitness,
+        _factory_capability: object,
+    ) -> None:
+        if _factory_capability is not _RESULT_FACTORY_CAPABILITY:
+            raise TypeError("native Methods results can only be created by the verified internal factory")
         if not isinstance(archive_id, str) or not archive_id:
             raise ValueError("native archive_id must be a non-empty string")
+        if type(live_witness) is not _LiveMethodsWitness:
+            raise TypeError("native Methods results require an internal live execution witness")
         super().__init__(
             predictions=projected.predictions,
             per_dataset={dataset_name: {**info, "engine": "native"} for dataset_name, info in projected.per_dataset.items()},
@@ -42,6 +57,7 @@ class NativeMethodsRunResult(RunResult):
         self._native_estimator = estimator
         self._native_archive_id = archive_id
         self._native_archive_reference: dict[str, str] | None = None
+        self._live_witness = live_witness
 
     @classmethod
     def from_estimator(
@@ -55,6 +71,7 @@ class NativeMethodsRunResult(RunResult):
     ) -> NativeMethodsRunResult:
         """Project a fitted estimator's canonical ScoreSet without re-execution."""
 
+        witness = _LiveMethodsWitness.from_estimator(estimator)
         outcome = _outcome_document(estimator)
         scores = outcome.get("score_set")
         if not isinstance(scores, Mapping):
@@ -69,7 +86,15 @@ class NativeMethodsRunResult(RunResult):
             metric,
             task_type,
         )
-        return cls(projected, estimator, archive_id=f"archive:{fingerprint}")
+        if witness._claim_for_estimator(estimator).outcome_fingerprint != fingerprint:
+            raise DagMLNativeCoverageError("native Methods live witness fingerprint does not match the projected training outcome")
+        return cls(
+            projected,
+            estimator,
+            archive_id=f"archive:{fingerprint}",
+            live_witness=witness,
+            _factory_capability=_RESULT_FACTORY_CAPABILITY,
+        )
 
     @property
     def native_estimator(self) -> DagMLPipelineEstimator:
@@ -82,6 +107,43 @@ class NativeMethodsRunResult(RunResult):
         """The exact Core-issued reference from the last successful export."""
 
         return None if self._native_archive_reference is None else dict(self._native_archive_reference)
+
+    @property
+    def native_execution_claim(self) -> NativeMethodsExecutionClaim:
+        """Return the current audit-only claim for attached strict execution.
+
+        This property fails closed once the result has been detached or closed.
+        It intentionally exposes neither the raw PyO3 result nor native input
+        buffers, callbacks, library paths, or controllers.
+        """
+
+        witness = getattr(self, "_live_witness", None)
+        if type(witness) is not _LiveMethodsWitness:
+            raise DagMLNativeCoverageError("native Methods result has no live execution witness")
+        return witness._claim_for_estimator(self._native_estimator)
+
+    @property
+    def native_execution_is_live(self) -> bool:
+        """Whether the strict process-local execution witness remains attached."""
+
+        witness = getattr(self, "_live_witness", None)
+        return type(witness) is _LiveMethodsWitness and witness._is_live_for_estimator(self._native_estimator)
+
+    def detach(self) -> None:
+        """Release legacy and strict native runtime resources deterministically."""
+
+        witness = getattr(self, "_live_witness", None)
+        if type(witness) is _LiveMethodsWitness:
+            witness.detach()
+        super().detach()
+
+    def close(self) -> None:
+        """Close ordinary result resources and detach the strict native facade."""
+
+        witness = getattr(self, "_live_witness", None)
+        if type(witness) is _LiveMethodsWitness:
+            witness.detach()
+        super().close()
 
     @property
     def native_methods_hpo_resume_state(self) -> dict[str, Any] | None:
@@ -208,6 +270,39 @@ class NativeMethodsRunResult(RunResult):
             archive_id=self._native_archive_id,
         )
         return path
+
+    def export_model(
+        self,
+        output_path: str | Path,
+        source: dict[str, Any] | None = None,
+        format: str | None = None,
+        fold: int | None = None,
+        *,
+        compatibility: str | None = None,
+    ) -> Path:
+        """Refuse legacy model export before it can create any side effect.
+
+        A strict Methods result is persistable only as its native Archive V2.
+        The inherited compatibility exporter may refit through legacy paths,
+        which would invalidate the execution claim.
+        """
+
+        _ = (output_path, source, format, fold, compatibility)
+        raise NotImplementedError("native Methods export_model is unavailable; use export(path, format='n4a') for Core Archive V2")
+
+    def __copy__(self) -> NativeMethodsRunResult:
+        raise TypeError("a live native Methods result cannot be copied; export its Archive V2 instead")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> NativeMethodsRunResult:
+        _ = memo
+        raise TypeError("a live native Methods result cannot be deep-copied; export its Archive V2 instead")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("a live native Methods result cannot be serialized; export its Archive V2 instead")
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> Any:
+        _ = protocol
+        raise TypeError("a live native Methods result cannot be serialized; export its Archive V2 instead")
 
 
 def _outcome_document(estimator: DagMLPipelineEstimator) -> Mapping[str, Any]:

--- a/nirs4all/api/native_session.py
+++ b/nirs4all/api/native_session.py
@@ -97,7 +97,13 @@ class NativeMethodsSession:
         """Fit this session's portable Methods pipeline exactly once per call."""
 
         self._require_open()
-        self._result = run_native_methods(
+        previous = self._result
+        if isinstance(previous, NativeMethodsRunResult):
+            # Keep the prior result session-owned until its exact live facade
+            # has detached. This prevents a failed close from being hidden by
+            # a newly created result or by an overwritten session reference.
+            previous.close()
+        result = run_native_methods(
             self._pipeline,
             dataset,
             name=self._name,
@@ -106,7 +112,8 @@ class NativeMethodsSession:
             tuning=self._tuning,
             calibration=self._calibration,
         )
-        return self._result
+        self._result = result
+        return result
 
     def retrain(self, dataset: Mapping[str, Any]) -> NativeMethodsRefitResult:
         """Full-refit the attested selected Methods variant on one new cohort.
@@ -124,6 +131,11 @@ class NativeMethodsSession:
             raise NotImplementedError(
                 "a native Package V3 refit child cannot be retrained again"
             )
+        # ``refit_native_methods`` consumes only the durable package/outcome,
+        # so release the parent facade first. A close failure leaves the parent
+        # session-owned and prevents creating a child with an unowned live
+        # native result.
+        parent.close()
         result = retrain(
             parent,
             # ``retrain`` exposes the public ``DataSpec`` union, whose
@@ -178,8 +190,11 @@ class NativeMethodsSession:
         return self.result.export(path)
 
     def close(self) -> None:
-        """Release this session's in-memory estimator reference."""
+        """Release the current live native result before dropping its reference."""
 
+        result = self._result
+        if isinstance(result, NativeMethodsRunResult):
+            result.close()
         self._result = None
         self._closed = True
 

--- a/nirs4all/api/native_training.py
+++ b/nirs4all/api/native_training.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import Mapping, Sequence
+from contextlib import suppress
 from typing import Any, cast
 
 import numpy as np
@@ -134,20 +135,26 @@ def fit_native_pipeline(
         ),
         require_explicit_sample_ids=True,
     )
-    estimator.fit(X, y, sample_ids=sample_ids, groups=groups, metadata=metadata)
-    if estimator.predictor_package_ is None:
-        raise DagMLNativeCoverageError("native DAG-ML training did not return an exportable Package V2")
     try:
+        estimator.fit(X, y, sample_ids=sample_ids, groups=groups, metadata=metadata)
+        if estimator.predictor_package_ is None:
+            raise DagMLNativeCoverageError("native DAG-ML training did not return an exportable Package V2")
         validate_native_methods_package(estimator.predictor_package_)
+        estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
+            estimator.predictor_package_,
+            dagml_module=dagml_module,
+            methods_library_path=resolved_methods_library_path,
+        )
+        estimator.prediction_identity_decoder = _decode_raw_methods_prediction
+        return estimator
     except RawArrayMethodsReplayError as error:
+        with suppress(BaseException):
+            estimator.detach_native_training_result()
         raise DagMLNativeCoverageError("native DAG-ML training did not return a replayable portable Methods Package V2") from error
-    estimator.prediction_compiler = RawArrayMethodsReplayCompiler(
-        estimator.predictor_package_,
-        dagml_module=dagml_module,
-        methods_library_path=resolved_methods_library_path,
-    )
-    estimator.prediction_identity_decoder = _decode_raw_methods_prediction
-    return estimator
+    except BaseException:
+        with suppress(BaseException):
+            estimator.detach_native_training_result()
+        raise
 
 
 def run_native_methods(
@@ -233,13 +240,24 @@ def run_native_methods(
     if retrain_lineage is not None:
         fit_kwargs["retrain_lineage"] = retrain_lineage
     estimator = fit_native_pipeline(pipeline, dataset["X"], dataset["y"], **fit_kwargs)
-    if calibration_operation is not None:
-        _attach_native_conformal_calibration(estimator, calibration_operation)
-    return NativeMethodsRunResult.from_estimator(
-        estimator,
-        dataset_name=name or "native",
-        model_name=_native_model_name(pipeline),
-    )
+    try:
+        if calibration_operation is not None:
+            _attach_native_conformal_calibration(estimator, calibration_operation)
+        # Calibration mutates the retained TrainingResult/outcome and may change
+        # its fingerprint. ``from_estimator`` binds its internal live witness
+        # only after every optional native post-training operation has finalized.
+        return NativeMethodsRunResult.from_estimator(
+            estimator,
+            dataset_name=name or "native",
+            model_name=_native_model_name(pipeline),
+        )
+    except BaseException:
+        # A fitted native result owns process-local handles even if the later
+        # result projection fails. Preserve the original failure while making
+        # the public estimator lifecycle seam attempt a deterministic release.
+        with suppress(BaseException):
+            estimator.detach_native_training_result()
+        raise
 
 
 def refit_native_methods(

--- a/nirs4all/api/native_witness.py
+++ b/nirs4all/api/native_witness.py
@@ -1,0 +1,294 @@
+"""Live, process-local provenance for the strict Methods execution lane.
+
+The public ``engine=\"native\"`` path already has an intentionally separate
+Dag-ML entry point: it supplies native Methods inputs and never installs a
+Python operator callback.  This module does *not* turn that local fact into a
+portable attestation.  It retains the exact live ``dag_ml.TrainingResult``
+facade only long enough to make the local execution boundary observable and to
+release its process-local resources deterministically.
+
+The durable evidence remains the signed outcome and portable package owned by
+Dag-ML.  The internal live witness is deliberately neither serializable nor
+copyable, and is invalid after ``detach()``/``close()``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from threading import RLock
+from typing import TYPE_CHECKING, Any, SupportsIndex
+
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+if TYPE_CHECKING:
+    from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
+
+
+@dataclass(frozen=True, slots=True)
+class NativeMethodsExecutionClaim:
+    """Audit-only description of one locally witnessed strict execution.
+
+    This is intentionally a small immutable projection.  It is not a signed
+    receipt and cannot be used to establish provenance after the live witness
+    has been detached or a result has crossed a process boundary.
+    """
+
+    schema_version: int
+    execution_entrypoint: str
+    execution_mode: str
+    outcome_fingerprint: str
+    methods_library_mode: str
+    portable_artifacts_required: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a detached JSON-compatible audit projection."""
+
+        return asdict(self)
+
+
+_WITNESS_FACTORY_CAPABILITY = object()
+
+
+class _LiveMethodsWitness:
+    """Non-serializable live holder for a strict Dag-ML Methods result.
+
+    Constructing a witness validates the exact facts nirs4all controls at the
+    boundary: the compiled request uses Methods inputs, has an explicit native
+    library path, forbids a Python callback, and returned an attached
+    ``dag_ml.TrainingResult`` whose outcome fingerprint is the final outcome
+    fingerprint.  Dag-ML remains authoritative for graph and controller
+    validation.
+    """
+
+    __slots__ = (
+        "_claim",
+        "_estimator",
+        "_factory_capability",
+        "_lock",
+        "_native_training_result",
+        "_training_result",
+    )
+
+    def __init__(
+        self,
+        estimator: Any,
+        training_result: Any,
+        native_training_result: Any,
+        claim: NativeMethodsExecutionClaim,
+        *,
+        _factory_capability: object,
+    ) -> None:
+        if _factory_capability is not _WITNESS_FACTORY_CAPABILITY:
+            raise TypeError("live Methods witnesses can only be created by the verified internal factory")
+        self._estimator = estimator
+        self._training_result: Any | None = training_result
+        self._native_training_result: Any | None = native_training_result
+        self._claim = claim
+        self._factory_capability = _factory_capability
+        self._lock = RLock()
+
+    @classmethod
+    def from_estimator(cls, estimator: DagMLPipelineEstimator) -> _LiveMethodsWitness:
+        """Bind a witness to a fully finalized strict Methods estimator.
+
+        Call this only after optional result-mutating operations (currently
+        conformal calibration) have completed, so the witness sees the final
+        outcome fingerprint.
+        """
+
+        execution = getattr(estimator, "native_training_execution_", None)
+        if execution is None:
+            raise DagMLNativeCoverageError("strict Methods result omitted its native training execution")
+        if getattr(execution, "op_callback", object()) is not None:
+            raise DagMLNativeCoverageError("strict Methods execution must not retain a Python operator callback")
+        methods_inputs = getattr(execution, "methods_inputs", None)
+        if not isinstance(methods_inputs, Mapping) or not methods_inputs:
+            raise DagMLNativeCoverageError("strict Methods execution omitted non-empty native Methods inputs")
+        library_path = getattr(execution, "methods_library_path", None)
+        if not isinstance(library_path, str) or not library_path:
+            raise DagMLNativeCoverageError("strict Methods execution omitted its explicit libn4m path")
+        path = Path(library_path)
+        if not path.is_absolute():
+            raise DagMLNativeCoverageError("strict Methods execution libn4m path must be absolute")
+        try:
+            canonical_path = path.resolve(strict=True)
+        except OSError as error:
+            raise DagMLNativeCoverageError("strict Methods execution libn4m path is unavailable") from error
+        if not canonical_path.is_file() or str(canonical_path) != library_path:
+            raise DagMLNativeCoverageError("strict Methods execution libn4m path must be canonical and regular")
+
+        dagml_module = getattr(estimator, "dagml_module", "dag_ml")
+        if dagml_module != "dag_ml" or getattr(estimator, "native_client", None) is not None:
+            raise DagMLNativeCoverageError("a live Methods witness requires the standard dag_ml facade and default Dag-ML client")
+        try:
+            dag_ml = importlib.import_module(dagml_module)
+        except ImportError as error:  # pragma: no cover - dependency failure is environment-specific
+            raise DagMLNativeCoverageError("strict Methods witness cannot import the configured Dag-ML facade") from error
+        expected_type = getattr(dag_ml, "TrainingResult", None)
+        if not isinstance(expected_type, type):
+            raise DagMLNativeCoverageError("configured Dag-ML facade does not expose TrainingResult")
+        try:
+            dag_ml_native = importlib.import_module("dag_ml._dag_ml")
+        except ImportError as error:  # pragma: no cover - dependency failure is environment-specific
+            raise DagMLNativeCoverageError("strict Methods witness cannot import the configured Dag-ML native facade") from error
+        expected_native_type = getattr(dag_ml_native, "TrainingResult", None)
+        if not isinstance(expected_native_type, type):
+            raise DagMLNativeCoverageError("configured Dag-ML native facade does not expose TrainingResult")
+
+        training_result = getattr(estimator, "training_result_", None)
+        if type(training_result) is not expected_type:
+            raise DagMLNativeCoverageError("strict Methods execution did not retain the exact Dag-ML TrainingResult facade")
+        if getattr(training_result, "is_attached", None) is not True:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult must be attached when its live witness is created")
+        native_training_result = getattr(training_result, "_native", None)
+        if type(native_training_result) is not expected_native_type:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult did not retain the exact native TrainingResult")
+        if getattr(native_training_result, "is_attached", None) is not True:
+            raise DagMLNativeCoverageError("strict Methods native TrainingResult must be attached when its live witness is created")
+        outcome_fingerprint = getattr(training_result, "outcome_fingerprint", None)
+        if not isinstance(outcome_fingerprint, str) or not outcome_fingerprint:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult omitted its outcome fingerprint")
+        if re.fullmatch(r"[0-9a-f]{64}", outcome_fingerprint) is None:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult outcome fingerprint must be canonical SHA-256")
+        if getattr(native_training_result, "outcome_fingerprint", None) != outcome_fingerprint:
+            raise DagMLNativeCoverageError("strict Methods native TrainingResult fingerprint does not match its facade")
+
+        result_outcome = getattr(training_result, "outcome", None)
+        result_outcome_to_dict = getattr(result_outcome, "to_dict", None)
+        if callable(result_outcome_to_dict):
+            result_outcome = result_outcome_to_dict()
+        if not isinstance(result_outcome, dict) or result_outcome.get("outcome_fingerprint") != outcome_fingerprint:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult outcome does not match its canonical fingerprint")
+
+        outcome = getattr(estimator, "training_outcome_", None)
+        to_dict = getattr(outcome, "to_dict", None)
+        if callable(to_dict):
+            outcome = to_dict()
+        if not isinstance(outcome, dict) or outcome.get("outcome_fingerprint") != outcome_fingerprint:
+            raise DagMLNativeCoverageError("strict Methods TrainingResult fingerprint does not match the finalized training outcome")
+
+        return cls(
+            estimator,
+            training_result,
+            native_training_result,
+            NativeMethodsExecutionClaim(
+                schema_version=1,
+                execution_entrypoint="dag_ml.execute_methods_training",
+                execution_mode="methods_callback_free",
+                outcome_fingerprint=outcome_fingerprint,
+                methods_library_mode="explicit_absolute",
+                portable_artifacts_required=True,
+            ),
+            _factory_capability=_WITNESS_FACTORY_CAPABILITY,
+        )
+
+    def _claim_for_estimator(self, estimator: Any) -> NativeMethodsExecutionClaim:
+        """Return the claim only for the exact estimator this witness owns."""
+
+        with self._lock:
+            training_result = self._training_result
+            native_training_result = self._native_training_result
+            if self._factory_capability is not _WITNESS_FACTORY_CAPABILITY:
+                raise DagMLNativeCoverageError("the live Methods witness was not created by the internal factory")
+            if estimator is not self._estimator:
+                raise DagMLNativeCoverageError("the live Methods witness does not own this estimator")
+            if (
+                training_result is None
+                or native_training_result is None
+                or getattr(training_result, "is_attached", None) is not True
+                or getattr(native_training_result, "is_attached", None) is not True
+            ):
+                raise DagMLNativeCoverageError("the live Methods witness is no longer attached")
+            if getattr(self._estimator, "training_result_", None) is not training_result:
+                raise DagMLNativeCoverageError("the live Methods witness no longer owns the estimator TrainingResult")
+            if getattr(training_result, "_native", None) is not native_training_result:
+                raise DagMLNativeCoverageError("the live Methods witness no longer owns the exact native TrainingResult")
+            if getattr(training_result, "outcome_fingerprint", None) != self._claim.outcome_fingerprint:
+                raise DagMLNativeCoverageError("the live Methods witness no longer matches its outcome fingerprint")
+            if getattr(native_training_result, "outcome_fingerprint", None) != self._claim.outcome_fingerprint:
+                raise DagMLNativeCoverageError("the live Methods witness native result no longer matches its outcome fingerprint")
+            return self._claim
+
+    @property
+    def claim(self) -> NativeMethodsExecutionClaim:
+        """The immutable, audit-only local execution claim."""
+
+        return self._claim_for_estimator(self._estimator)
+
+    def _is_live_for_estimator(self, estimator: Any) -> bool:
+        """Whether this witness is still live for one exact estimator."""
+
+        try:
+            self._claim_for_estimator(estimator)
+        except DagMLNativeCoverageError:
+            return False
+        return True
+
+    @property
+    def is_live(self) -> bool:
+        """Whether the attached Dag-ML result is still held by this witness."""
+
+        return self._is_live_for_estimator(self._estimator)
+
+    def detach(self) -> bool:
+        """Detach the exact retained Dag-ML result once and release it.
+
+        Portable outcome/package state is preserved by Dag-ML's own detach
+        contract.  Repeated calls are harmless and return ``False``.
+        """
+
+        with self._lock:
+            training_result = self._training_result
+            if training_result is None:
+                return False
+            native_training_result = self._native_training_result
+            if native_training_result is None:
+                raise DagMLNativeCoverageError("the live Methods witness lost its native TrainingResult")
+            if getattr(training_result, "_native", None) is not native_training_result:
+                raise DagMLNativeCoverageError("the live Methods witness no longer owns the exact native TrainingResult")
+            if getattr(training_result, "is_attached", None) is False and getattr(native_training_result, "is_attached", None) is False:
+                self._training_result = None
+                self._native_training_result = None
+                return False
+            if getattr(training_result, "is_attached", None) is not True or getattr(native_training_result, "is_attached", None) is not True:
+                raise DagMLNativeCoverageError("strict Methods TrainingResult attachment state is inconsistent")
+            detach = getattr(training_result, "detach", None)
+            if not callable(detach):
+                raise DagMLNativeCoverageError("strict Methods TrainingResult does not expose detach()")
+            detached = detach()
+            if not isinstance(detached, bool):
+                raise DagMLNativeCoverageError("strict Methods TrainingResult detach() must return bool")
+            if detached:
+                if getattr(training_result, "is_attached", None) is not False or getattr(native_training_result, "is_attached", None) is not False:
+                    raise DagMLNativeCoverageError("strict Methods TrainingResult detach() did not release its exact native result")
+                self._training_result = None
+                self._native_training_result = None
+                return True
+            if getattr(training_result, "is_attached", None) is False and getattr(native_training_result, "is_attached", None) is False:
+                self._training_result = None
+                self._native_training_result = None
+                return False
+            raise DagMLNativeCoverageError("strict Methods TrainingResult detach() reported False while still attached")
+
+    close = detach
+
+    def __copy__(self) -> _LiveMethodsWitness:
+        raise TypeError("a live Methods witness cannot be copied")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> _LiveMethodsWitness:
+        _ = memo
+        raise TypeError("a live Methods witness cannot be deep-copied")
+
+    def __reduce__(self) -> Any:
+        raise TypeError("a live Methods witness cannot be serialized")
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> Any:
+        _ = protocol
+        raise TypeError("a live Methods witness cannot be serialized")
+
+
+__all__ = ["NativeMethodsExecutionClaim"]

--- a/nirs4all/api/native_witness.py
+++ b/nirs4all/api/native_witness.py
@@ -8,8 +8,9 @@ facade only long enough to make the local execution boundary observable and to
 release its process-local resources deterministically.
 
 The durable evidence remains the signed outcome and portable package owned by
-Dag-ML.  The internal live witness is deliberately neither serializable nor
-copyable, and is invalid after ``detach()``/``close()``.
+Dag-ML.  The internal live witness relies only on Dag-ML's public Python
+lifecycle surface, is deliberately neither serializable nor copyable, and is
+invalid after ``detach()``/``close()``.
 """
 
 from __future__ import annotations
@@ -69,7 +70,6 @@ class _LiveMethodsWitness:
         "_estimator",
         "_factory_capability",
         "_lock",
-        "_native_training_result",
         "_training_result",
     )
 
@@ -77,7 +77,6 @@ class _LiveMethodsWitness:
         self,
         estimator: Any,
         training_result: Any,
-        native_training_result: Any,
         claim: NativeMethodsExecutionClaim,
         *,
         _factory_capability: object,
@@ -86,7 +85,6 @@ class _LiveMethodsWitness:
             raise TypeError("live Methods witnesses can only be created by the verified internal factory")
         self._estimator = estimator
         self._training_result: Any | None = training_result
-        self._native_training_result: Any | None = native_training_result
         self._claim = claim
         self._factory_capability = _factory_capability
         self._lock = RLock()
@@ -131,32 +129,16 @@ class _LiveMethodsWitness:
         expected_type = getattr(dag_ml, "TrainingResult", None)
         if not isinstance(expected_type, type):
             raise DagMLNativeCoverageError("configured Dag-ML facade does not expose TrainingResult")
-        try:
-            dag_ml_native = importlib.import_module("dag_ml._dag_ml")
-        except ImportError as error:  # pragma: no cover - dependency failure is environment-specific
-            raise DagMLNativeCoverageError("strict Methods witness cannot import the configured Dag-ML native facade") from error
-        expected_native_type = getattr(dag_ml_native, "TrainingResult", None)
-        if not isinstance(expected_native_type, type):
-            raise DagMLNativeCoverageError("configured Dag-ML native facade does not expose TrainingResult")
-
         training_result = getattr(estimator, "training_result_", None)
         if type(training_result) is not expected_type:
             raise DagMLNativeCoverageError("strict Methods execution did not retain the exact Dag-ML TrainingResult facade")
         if getattr(training_result, "is_attached", None) is not True:
             raise DagMLNativeCoverageError("strict Methods TrainingResult must be attached when its live witness is created")
-        native_training_result = getattr(training_result, "_native", None)
-        if type(native_training_result) is not expected_native_type:
-            raise DagMLNativeCoverageError("strict Methods TrainingResult did not retain the exact native TrainingResult")
-        if getattr(native_training_result, "is_attached", None) is not True:
-            raise DagMLNativeCoverageError("strict Methods native TrainingResult must be attached when its live witness is created")
         outcome_fingerprint = getattr(training_result, "outcome_fingerprint", None)
         if not isinstance(outcome_fingerprint, str) or not outcome_fingerprint:
             raise DagMLNativeCoverageError("strict Methods TrainingResult omitted its outcome fingerprint")
         if re.fullmatch(r"[0-9a-f]{64}", outcome_fingerprint) is None:
             raise DagMLNativeCoverageError("strict Methods TrainingResult outcome fingerprint must be canonical SHA-256")
-        if getattr(native_training_result, "outcome_fingerprint", None) != outcome_fingerprint:
-            raise DagMLNativeCoverageError("strict Methods native TrainingResult fingerprint does not match its facade")
-
         result_outcome = getattr(training_result, "outcome", None)
         result_outcome_to_dict = getattr(result_outcome, "to_dict", None)
         if callable(result_outcome_to_dict):
@@ -174,7 +156,6 @@ class _LiveMethodsWitness:
         return cls(
             estimator,
             training_result,
-            native_training_result,
             NativeMethodsExecutionClaim(
                 schema_version=1,
                 execution_entrypoint="dag_ml.execute_methods_training",
@@ -191,26 +172,19 @@ class _LiveMethodsWitness:
 
         with self._lock:
             training_result = self._training_result
-            native_training_result = self._native_training_result
             if self._factory_capability is not _WITNESS_FACTORY_CAPABILITY:
                 raise DagMLNativeCoverageError("the live Methods witness was not created by the internal factory")
             if estimator is not self._estimator:
                 raise DagMLNativeCoverageError("the live Methods witness does not own this estimator")
             if (
                 training_result is None
-                or native_training_result is None
                 or getattr(training_result, "is_attached", None) is not True
-                or getattr(native_training_result, "is_attached", None) is not True
             ):
                 raise DagMLNativeCoverageError("the live Methods witness is no longer attached")
             if getattr(self._estimator, "training_result_", None) is not training_result:
                 raise DagMLNativeCoverageError("the live Methods witness no longer owns the estimator TrainingResult")
-            if getattr(training_result, "_native", None) is not native_training_result:
-                raise DagMLNativeCoverageError("the live Methods witness no longer owns the exact native TrainingResult")
             if getattr(training_result, "outcome_fingerprint", None) != self._claim.outcome_fingerprint:
                 raise DagMLNativeCoverageError("the live Methods witness no longer matches its outcome fingerprint")
-            if getattr(native_training_result, "outcome_fingerprint", None) != self._claim.outcome_fingerprint:
-                raise DagMLNativeCoverageError("the live Methods witness native result no longer matches its outcome fingerprint")
             return self._claim
 
     @property
@@ -245,16 +219,10 @@ class _LiveMethodsWitness:
             training_result = self._training_result
             if training_result is None:
                 return False
-            native_training_result = self._native_training_result
-            if native_training_result is None:
-                raise DagMLNativeCoverageError("the live Methods witness lost its native TrainingResult")
-            if getattr(training_result, "_native", None) is not native_training_result:
-                raise DagMLNativeCoverageError("the live Methods witness no longer owns the exact native TrainingResult")
-            if getattr(training_result, "is_attached", None) is False and getattr(native_training_result, "is_attached", None) is False:
+            if getattr(training_result, "is_attached", None) is False:
                 self._training_result = None
-                self._native_training_result = None
                 return False
-            if getattr(training_result, "is_attached", None) is not True or getattr(native_training_result, "is_attached", None) is not True:
+            if getattr(training_result, "is_attached", None) is not True:
                 raise DagMLNativeCoverageError("strict Methods TrainingResult attachment state is inconsistent")
             detach = getattr(training_result, "detach", None)
             if not callable(detach):
@@ -263,14 +231,12 @@ class _LiveMethodsWitness:
             if not isinstance(detached, bool):
                 raise DagMLNativeCoverageError("strict Methods TrainingResult detach() must return bool")
             if detached:
-                if getattr(training_result, "is_attached", None) is not False or getattr(native_training_result, "is_attached", None) is not False:
-                    raise DagMLNativeCoverageError("strict Methods TrainingResult detach() did not release its exact native result")
+                if getattr(training_result, "is_attached", None) is not False:
+                    raise DagMLNativeCoverageError("strict Methods TrainingResult detach() did not release its facade")
                 self._training_result = None
-                self._native_training_result = None
                 return True
-            if getattr(training_result, "is_attached", None) is False and getattr(native_training_result, "is_attached", None) is False:
+            if getattr(training_result, "is_attached", None) is False:
                 self._training_result = None
-                self._native_training_result = None
                 return False
             raise DagMLNativeCoverageError("strict Methods TrainingResult detach() reported False while still attached")
 

--- a/nirs4all/pipeline/dagml/estimator.py
+++ b/nirs4all/pipeline/dagml/estimator.py
@@ -8,6 +8,7 @@ replay once the nirs4all→DAG-ML contract compiler is supplied.
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol, cast
@@ -198,20 +199,28 @@ class DagMLPipelineEstimator(BaseEstimator):
             )
 
         self.training_result_ = training_result
-        # Retain the exact signed contracts that produced this attached native
-        # result.  Full refit may use them only as parent provenance evidence;
-        # it must never rebuild a recipe from Python or re-enter CV/SELECT.
-        self.native_training_execution_ = execution
-        self.training_outcome_ = getattr(training_result, "outcome", None)
-        self.outputs_ = list(getattr(training_result, "outputs", []) or [])
-        self.output_binding_ = self._select_output_binding(self.outputs_)
-        self.predictor_package_ = self._export_predictor_package(
-            training_result,
-            execution,
-        )
-        self.fit_identity_frame_ = identity_frame
-        self.n_features_in_ = self._infer_n_features(X)
-        return self
+        try:
+            # Retain the exact signed contracts that produced this attached native
+            # result.  Full refit may use them only as parent provenance evidence;
+            # it must never rebuild a recipe from Python or re-enter CV/SELECT.
+            self.native_training_execution_ = execution
+            self.training_outcome_ = getattr(training_result, "outcome", None)
+            self.outputs_ = list(getattr(training_result, "outputs", []) or [])
+            self.output_binding_ = self._select_output_binding(self.outputs_)
+            self.predictor_package_ = self._export_predictor_package(
+                training_result,
+                execution,
+            )
+            self.fit_identity_frame_ = identity_frame
+            self.n_features_in_ = self._infer_n_features(X)
+            return self
+        except BaseException:
+            # Once native execution returned an attached TrainingResult, every
+            # later projection/export failure must release its process-local
+            # resources before propagating the original error.
+            with suppress(BaseException):
+                self.detach_native_training_result()
+            raise
 
     def predict(self, X: Any) -> np.ndarray:
         """Predict via native loaded-package replay.
@@ -397,6 +406,32 @@ class DagMLPipelineEstimator(BaseEstimator):
         finally:
             if replay.cleanup is not None:
                 replay.cleanup()
+
+    def detach_native_training_result(self) -> bool:
+        """Release attached DAG-ML execution resources without losing portable state.
+
+        ``fit_native_pipeline`` is public and returns this estimator directly,
+        so callers need a deterministic lifecycle operation independent of the
+        higher-level :class:`~nirs4all.api.native_result.NativeMethodsRunResult`.
+        DAG-ML's ``TrainingResult.detach()`` preserves the signed outcome and
+        portable predictor package used by later native replay/export.
+
+        Returns:
+            ``True`` only when this call performed the attached-to-detached
+            transition. Repeated calls are harmless and return ``False``.
+        """
+
+        check_is_fitted(self, attributes=["training_result_"])
+        training_result = self.training_result_
+        if getattr(training_result, "is_attached", False) is not True:
+            return False
+        detach = getattr(training_result, "detach", None)
+        if not callable(detach):
+            raise DagMLNativeCoverageError("DAG-ML training result does not expose detach()")
+        detached = detach()
+        if not isinstance(detached, bool):
+            raise DagMLNativeCoverageError("DAG-ML training result detach() must return bool")
+        return detached
 
     def export_native_archive(
         self,

--- a/tests/integration/api/test_native_methods_witness.py
+++ b/tests/integration/api/test_native_methods_witness.py
@@ -3,38 +3,51 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import numpy as np
 import pytest
 from sklearn.cross_decomposition import PLSRegression
 from sklearn.model_selection import KFold
 
+from nirs4all.pipeline.dagml.native_archive_replay import validate_methods_archive_v2
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
 
 _REQUIRE_N4M = os.environ.get("NIRS4ALL_REQUIRE_N4M") == "1"
 
-try:
-    import dag_ml
-    import n4m
-except Exception as error:  # pragma: no cover - exact loader failures depend on the host wheel
-    message = f"installed Methods witness runtime is unavailable: {error}"
-    if _REQUIRE_N4M:
-        pytest.fail(message, pytrace=True)
-    pytest.skip(message, allow_module_level=True)
-
-if not callable(getattr(dag_ml, "execute_methods_training", None)) or not isinstance(getattr(dag_ml, "TrainingResult", None), type):
-    message = "installed dag-ml wheel does not expose the strict Methods TrainingResult surface"
-    if _REQUIRE_N4M:
-        pytest.fail(message, pytrace=True)
-    pytest.skip(message, allow_module_level=True)
-
 pytestmark = pytest.mark.methods
 
 
-def test_installed_methods_witness_claim_closes_through_the_public_dagml_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+def _require_installed_runtime() -> tuple[object, object]:
+    """Import the published runtime only after the test removes library overrides."""
+
+    try:
+        import dag_ml
+        import n4m
+    except Exception as error:  # pragma: no cover - exact loader failures depend on the host wheel
+        message = f"installed Methods witness runtime is unavailable: {error}"
+        if _REQUIRE_N4M:
+            pytest.fail(message, pytrace=True)
+        pytest.skip(message)
+    if not callable(getattr(dag_ml, "execute_methods_training", None)) or not isinstance(
+        getattr(dag_ml, "TrainingResult", None), type
+    ):
+        message = "installed dag-ml wheel does not expose the strict Methods TrainingResult surface"
+        if _REQUIRE_N4M:
+            pytest.fail(message, pytrace=True)
+        pytest.skip(message)
+    return dag_ml, n4m
+
+
+def test_installed_methods_witness_claim_closes_through_the_public_dagml_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """The public native route yields a live claim and closes the real wheel facade."""
 
     monkeypatch.delenv("N4M_LIB_PATH", raising=False)
+    assert "N4M_LIB_PATH" not in os.environ
+    dag_ml, n4m = _require_installed_runtime()
     assert callable(n4m.library_path)
 
     import nirs4all
@@ -72,3 +85,7 @@ def test_installed_methods_witness_claim_closes_through_the_public_dagml_lifecyc
     with pytest.raises(DagMLNativeCoverageError, match="no longer attached"):
         _ = result.native_execution_claim
     assert estimator.detach_native_training_result() is False
+
+    archive_path = result.export(tmp_path / "native-methods-witness.n4a")
+    assert archive_path.is_file()
+    validate_methods_archive_v2(archive_path)

--- a/tests/integration/api/test_native_methods_witness.py
+++ b/tests/integration/api/test_native_methods_witness.py
@@ -1,0 +1,74 @@
+"""Installed-wheel lifecycle proof for the strict native Methods witness."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.model_selection import KFold
+
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+_REQUIRE_N4M = os.environ.get("NIRS4ALL_REQUIRE_N4M") == "1"
+
+try:
+    import dag_ml
+    import n4m
+except Exception as error:  # pragma: no cover - exact loader failures depend on the host wheel
+    message = f"installed Methods witness runtime is unavailable: {error}"
+    if _REQUIRE_N4M:
+        pytest.fail(message, pytrace=True)
+    pytest.skip(message, allow_module_level=True)
+
+if not callable(getattr(dag_ml, "execute_methods_training", None)) or not isinstance(getattr(dag_ml, "TrainingResult", None), type):
+    message = "installed dag-ml wheel does not expose the strict Methods TrainingResult surface"
+    if _REQUIRE_N4M:
+        pytest.fail(message, pytrace=True)
+    pytest.skip(message, allow_module_level=True)
+
+pytestmark = pytest.mark.methods
+
+
+def test_installed_methods_witness_claim_closes_through_the_public_dagml_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The public native route yields a live claim and closes the real wheel facade."""
+
+    monkeypatch.delenv("N4M_LIB_PATH", raising=False)
+    assert callable(n4m.library_path)
+
+    import nirs4all
+
+    features = np.asarray(
+        [[0.0, 1.0], [1.0, 0.0], [2.0, 1.0], [3.0, 0.0], [4.0, 1.0], [5.0, 0.0]],
+        dtype=float,
+    )
+    targets = np.arange(6.0, dtype=float)
+    result = nirs4all.run(
+        [KFold(n_splits=3), {"model": PLSRegression(n_components=1)}],
+        {"X": features, "y": targets, "sample_ids": [f"fit-{index}" for index in range(len(features))]},
+        engine="native",
+        save_charts=False,
+    )
+
+    assert type(result) is nirs4all.NativeMethodsRunResult
+    estimator = result.native_estimator
+    training_result = estimator.training_result_
+    assert type(training_result) is dag_ml.TrainingResult
+    assert training_result.is_attached is True
+    claim = result.native_execution_claim
+    assert claim.execution_entrypoint == "dag_ml.execute_methods_training"
+    assert claim.execution_mode == "methods_callback_free"
+    assert claim.methods_library_mode == "explicit_absolute"
+    assert claim.portable_artifacts_required is True
+    assert claim.outcome_fingerprint == training_result.outcome_fingerprint
+    assert claim.outcome_fingerprint == training_result.outcome.to_dict()["outcome_fingerprint"]
+    assert result.native_execution_is_live is True
+
+    result.close()
+
+    assert training_result.is_attached is False
+    assert result.native_execution_is_live is False
+    with pytest.raises(DagMLNativeCoverageError, match="no longer attached"):
+        _ = result.native_execution_claim
+    assert estimator.detach_native_training_result() is False

--- a/tests/unit/api/test_engine_transition.py
+++ b/tests/unit/api/test_engine_transition.py
@@ -11,10 +11,12 @@ from sklearn.cross_decomposition import PLSRegression
 from sklearn.model_selection import KFold
 
 import nirs4all
+from nirs4all.api import native_result
 from nirs4all.api.explain import explain
 from nirs4all.api.native_refit_result import NativeMethodsRefitResult
 from nirs4all.api.native_result import NativeMethodsRunResult
 from nirs4all.api.native_retrain_lineage import NativeRetrainLineage
+from nirs4all.api.native_witness import NativeMethodsExecutionClaim
 from nirs4all.api.predict import predict
 from nirs4all.api.retrain import retrain
 from nirs4all.api.run import run
@@ -23,6 +25,46 @@ from nirs4all.pipeline.dagml.native_archive_replay import (
     NativeArchivePrediction,
 )
 from nirs4all.pipeline.engine import require_legacy_engine
+
+
+class _TestWitness:
+    """Test-only witness substituted at mocked fit boundaries."""
+
+    def __init__(self, estimator: object, outcome_fingerprint: str) -> None:
+        self._estimator = estimator
+        self._claim = NativeMethodsExecutionClaim(
+            schema_version=1,
+            execution_entrypoint="dag_ml.execute_methods_training",
+            execution_mode="methods_callback_free",
+            outcome_fingerprint=outcome_fingerprint,
+            methods_library_mode="explicit_absolute",
+            portable_artifacts_required=True,
+        )
+        self._live = True
+
+    @classmethod
+    def from_estimator(cls, estimator):  # noqa: ANN001
+        return cls(estimator, estimator.training_outcome_["outcome_fingerprint"])
+
+    def _claim_for_estimator(self, estimator: object) -> NativeMethodsExecutionClaim:
+        if not self._live or estimator is not self._estimator:
+            raise RuntimeError("test witness no longer owns the estimator")
+        return self._claim
+
+    def _is_live_for_estimator(self, estimator: object) -> bool:
+        return self._live and estimator is self._estimator
+
+    def detach(self) -> bool:
+        if not self._live:
+            return False
+        self._live = False
+        return True
+
+
+def _patch_live_witness(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Supply an explicit attached witness for mocked strict-fit boundaries."""
+
+    monkeypatch.setattr(native_result, "_LiveMethodsWitness", _TestWitness)
 
 
 def test_require_legacy_engine_accepts_legacy() -> None:
@@ -85,6 +127,7 @@ def test_run_native_executes_the_methods_subset_without_constructing_a_legacy_ru
         return Estimator()
 
     monkeypatch.setattr("nirs4all.api.native_training.fit_native_pipeline", native_fit)
+    _patch_live_witness(monkeypatch)
 
     result = run(
         [{"split": "stub"}, {"model": "stub"}],
@@ -185,6 +228,7 @@ def test_run_native_attaches_identity_bound_conformal_calibration_without_legacy
         )
 
     monkeypatch.setattr("nirs4all.api.native_training.fit_native_pipeline", lambda *_args, **_kwargs: estimator)
+    _patch_live_witness(monkeypatch)
     monkeypatch.setattr("nirs4all.api.native_training.compile_methods_conformal_calibration_replay", compile_calibration)
     monkeypatch.setattr("nirs4all.api.native_training.validate_native_methods_package", lambda package: package)
     monkeypatch.setattr(
@@ -298,6 +342,7 @@ def test_run_native_routes_strict_methods_hpo_through_the_native_compiler(
         return Estimator()
 
     monkeypatch.setattr("nirs4all.api.native_training.fit_native_pipeline", native_fit)
+    _patch_live_witness(monkeypatch)
     result = run(
         [{"split": "stub"}, {"model": "stub"}],
         {"X": np.asarray([[1.0], [2.0]]), "y": np.asarray([1.0, 2.0]), "sample_ids": ["s1", "s2"]},

--- a/tests/unit/api/test_native_result.py
+++ b/tests/unit/api/test_native_result.py
@@ -2,9 +2,55 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
+from nirs4all.api import native_result
 from nirs4all.api.native_result import NativeMethodsRunResult
+from nirs4all.api.native_witness import NativeMethodsExecutionClaim
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+
+class _TestWitness:
+    """Minimal test double for result projection tests, never production evidence."""
+
+    def __init__(self, estimator: object) -> None:
+        self._estimator = estimator
+        self._live = True
+        self._claim = NativeMethodsExecutionClaim(
+            schema_version=1,
+            execution_entrypoint="dag_ml.execute_methods_training",
+            execution_mode="methods_callback_free",
+            outcome_fingerprint="a" * 64,
+            methods_library_mode="explicit_absolute",
+            portable_artifacts_required=True,
+        )
+
+    @classmethod
+    def from_estimator(cls, estimator: object) -> _TestWitness:
+        return cls(estimator)
+
+    def _claim_for_estimator(self, estimator: object) -> NativeMethodsExecutionClaim:
+        if not self._live:
+            raise DagMLNativeCoverageError("the live Methods witness is no longer attached")
+        if estimator is not self._estimator:
+            raise DagMLNativeCoverageError("the live Methods witness does not own this estimator")
+        return self._claim
+
+    def _is_live_for_estimator(self, estimator: object) -> bool:
+        return self._live and estimator is self._estimator
+
+    def detach(self) -> bool:
+        if not self._live:
+            return False
+        self._live = False
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _patch_witness_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(native_result, "_LiveMethodsWitness", _TestWitness)
 
 
 class _Estimator:
@@ -82,8 +128,9 @@ def test_native_methods_result_projects_native_scores_and_exports_archive_v2(tmp
     ],
 )
 def test_native_methods_result_refuses_legacy_export_routes(tmp_path, kwargs, message) -> None:  # noqa: ANN001
+    estimator = _Estimator()
     result = NativeMethodsRunResult.from_estimator(
-        _Estimator(),  # type: ignore[arg-type]
+        estimator,  # type: ignore[arg-type]
         dataset_name="native",
         model_name="PLSRegression",
     )

--- a/tests/unit/api/test_native_training.py
+++ b/tests/unit/api/test_native_training.py
@@ -12,6 +12,7 @@ from nirs4all.api.native_retrain_lineage import NativeRetrainLineage
 from nirs4all.api.native_training import fit_native_pipeline
 from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
 from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+from nirs4all.pipeline.dagml.raw_replay_lowerer import RawArrayMethodsReplayError
 
 
 @pytest.fixture
@@ -24,6 +25,10 @@ def native_library(tmp_path) -> str:
 
 
 class _TrainingResult:
+    def __init__(self) -> None:
+        self.is_attached = True
+        self.detach_calls = 0
+
     outcome = {"native": True}
     outputs = [
         {
@@ -44,6 +49,13 @@ class _TrainingResult:
                 ],
             },
         }
+
+    def detach(self) -> bool:
+        self.detach_calls += 1
+        if not self.is_attached:
+            return False
+        self.is_attached = False
+        return True
 
 
 class _Client:
@@ -68,6 +80,67 @@ class _Client:
                 }
             ]
         }
+
+
+def test_fit_native_pipeline_uses_the_callback_free_methods_client_when_contracts_require_it(
+    monkeypatch: pytest.MonkeyPatch, native_library: str
+) -> None:
+    """The strict lane must not silently select the generic callback client."""
+
+    from nirs4all.pipeline.dagml.estimator import DagMLTrainingExecution
+
+    class StrictTrainingResult(_TrainingResult):
+        def export_portable_predictor_package(self, package_id: str, **_kwargs: Any) -> dict[str, Any]:
+            return super().export_portable_predictor_package(package_id)
+
+    class StrictClient:
+        def __init__(self) -> None:
+            self.methods_calls: list[tuple[tuple[Any, ...], dict[str, Any]]] = []
+
+        def execute_training(self, *_args: Any, **_kwargs: Any) -> StrictTrainingResult:
+            raise AssertionError("strict Methods fit selected generic execute_training")
+
+        def execute_methods_training(self, *args: Any, **kwargs: Any) -> StrictTrainingResult:
+            self.methods_calls.append((args, kwargs))
+            return StrictTrainingResult()
+
+    execution = DagMLTrainingExecution(
+        request={"request": "methods"},
+        data_envelopes={"data:train": {}},
+        relations={"records": []},
+        training_influence={"entries": []},
+        op_callback=None,
+        outcome_id="outcome:methods",
+        run_id="run:methods",
+        bundle_id="bundle:methods",
+        methods_inputs={"data:train": {"sample_ids": ["fit-a", "fit-b"]}},
+        methods_library_path=native_library,
+    )
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        lambda *_args, **_kwargs: execution,
+    )
+    client = StrictClient()
+
+    fit_native_pipeline(
+        [{"split": "stub"}, {"model": "stub"}],
+        np.asarray([[1.0], [2.0]]),
+        np.asarray([1.0, 2.0]),
+        sample_ids=["fit-a", "fit-b"],
+        native_client=client,
+        methods_library_path=native_library,
+    )
+
+    assert len(client.methods_calls) == 1
+    args, kwargs = client.methods_calls[0]
+    assert args[:5] == (
+        {"request": "methods"},
+        {"data:train": {}},
+        {"records": []},
+        {"entries": []},
+        {"data:train": {"sample_ids": ["fit-a", "fit-b"]}},
+    )
+    assert kwargs["methods_library_path"] == native_library
 
 
 def test_fit_native_pipeline_is_a_public_strict_native_composition(
@@ -119,6 +192,100 @@ def test_fit_native_pipeline_is_a_public_strict_native_composition(
     assert estimator.prediction_compiler is not None
     assert estimator.prediction_identity_decoder is not None
     assert nirs4all.fit_native_pipeline is fit_native_pipeline
+
+
+def test_estimator_fit_detaches_an_attached_result_when_post_execution_projection_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No attached Dag-ML result may escape a failed post-execution projection."""
+
+    from nirs4all.pipeline.dagml.estimator import DagMLTrainingExecution
+
+    class Compiler:
+        def compile_fit(self, _estimator, _X, _y, **_kwargs):  # noqa: ANN001
+            return DagMLTrainingExecution(
+                request={},
+                data_envelopes={},
+                relations={},
+                training_influence={},
+                op_callback=lambda task: task,
+                outcome_id="o",
+                run_id="r",
+                bundle_id="b",
+            )
+
+    class Client:
+        def __init__(self) -> None:
+            self.result = _TrainingResult()
+
+        def execute_training(self, *_args: Any, **_kwargs: Any) -> _TrainingResult:
+            return self.result
+
+    client = Client()
+    estimator = DagMLPipelineEstimator(
+        training_compiler=Compiler(),
+        native_client=client,
+    )
+    monkeypatch.setattr(
+        estimator,
+        "_select_output_binding",
+        lambda _outputs: (_ for _ in ()).throw(RuntimeError("projection failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="projection failed"):
+        estimator.fit(
+            np.asarray([[1.0], [2.0]]),
+            np.asarray([1.0, 2.0]),
+        )
+    assert client.result.detach_calls == 1
+    assert not client.result.is_attached
+
+
+def test_fit_native_pipeline_detaches_when_post_fit_package_validation_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    native_library: str,
+) -> None:
+    """Package validation errors must not retain native handles after fit returns."""
+
+    class Client(_Client):
+        def __init__(self) -> None:
+            super().__init__()
+            self.result = _TrainingResult()
+
+        def execute_training(self, *args: Any, **kwargs: Any) -> _TrainingResult:
+            self.calls.append((args, kwargs))
+            return self.result
+
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.RawArrayDagMLTrainingCompiler.compile_fit",
+        lambda *_args, **_kwargs: __import__("nirs4all.pipeline.dagml.estimator", fromlist=["DagMLTrainingExecution"]).DagMLTrainingExecution(
+            request={},
+            data_envelopes={},
+            relations={},
+            training_influence={},
+            op_callback=lambda task: task,
+            outcome_id="o",
+            run_id="r",
+            bundle_id="b",
+        ),
+    )
+    monkeypatch.setattr(
+        "nirs4all.api.native_training.validate_native_methods_package",
+        lambda _package: (_ for _ in ()).throw(RawArrayMethodsReplayError("invalid package")),
+    )
+    client = Client()
+
+    with pytest.raises(DagMLNativeCoverageError, match="replayable portable Methods"):
+        fit_native_pipeline(
+            [{"split": "stub"}, {"model": "stub"}],
+            np.asarray([[1.0], [2.0]]),
+            np.asarray([1.0, 2.0]),
+            sample_ids=["fit-a", "fit-b"],
+            native_client=client,
+            methods_library_path=native_library,
+        )
+    assert client.result.detach_calls == 1
+    assert not client.result.is_attached
 
 
 def test_fit_native_pipeline_seals_internal_retrain_lineage_into_compiler_diagnostics(

--- a/tests/unit/api/test_native_witness.py
+++ b/tests/unit/api/test_native_witness.py
@@ -27,7 +27,7 @@ class _Outcome:
         return dict(self._document)
 
 
-class _NativeTrainingResult:
+class _TrainingResult:
     def __init__(self, document: dict[str, object]) -> None:
         self._document = document
         self.is_attached = True
@@ -51,31 +51,6 @@ class _NativeTrainingResult:
             return False
         self.is_attached = False
         return True
-
-
-class _TrainingResult:
-    def __init__(self, document: dict[str, object]) -> None:
-        self._document = document
-        self._native = _NativeTrainingResult(document)
-
-    @property
-    def is_attached(self) -> bool:
-        return self._native.is_attached
-
-    @property
-    def detach_calls(self) -> int:
-        return self._native.detach_calls
-
-    @property
-    def outcome_fingerprint(self) -> str:
-        return self._native.outcome_fingerprint
-
-    @property
-    def outcome(self) -> _Outcome:
-        return _Outcome(self._document)
-
-    def detach(self) -> bool:
-        return self._native.detach()
 
 
 def _score_set() -> dict[str, object]:
@@ -102,11 +77,7 @@ def _score_set() -> dict[str, object]:
 def _install_dagml_facade(monkeypatch: pytest.MonkeyPatch) -> None:
     facade = ModuleType("dag_ml")
     facade.TrainingResult = _TrainingResult
-    native = ModuleType("dag_ml._dag_ml")
-    native.TrainingResult = _NativeTrainingResult
-    facade._dag_ml = native  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "dag_ml", facade)
-    monkeypatch.setitem(sys.modules, "dag_ml._dag_ml", native)
 
 
 def _estimator(tmp_path: Path, *, callback: object | None = None) -> tuple[SimpleNamespace, _TrainingResult]:
@@ -186,13 +157,12 @@ def test_live_witness_constructor_is_internal_and_cannot_forge_a_claim(
         _LiveMethodsWitness(
             estimator,
             training_result,
-            training_result._native,
             claim,
             _factory_capability=object(),
         )
 
 
-def test_native_result_factory_does_not_accept_an_injected_witness_and_detects_raw_swap(
+def test_native_result_factory_does_not_accept_an_injected_witness_and_detects_facade_swap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -208,8 +178,8 @@ def test_native_result_factory_does_not_accept_an_injected_witness_and_detects_r
             live_witness=witness,
         )
 
-    training_result_a._native = _NativeTrainingResult(dict(training_result_a._document))
-    with pytest.raises(DagMLNativeCoverageError, match="exact native TrainingResult"):
+    estimator_a.training_result_ = _TrainingResult(dict(training_result_a._document))
+    with pytest.raises(DagMLNativeCoverageError, match="no longer owns the estimator TrainingResult"):
         _ = witness.claim
     assert not witness.is_live
 
@@ -221,7 +191,7 @@ def test_live_witness_detach_failure_keeps_ownership_for_retry(
     _install_dagml_facade(monkeypatch)
     estimator, training_result = _estimator(tmp_path)
     witness = _LiveMethodsWitness.from_estimator(estimator)  # type: ignore[arg-type]
-    training_result._native.raise_once_on_detach = True
+    training_result.raise_once_on_detach = True
 
     with pytest.raises(RuntimeError, match="failed once"):
         witness.detach()
@@ -301,7 +271,7 @@ def test_native_session_close_failure_retains_result_for_retry(
     )
     session = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}])
     session._result = result  # noqa: SLF001 - exercise close ownership directly
-    training_result._native.raise_once_on_detach = True
+    training_result.raise_once_on_detach = True
 
     with pytest.raises(RuntimeError, match="failed once"):
         session.close()
@@ -329,7 +299,7 @@ def test_native_session_replacement_failure_keeps_previous_result_owned(
     )
     session = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}])
     session._result = previous  # noqa: SLF001 - exercise replacement ownership directly
-    training_result._native.raise_once_on_detach = True
+    training_result.raise_once_on_detach = True
 
     def reached(*_args: object, **_kwargs: object) -> object:
         raise AssertionError("replacement work ran before the prior live result closed")

--- a/tests/unit/api/test_native_witness.py
+++ b/tests/unit/api/test_native_witness.py
@@ -1,0 +1,391 @@
+"""Live execution witness boundaries for the strict Methods lane."""
+
+from __future__ import annotations
+
+import copy
+import importlib
+import pickle
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+from nirs4all.api import native_session, native_training, native_witness
+from nirs4all.api.native_result import NativeMethodsRunResult
+from nirs4all.api.native_session import NativeMethodsSession
+from nirs4all.api.native_witness import _LiveMethodsWitness
+from nirs4all.pipeline.dagml.estimator import DagMLPipelineEstimator
+from nirs4all.pipeline.dagml.native_client import DagMLNativeCoverageError
+
+
+class _Outcome:
+    def __init__(self, document: dict[str, object]) -> None:
+        self._document = document
+
+    def to_dict(self) -> dict[str, object]:
+        return dict(self._document)
+
+
+class _NativeTrainingResult:
+    def __init__(self, document: dict[str, object]) -> None:
+        self._document = document
+        self.is_attached = True
+        self.detach_calls = 0
+        self.raise_once_on_detach = False
+
+    @property
+    def outcome_fingerprint(self) -> str:
+        return self._document["outcome_fingerprint"]  # type: ignore[return-value]
+
+    @property
+    def outcome(self) -> _Outcome:
+        return _Outcome(self._document)
+
+    def detach(self) -> bool:
+        self.detach_calls += 1
+        if self.raise_once_on_detach:
+            self.raise_once_on_detach = False
+            raise RuntimeError("native detach failed once")
+        if not self.is_attached:
+            return False
+        self.is_attached = False
+        return True
+
+
+class _TrainingResult:
+    def __init__(self, document: dict[str, object]) -> None:
+        self._document = document
+        self._native = _NativeTrainingResult(document)
+
+    @property
+    def is_attached(self) -> bool:
+        return self._native.is_attached
+
+    @property
+    def detach_calls(self) -> int:
+        return self._native.detach_calls
+
+    @property
+    def outcome_fingerprint(self) -> str:
+        return self._native.outcome_fingerprint
+
+    @property
+    def outcome(self) -> _Outcome:
+        return _Outcome(self._document)
+
+    def detach(self) -> bool:
+        return self._native.detach()
+
+
+def _score_set() -> dict[str, object]:
+    return {
+        "schema_version": 2,
+        "selection_metric": "rmse",
+        "reports": [
+            {
+                "producer_node": "model:methods",
+                "producer_port": "oof",
+                "partition": "validation",
+                "fold_id": "avg",
+                "level": "sample",
+                "metrics": {"rmse": 0.5},
+                "row_count": 2,
+                "target_names": ["y"],
+                "target_width": 1,
+                "variant_id": "variant:base",
+            }
+        ],
+    }
+
+
+def _install_dagml_facade(monkeypatch: pytest.MonkeyPatch) -> None:
+    facade = ModuleType("dag_ml")
+    facade.TrainingResult = _TrainingResult
+    native = ModuleType("dag_ml._dag_ml")
+    native.TrainingResult = _NativeTrainingResult
+    facade._dag_ml = native  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "dag_ml", facade)
+    monkeypatch.setitem(sys.modules, "dag_ml._dag_ml", native)
+
+
+def _estimator(tmp_path: Path, *, callback: object | None = None) -> tuple[SimpleNamespace, _TrainingResult]:
+    library = tmp_path / "libn4m.so"
+    library.write_bytes(b"methods")
+    fingerprint = "a" * 64
+    outcome: dict[str, object] = {
+        "outcome_fingerprint": fingerprint,
+        "score_set": _score_set(),
+    }
+    result = _TrainingResult(outcome)
+    estimator = SimpleNamespace(
+        dagml_module="dag_ml",
+        native_client=None,
+        native_training_execution_=SimpleNamespace(
+            methods_inputs={"data:train": {"sample_ids": ["s1", "s2"]}},
+            methods_library_path=str(library.resolve()),
+            op_callback=callback,
+        ),
+        training_result_=result,
+        training_outcome_=outcome,
+        predictor_package_={"package_id": "package:native"},
+    )
+
+    def export_native_archive(path: Path, *, archive_id: str) -> dict[str, str]:
+        path.write_bytes(b"native-archive")
+        return {"archive_id": archive_id, "archive_sha256": "b" * 64}
+
+    estimator.export_native_archive = export_native_archive
+    return estimator, result
+
+
+def test_live_witness_is_exact_redacted_nonserializable_and_invalidates_after_detach(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+
+    witness = _LiveMethodsWitness.from_estimator(estimator)  # type: ignore[arg-type]
+    claim = witness.claim
+
+    assert claim.to_dict() == {
+        "schema_version": 1,
+        "execution_entrypoint": "dag_ml.execute_methods_training",
+        "execution_mode": "methods_callback_free",
+        "outcome_fingerprint": "a" * 64,
+        "methods_library_mode": "explicit_absolute",
+        "portable_artifacts_required": True,
+    }
+    assert "libn4m" not in repr(claim)
+    assert witness.is_live
+    with pytest.raises(TypeError, match="cannot be copied"):
+        copy.copy(witness)
+    with pytest.raises(TypeError, match="cannot be deep-copied"):
+        copy.deepcopy(witness)
+    with pytest.raises(TypeError, match="cannot be serialized"):
+        pickle.dumps(witness)
+
+    assert witness.detach() is True
+    assert witness.detach() is False
+    assert training_result.detach_calls == 1
+    assert not witness.is_live
+    with pytest.raises(DagMLNativeCoverageError, match="no longer attached"):
+        _ = witness.claim
+
+
+def test_live_witness_constructor_is_internal_and_cannot_forge_a_claim(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+    claim = _LiveMethodsWitness.from_estimator(estimator).claim  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="internal factory"):
+        _LiveMethodsWitness(
+            estimator,
+            training_result,
+            training_result._native,
+            claim,
+            _factory_capability=object(),
+        )
+
+
+def test_native_result_factory_does_not_accept_an_injected_witness_and_detects_raw_swap(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator_a, training_result_a = _estimator(tmp_path)
+    witness = _LiveMethodsWitness.from_estimator(estimator_a)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'live_witness'"):
+        NativeMethodsRunResult.from_estimator(
+            estimator_a,  # type: ignore[arg-type]
+            dataset_name="native",
+            model_name="MethodsPLS",
+            live_witness=witness,
+        )
+
+    training_result_a._native = _NativeTrainingResult(dict(training_result_a._document))
+    with pytest.raises(DagMLNativeCoverageError, match="exact native TrainingResult"):
+        _ = witness.claim
+    assert not witness.is_live
+
+
+def test_live_witness_detach_failure_keeps_ownership_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+    witness = _LiveMethodsWitness.from_estimator(estimator)  # type: ignore[arg-type]
+    training_result._native.raise_once_on_detach = True
+
+    with pytest.raises(RuntimeError, match="failed once"):
+        witness.detach()
+    assert witness.is_live
+    assert training_result.detach_calls == 1
+
+    assert witness.detach() is True
+    assert training_result.detach_calls == 2
+    assert not witness.is_live
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda estimator: setattr(estimator.native_training_execution_, "op_callback", object()), "operator callback"),
+        (lambda estimator: setattr(estimator.native_training_execution_, "methods_inputs", {}), "non-empty native Methods inputs"),
+        (lambda estimator: setattr(estimator.native_training_execution_, "methods_library_path", "relative/libn4m.so"), "must be absolute"),
+        (lambda estimator: setattr(estimator, "native_client", object()), "default Dag-ML client"),
+        (lambda estimator: setattr(estimator, "training_outcome_", {"outcome_fingerprint": "b" * 64}), "finalized training outcome"),
+    ],
+)
+def test_live_witness_refuses_any_non_strict_or_mismatched_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mutate,
+    message: str,
+) -> None:  # noqa: ANN001
+    _install_dagml_facade(monkeypatch)
+    estimator, _training_result = _estimator(tmp_path)
+    mutate(estimator)
+
+    with pytest.raises(DagMLNativeCoverageError, match=message):
+        _LiveMethodsWitness.from_estimator(estimator)  # type: ignore[arg-type]
+
+
+def test_native_result_and_session_detach_live_facade_but_preserve_native_archive(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+    result = NativeMethodsRunResult.from_estimator(
+        estimator,  # type: ignore[arg-type]
+        dataset_name="native",
+        model_name="MethodsPLS",
+    )
+
+    assert result.native_execution_claim.outcome_fingerprint == "a" * 64
+    assert result.native_execution_is_live
+    no_model_path = tmp_path / "forbidden.joblib"
+    with pytest.raises(NotImplementedError, match="export_model is unavailable"):
+        result.export_model(no_model_path)
+    assert not no_model_path.exists()
+
+    session = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}])
+    session._result = result  # noqa: SLF001 - exercise close ownership directly
+    session.close()
+
+    assert training_result.detach_calls == 1
+    assert not result.native_execution_is_live
+    with pytest.raises(DagMLNativeCoverageError, match="no longer attached"):
+        _ = result.native_execution_claim
+    exported = result.export(tmp_path / "portable.n4a")
+    assert exported.read_bytes() == b"native-archive"
+
+
+def test_native_session_close_failure_retains_result_for_retry(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+    result = NativeMethodsRunResult.from_estimator(
+        estimator,  # type: ignore[arg-type]
+        dataset_name="native",
+        model_name="MethodsPLS",
+    )
+    session = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}])
+    session._result = result  # noqa: SLF001 - exercise close ownership directly
+    training_result._native.raise_once_on_detach = True
+
+    with pytest.raises(RuntimeError, match="failed once"):
+        session.close()
+    assert not session.closed
+    assert session.result is result
+    assert result.native_execution_is_live
+
+    session.close()
+    assert session.closed
+    assert training_result.detach_calls == 2
+
+
+@pytest.mark.parametrize("operation", ["run", "retrain"])
+def test_native_session_replacement_failure_keeps_previous_result_owned(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    operation: str,
+) -> None:
+    _install_dagml_facade(monkeypatch)
+    estimator, training_result = _estimator(tmp_path)
+    previous = NativeMethodsRunResult.from_estimator(
+        estimator,  # type: ignore[arg-type]
+        dataset_name="native",
+        model_name="MethodsPLS",
+    )
+    session = NativeMethodsSession([{"split": "stub"}, {"model": "stub"}])
+    session._result = previous  # noqa: SLF001 - exercise replacement ownership directly
+    training_result._native.raise_once_on_detach = True
+
+    def reached(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("replacement work ran before the prior live result closed")
+
+    if operation == "run":
+        monkeypatch.setattr(native_session, "run_native_methods", reached)
+        with pytest.raises(RuntimeError, match="failed once"):
+            session.run({})
+    else:
+        monkeypatch.setattr(importlib.import_module("nirs4all.api.retrain"), "retrain", reached)
+        with pytest.raises(RuntimeError, match="failed once"):
+            session.retrain({"X": [], "y": [], "sample_ids": []})
+
+    assert session.result is previous
+    assert previous.native_execution_is_live
+
+
+def test_native_training_projection_failure_detaches_the_fitted_estimator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FittedEstimator:
+        def __init__(self) -> None:
+            self.detach_calls = 0
+
+        def detach_native_training_result(self) -> bool:
+            self.detach_calls += 1
+            return True
+
+    class FailingWitness:
+        @classmethod
+        def from_estimator(cls, _estimator: object) -> object:
+            raise RuntimeError("witness projection failed")
+
+    estimator = FittedEstimator()
+    monkeypatch.setattr(native_training, "fit_native_pipeline", lambda *_args, **_kwargs: estimator)
+    monkeypatch.setattr("nirs4all.api.native_result._LiveMethodsWitness", FailingWitness)
+
+    with pytest.raises(RuntimeError, match="witness projection failed"):
+        native_training.run_native_methods(
+            [{"split": "stub"}, {"model": "stub"}],
+            {"X": [[1.0], [2.0]], "y": [1.0, 2.0], "sample_ids": ["s1", "s2"]},
+            save_charts=False,
+        )
+    assert estimator.detach_calls == 1
+
+
+def test_direct_fit_estimator_has_idempotent_native_detach() -> None:
+    document = {"outcome_fingerprint": "a" * 64}
+    training_result = _TrainingResult(document)
+    estimator = object.__new__(DagMLPipelineEstimator)
+    estimator.training_result_ = training_result
+    estimator.training_outcome_ = document
+    estimator.predictor_package_ = {"package_id": "package:native"}
+
+    assert estimator.detach_native_training_result() is True
+    assert estimator.detach_native_training_result() is False
+    assert training_result.detach_calls == 1
+    assert estimator.training_outcome_ == document
+    assert estimator.predictor_package_ == {"package_id": "package:native"}


### PR DESCRIPTION
## Summary
- adds an internal, non-serializable live witness for the strict callback-free Methods lane
- binds the result to the exact Dag-ML facade and PyO3 TrainingResult, then releases it transactionally on close/replacement/failure
- keeps durable Archive V2 export available after detach and refuses legacy export_model paths

## Validation
- python3.11 -m pytest tests/unit/api/test_native_witness.py tests/unit/api/test_native_result.py tests/unit/api/test_native_session.py tests/unit/api/test_engine_transition.py tests/unit/api/test_native_training.py tests/regression/test_public_api_contract.py tests/unit/pipeline/dagml/test_native_client.py tests/unit/pipeline/dagml/test_methods_runtime.py -q (139 passed)
- python3.11 -m ruff check [touched files]
- git diff --check
- real installed dag-ml 0.3.19 + Methods cycle: live claim -> close -> Archive V2 export

## Review
Independent Sol review accepted the final patch.