### PR TITLE
chore(deps): require dag-ml 0.3.20

### DIFF
--- a/.github/workflows/methods-installed.yml
+++ b/.github/workflows/methods-installed.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install released DAG-ML and nirs4all-methods wheels
         env:
           METHODS_PACKAGE: ${{ inputs.methods_package || 'nirs4all-methods==1.0.13' }}
-        run: python -m pip install "dag-ml==0.3.19" "$METHODS_PACKAGE"
+        run: python -m pip install "dag-ml==0.3.20" "$METHODS_PACKAGE"
 
       - name: Verify published DAG-ML and n4m runtime
         run: |
@@ -50,9 +50,9 @@ jobs:
           import dag_ml
           import n4m
 
-          assert version("dag-ml") == "0.3.19"
+          assert version("dag-ml") == "0.3.20"
           assert version("nirs4all-methods") == "1.0.13"
-          assert dag_ml.version() == "0.3.19"
+          assert dag_ml.version() == "0.3.20"
           abi = tuple(n4m.abi_version())
           assert len(abi) == 3 and abi[0] == 2 and abi[1] >= 2
           library = Path(n4m.library_path()).resolve(strict=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dependencies = [
     # dag-ml execution core — hard dependency, not an extra, so the native backend
     # is selectable out of the box via engine="dag-ml" or N4A_ENGINE=dag-ml. The
     # public Python line remains legacy-default until the explicit ADR-17 drop.
-    "dag-ml>=0.3.19",
+    "dag-ml>=0.3.20",
     "dag-ml-data>=0.2.8",
 ]
 
@@ -121,7 +121,7 @@ migration = ["duckdb>=1.0.0"]
 # the official Methods binding, and the DAG-ML replay surface required by the
 # fail-closed ``engine=\"native\"`` API.
 native = [
-    "dag-ml>=0.3.19",
+    "dag-ml>=0.3.20",
     "dag-ml-data>=0.2.9",
     # Archive V3 replay is exposed by the Core Python facade starting in 0.3.22.
     "nirs4all-core[methods]>=0.3.22",

--- a/requirements-examples.txt
+++ b/requirements-examples.txt
@@ -50,5 +50,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.19
+dag-ml>=0.3.20
 dag-ml-data>=0.2.8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -62,5 +62,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency; the public default remains legacy
 # until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.19
+dag-ml>=0.3.20
 dag-ml-data>=0.2.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ trendfitter>=0.0.6
 
 # dag-ml execution core — a hard dependency, not an extra. The public default
 # remains legacy until the ADR-17 cutover gate is explicitly satisfied.
-dag-ml>=0.3.19
+dag-ml>=0.3.20
 dag-ml-data>=0.2.8


### PR DESCRIPTION
## Summary

- Raise the `dag-ml` floor to the published `0.3.20` release for both core and native dependency sets.
- Keep `requirements.txt`, test/example requirements, and the installed Methods workflow on the same release.

## Validation

- Resolved isolated published wheels: `dag-ml 0.3.20`, `nirs4all-core 0.3.22`, and `nirs4all-methods 1.0.13` (ABI `2.3.0`).
- Installed Methods/native integration: 12 passed.
- Public exports check: 1 passed.
- Built sdist and wheel; verified generated package metadata.
- `ruff check .` passed.
- `mypy nirs4all` passed (476 source files).

## Independent review

- Sol review: **ACCEPT**; no blocking findings.

## Compatibility

This is a dependency-floor alignment only. The current legacy default engine and the pure-Python rollback tag `0.12.10` are unchanged.