### PR TITLE
fix(dagml): refuse stateful concat before fallback

### DIFF
--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -173,18 +173,22 @@
       "owner_lane": "L5"
     },
     {
-      "case": "concat_transform_pca_svd_plsr",
-      "shape": "stateful_concat_transform_pre_cv",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
-    },
+    }
+  ],
+  "expected_preflight_refusal": [
     {
       "case": "refit_params_use_all_partitions",
-      "shape": "refit_params",
+      "shape": "refit_params_use_all_partitions",
+      "error_type": "DagMlRefitParamsMigrationRequired",
+      "owner_lane": "L5"
+    },
+    {
+      "case": "concat_transform_pca_svd_plsr",
+      "shape": "stateful_concat_transform_pre_cv",
+      "error_type": "DagMlStatefulConcatTransformMigrationRequired",
       "owner_lane": "L5"
     }
   ],
@@ -333,7 +337,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 10,
+    "fallback": 8,
+    "preflight_refusal": 2,
     "native": 85,
     "xfail_strict": 0,
     "skip": 0,

--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -173,18 +173,17 @@
       "owner_lane": "L5"
     },
     {
+      "case": "refit_params_use_all_partitions",
+      "shape": "refit_params",
+      "owner_lane": "L5"
+    },
+    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
     }
   ],
   "expected_preflight_refusal": [
-    {
-      "case": "refit_params_use_all_partitions",
-      "shape": "refit_params_use_all_partitions",
-      "error_type": "DagMlRefitParamsMigrationRequired",
-      "owner_lane": "L5"
-    },
     {
       "case": "concat_transform_pca_svd_plsr",
       "shape": "stateful_concat_transform_pre_cv",
@@ -337,8 +336,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 8,
-    "preflight_refusal": 2,
+    "fallback": 9,
+    "preflight_refusal": 1,
     "native": 85,
     "xfail_strict": 0,
     "skip": 0,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -159,7 +159,7 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage fallback boundary — `EXPECTED_FALLBACK` (8)
+### C.1 Native-coverage fallback boundary — `EXPECTED_FALLBACK` (9)
 
 Shapes the dag-ml host bridge does **not serialize yet**. A normal
 `engine="dag-ml"` request fails closed; the parity harness exercises these rows
@@ -179,12 +179,13 @@ Source: `test_conformance_dual_engine.py` (`EXPECTED_FALLBACK`).
 | branch (duplication) + merge → multi-model | `branch_dup_three_way_merge_predictions`, `branch_dup_named_with_metamodel`, `branch_dup_merge_all` |
 | branch separation by metadata/tag/filter | `branch_separation_by_metadata_auto`, `branch_separation_by_tag`, `branch_separation_by_filter` |
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
+| legacy `refit_params` compatibility no-op | `refit_params_use_all_partitions` |
 | by-source / per-source multi-source | `multi_source_per_source_models_stacking` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**
 
-#### C.1a Semantic preflight refusals — `EXPECTED_PREFLIGHT_REFUSAL` (2)
+#### C.1a Semantic preflight refusals — `EXPECTED_PREFLIGHT_REFUSAL` (1)
 
 These rows are not fallback coverage gaps. Their Python legacy semantics cannot
 be silently substituted for the DAG-ML contract, so they raise a dedicated
@@ -195,7 +196,6 @@ materialization, warning emission, or `PipelineRunner` construction — even wit
 
 | Case | Error type | Native/legacy semantic boundary |
 |---|---|---|
-| `refit_params_use_all_partitions` | `DagMlRefitParamsMigrationRequired` | legacy refit can include held-out partitions; native `REFIT FullTrain` is fixed to FoldSet sample IDs |
 | `concat_transform_pca_svd_plsr` | `DagMlStatefulConcatTransformMigrationRequired` | legacy materializes PCA/SVD features pre-CV; native FeatureConcat fits them fold-locally |
 
 The never-xfailed `test_native_preflight_refusal_boundary` keeps the error type,
@@ -282,8 +282,8 @@ contract boundary.
 | Registered `PipelineCase`s | **95** | `cases_*.py` `register()` calls |
 | Non-runnable (`skip_reason` set) | **0** | no fixture/unknown/legacy-bug skips in the registry |
 | Runnable | **95** | 95 − 0 |
-| → fall back to legacy (`EXPECTED_FALLBACK`) | **8** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
-| → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **2** | typed error; no data work, legacy fallback, or `PipelineRunner` construction |
+| → fall back to legacy (`EXPECTED_FALLBACK`) | **9** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
+| → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **1** | typed error; no data work, legacy fallback, or `PipelineRunner` construction |
 | → run native on dag-ml | **85** | full parity asserted or parity-note pinned |
 | Strict-xfail (documented divergence) | **0** | `KNOWN_DIVERGENCES` is empty; no `legacy_bug` rows in the current registry |
 | `pytest.skip` (fixture) | **0** | fixture skips retired |
@@ -293,10 +293,11 @@ contract boundary.
 
 > **Correction to prior counts:** the current machine-readable ledger and live
 > registry have no `legacy_bug`, `unknown_semantics`, or fixture skip rows. The
-> verified meter is **0** non-runnable / **95** runnable: **8** catchable
-> fallback rows, **2** typed semantic migration refusals, and **85** native rows.
-> Stateful `concat_transform` and `refit_params.use_all_partitions` do not
-> fallback: they require an explicit native migration or `engine="legacy"`.
+> verified meter is **0** non-runnable / **95** runnable: **9** catchable
+> fallback rows, **1** typed semantic migration refusal, and **85** native rows.
+> Stateful `concat_transform` requires an explicit native migration or
+> `engine="legacy"`; `refit_params.use_all_partitions` remains a legacy no-op
+> on the ordinary fallback boundary.
 
 ---
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -115,17 +115,19 @@ enforced cross-engine tolerance is `1e-3`.**
 ## §B — 3-tier authority registry
 
 Each tier is a claim about **which engine is correct**, distinct from coverage,
-skip, and fallback bookkeeping (those are §C). The five scattered structures —
+skip, and fallback bookkeeping (those are §C). The six scattered structures —
 `_registry.SkipKind`, and `KNOWN_DIVERGENCES` / `NUM_PREDICTIONS_DIVERGENCE` /
-`Y_PRED_TOL_OVERRIDES` / `SAME_WINNER_CASES` / `EXPECTED_FALLBACK` in
-`test_conformance_dual_engine.py` — are consolidated here.
+`Y_PRED_TOL_OVERRIDES` / `SAME_WINNER_CASES` / `EXPECTED_FALLBACK` /
+`EXPECTED_PREFLIGHT_REFUSAL` in `test_conformance_dual_engine.py` — are
+consolidated here.
 
 ### Tier 1 — Python (legacy) authoritative
 
-**Default.** Every runnable case not listed in Tier 2 / Tier 3 and not in
-`EXPECTED_FALLBACK` runs *native* on dag-ml and must equal the legacy oracle
-within its matching `cross_impl_*` (or `per_case_tight`) band. No pytest marker;
-**PASS = green parity**. This is the implicit majority tier (≈70 cases).
+**Default.** Every runnable case not listed in Tier 2 / Tier 3 and in neither
+`EXPECTED_FALLBACK` nor `EXPECTED_PREFLIGHT_REFUSAL` runs *native* on dag-ml
+and must equal the legacy oracle within its matching `cross_impl_*` (or
+`per_case_tight`) band. No pytest marker; **PASS = green parity**. This is the
+implicit majority tier (≈70 cases).
 Authority: **Python (legacy)**, the oracle of record (ADR-01). Enforced by
 `assert_score_parity` / `assert_y_pred_parity` / `assert_runresult_contract`
 (`_conformance_helpers.py:170,355,253`).
@@ -149,45 +151,62 @@ Authority: **Python (legacy)**, the oracle of record (ADR-01). Enforced by
 ### Tier 3 — strict-xfail native comparisons
 
 There are currently **no** strict-xfail native comparison rows. The former
-`concat_transform_pca_svd_plsr` row is now an explicit `EXPECTED_FALLBACK`
-boundary (§C.1): the native FeatureConcat path fits stateful PCA/SVD fold-locally,
+`concat_transform_pca_svd_plsr` row is now an explicit preflight migration
+refusal (§C.1a): the native FeatureConcat path fits stateful PCA/SVD fold-locally,
 while the Python oracle materializes `concat_transform` before CV.
 
 ---
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage boundary — `EXPECTED_FALLBACK` (10)
+### C.1 Native-coverage fallback boundary — `EXPECTED_FALLBACK` (8)
 
 Shapes the dag-ml host bridge does **not serialize yet**. A normal
 `engine="dag-ml"` request fails closed; the parity harness exercises these rows
 only with the explicit `allow_legacy_fallback=True` diagnostic rollback. They
 make **no parity claim** — they are pinned by the never-xfailed
-`test_native_fallback_boundary` (`test_conformance_dual_engine.py:375`): a
+`test_native_fallback_boundary`: a
 fallback off the allowlist = native-coverage **regression → FAIL**; a native
 case on the allowlist = **stale entry → FAIL**. **Owner: L5/A3** (host-bridge
 serialization, runtime work — not a tolerance question). When L5 lands native
 coverage, the entry leaves the allowlist and the boundary test then demands
 native parity.
 
-Source: `test_conformance_dual_engine.py:310-337`.
+Source: `test_conformance_dual_engine.py` (`EXPECTED_FALLBACK`).
 
 | Shape group | Cases |
 |---|---|
 | branch (duplication) + merge → multi-model | `branch_dup_three_way_merge_predictions`, `branch_dup_named_with_metamodel`, `branch_dup_merge_all` |
 | branch separation by metadata/tag/filter | `branch_separation_by_metadata_auto`, `branch_separation_by_tag`, `branch_separation_by_filter` |
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
-| stateful `concat_transform` pre-CV materialization | `concat_transform_pca_svd_plsr` |
 | by-source / per-source multi-source | `multi_source_per_source_models_stacking` |
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**
 
+#### C.1a Semantic preflight refusals — `EXPECTED_PREFLIGHT_REFUSAL` (2)
+
+These rows are not fallback coverage gaps. Their Python legacy semantics cannot
+be silently substituted for the DAG-ML contract, so they raise a dedicated
+`DagMlMigrationRequired` subtype before backend availability, dataset
+materialization, warning emission, or `PipelineRunner` construction — even with
+`allow_legacy_fallback=True`. Callers must migrate the pipeline or select
+`engine="legacy"` explicitly.
+
+| Case | Error type | Native/legacy semantic boundary |
+|---|---|---|
+| `refit_params_use_all_partitions` | `DagMlRefitParamsMigrationRequired` | legacy refit can include held-out partitions; native `REFIT FullTrain` is fixed to FoldSet sample IDs |
+| `concat_transform_pca_svd_plsr` | `DagMlStatefulConcatTransformMigrationRequired` | legacy materializes PCA/SVD features pre-CV; native FeatureConcat fits them fold-locally |
+
+The never-xfailed `test_native_preflight_refusal_boundary` keeps the error type,
+absence of fallback, and absence of legacy/data-plane construction load-bearing.
+
 ### C.2 Coverage-debt fixture skips (0)
 
-All former fixture-debt rows are now runnable. The two shapes that still lack
-native coverage moved to the explicit `EXPECTED_FALLBACK` boundary; the
-multi-filter exclusion case now runs as a live legacy-oracle parity case.
+All former fixture-debt rows are now runnable. The remaining unsupported shapes
+use the explicit `EXPECTED_FALLBACK` boundary; semantic migration requirements
+are separately recorded in §C.1a. The multi-filter exclusion case runs as a
+live legacy-oracle parity case.
 
 | Case | Reason | Evidence |
 |---|---|---|
@@ -254,16 +273,18 @@ report §4 and SW5 §6 for the concrete test specs).
 ## §E — Coverage meter (the LOCK-DROP instrument)
 
 Counts verified against `tests/integration/parity/cases_*.py` (95 `register()`
-calls) after the fixture-debt cleanup. The `EXPECTED_FALLBACK` shrink target is the LOCK-DROP D1
-gate.
+calls) after the fixture-debt cleanup. The `EXPECTED_FALLBACK` shrink target is
+the LOCK-DROP D1 gate; semantic migration refusals are a separate explicit
+contract boundary.
 
 | Metric | Count | Note |
 |---|---|---|
 | Registered `PipelineCase`s | **95** | `cases_*.py` `register()` calls |
 | Non-runnable (`skip_reason` set) | **0** | no fixture/unknown/legacy-bug skips in the registry |
 | Runnable | **95** | 95 − 0 |
-| → fall back to legacy (`EXPECTED_FALLBACK`) | **11** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
-| → run native on dag-ml | **84** | full parity asserted or parity-note pinned |
+| → fall back to legacy (`EXPECTED_FALLBACK`) | **8** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
+| → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **2** | typed error; no data work, legacy fallback, or `PipelineRunner` construction |
+| → run native on dag-ml | **85** | full parity asserted or parity-note pinned |
 | Strict-xfail (documented divergence) | **0** | `KNOWN_DIVERGENCES` is empty; no `legacy_bug` rows in the current registry |
 | `pytest.skip` (fixture) | **0** | fixture skips retired |
 | `NUM_PREDICTIONS_DIVERGENCE` parity-notes (PASS) | **2** | counts pinned |
@@ -272,11 +293,10 @@ gate.
 
 > **Correction to prior counts:** the current machine-readable ledger and live
 > registry have no `legacy_bug`, `unknown_semantics`, or fixture skip rows. The
-> verified meter is **0** non-runnable / **95** runnable. `EXPECTED_FALLBACK` is
-> now **11** because the remaining shapes retain native-incompatible semantics:
-> native, `finetune_params` is an explicit coverage boundary, and stateful
-> `concat_transform` now falls back until dag-ml preserves the Python oracle's
-> pre-CV materialization semantics.
+> verified meter is **0** non-runnable / **95** runnable: **8** catchable
+> fallback rows, **2** typed semantic migration refusals, and **85** native rows.
+> Stateful `concat_transform` and `refit_params.use_all_partitions` do not
+> fallback: they require an explicit native migration or `engine="legacy"`.
 
 ---
 
@@ -289,8 +309,9 @@ gate.
 3. **XPASS = RED when strict-xfail rows exist.** There are no strict-xfail rows
    currently; any future `xfail(strict)` must flip the suite red the moment the
    engines reconverge, so a fixed divergence cannot silently leave coverage.
-4. **The native/fallback boundary can never silently widen.**
+4. **The native/fallback/refusal boundary can never silently widen.**
    `test_native_fallback_boundary` is never xfailed; an off-allowlist fallback or
-   a stale allowlist entry fails (`test_conformance_dual_engine.py:375`).
+   a stale allowlist entry fails. `test_native_preflight_refusal_boundary` also
+   rejects automatic legacy rollback for semantic migration rows.
 5. **num_predictions divergences are pinned, not exempted.** Only the documented
    `34/32` and `49/47` loser-refit-row deltas pass.

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -885,7 +885,7 @@ def run(
     selected_engine = resolve_engine(engine)
     if selected_engine == "dag-ml":
         # This must precede *every* DAG-ML execution route, including the tuning/calibration early
-        # return below. It reads configuration only, so semantic migrations cannot reach native work,
+        # return below. It reads configuration only, so a stateful pre-CV concat cannot reach native work,
         # dataset materialization, or the catchable legacy fallback boundary.
         from nirs4all.pipeline.dagml.migration_preflight import preflight_dagml_pipeline_migration
 

--- a/nirs4all/api/run.py
+++ b/nirs4all/api/run.py
@@ -883,6 +883,14 @@ def run(
         raise TypeError("allow_legacy_fallback must be True, False, or None")
 
     selected_engine = resolve_engine(engine)
+    if selected_engine == "dag-ml":
+        # This must precede *every* DAG-ML execution route, including the tuning/calibration early
+        # return below. It reads configuration only, so semantic migrations cannot reach native work,
+        # dataset materialization, or the catchable legacy fallback boundary.
+        from nirs4all.pipeline.dagml.migration_preflight import preflight_dagml_pipeline_migration
+
+        preflight_dagml_pipeline_migration(pipeline)
+
     custom_training_loss_requested = bool(training_losses) or local_implementations is not None
     if custom_training_loss_requested and selected_engine != "dag-ml":
         raise ValueError("training_losses/local_implementations require engine='dag-ml'")
@@ -1228,7 +1236,11 @@ def run(
     # (run_via_dagml cleans its own temp dir in a finally). ONLY
     # DagMlUnsupported/NotImplementedError/DagMlUnavailable are caught — a
     # GENUINE dag-ml runtime/operator bug propagates untouched (never silently
-    # swallowed into legacy).
+    # swallowed into legacy). Semantic migration requirements were deliberately
+    # checked immediately after engine selection, before tuning/calibration and
+    # this try block: they are RuntimeErrors outside those catchable capability
+    # signals, so an explicit legacy engine selection is required rather than an
+    # inferred rollback.
     if selected_engine == "dag-ml":
         from nirs4all.pipeline.dagml.errors import DagMlUnavailable, DagMlUnsupported
         from nirs4all.pipeline.dagml.run_backend import run_via_dagml

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -173,18 +173,22 @@
       "owner_lane": "L5"
     },
     {
-      "case": "concat_transform_pca_svd_plsr",
-      "shape": "stateful_concat_transform_pre_cv",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
-    },
+    }
+  ],
+  "expected_preflight_refusal": [
     {
       "case": "refit_params_use_all_partitions",
-      "shape": "refit_params",
+      "shape": "refit_params_use_all_partitions",
+      "error_type": "DagMlRefitParamsMigrationRequired",
+      "owner_lane": "L5"
+    },
+    {
+      "case": "concat_transform_pca_svd_plsr",
+      "shape": "stateful_concat_transform_pre_cv",
+      "error_type": "DagMlStatefulConcatTransformMigrationRequired",
       "owner_lane": "L5"
     }
   ],
@@ -333,7 +337,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 10,
+    "fallback": 8,
+    "preflight_refusal": 2,
     "native": 85,
     "xfail_strict": 0,
     "skip": 0,

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -173,18 +173,17 @@
       "owner_lane": "L5"
     },
     {
+      "case": "refit_params_use_all_partitions",
+      "shape": "refit_params",
+      "owner_lane": "L5"
+    },
+    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
     }
   ],
   "expected_preflight_refusal": [
-    {
-      "case": "refit_params_use_all_partitions",
-      "shape": "refit_params_use_all_partitions",
-      "error_type": "DagMlRefitParamsMigrationRequired",
-      "owner_lane": "L5"
-    },
     {
       "case": "concat_transform_pca_svd_plsr",
       "shape": "stateful_concat_transform_pre_cv",
@@ -337,8 +336,8 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 8,
-    "preflight_refusal": 2,
+    "fallback": 9,
+    "preflight_refusal": 1,
     "native": 85,
     "xfail_strict": 0,
     "skip": 0,

--- a/nirs4all/pipeline/dagml/errors.py
+++ b/nirs4all/pipeline/dagml/errors.py
@@ -85,16 +85,12 @@ class DagMlMigrationRequired(RuntimeError):
     """
 
 
-class DagMlRefitParamsMigrationRequired(DagMlMigrationRequired):
-    """Legacy ``refit_params.use_all_partitions`` has no native refit equivalent."""
-
-
 class DagMlStatefulConcatTransformMigrationRequired(DagMlMigrationRequired):
     """Legacy pre-CV stateful ``concat_transform`` semantics need an explicit migration."""
 
 
 class DagMlPipelinePreflightRequired(DagMlMigrationRequired):
-    """The active declarative pipeline cannot be inspected safely before native routing."""
+    """A generator cannot prove whether it selects a stateful pre-CV concat."""
 
 
 class DagMlExportRefusal(RuntimeError):

--- a/nirs4all/pipeline/dagml/errors.py
+++ b/nirs4all/pipeline/dagml/errors.py
@@ -2,9 +2,10 @@
 
 ``DagMlUnsupported`` is the catchable error every unsupported-or-failed dag-ml shape raises;
 ``DagMlUnavailable`` is the narrow error a dag-ml-backend PREFLIGHT raises when NEITHER execution
-mechanism is installed (no in-process PyO3 extension AND no dag-ml-cli binary); ``_cli_child_error``
-extracts the real cause from a dag-ml-cli failure; ``_raise_run_failure`` decides
-propagate-vs-fallback for a non-zero subprocess run from the adapter's structured ``error_kind``
+mechanism is installed (no in-process PyO3 extension AND no dag-ml-cli binary).
+``DagMlMigrationRequired`` names a semantic boundary that deliberately cannot use automatic legacy
+rollback. ``_cli_child_error`` extracts the real cause from a dag-ml-cli failure; ``_raise_run_failure``
+decides propagate-vs-fallback for a non-zero subprocess run from the adapter's structured ``error_kind``
 (:func:`_run_failure_kind`); ``_reject_multi_model`` rejects a multi-model pipeline UP FRONT.
 """
 
@@ -72,6 +73,28 @@ class DagMlUnavailable(RuntimeError):
     NOT a subclass of ``DagMlUnsupported``/``NotImplementedError``: "the backend is not installed" is a
     distinct condition from "this pipeline shape is unsupported", and ``run()`` catches it explicitly.
     """
+
+
+class DagMlMigrationRequired(RuntimeError):
+    """A legacy semantic needs an explicit migration and may not auto-fallback.
+
+    ``allow_legacy_fallback`` is intentionally limited to ordinary capability and availability
+    boundaries. It must not make a native request appear successful by silently changing its
+    execution contract. Callers must either migrate the pipeline or select ``engine="legacy"``
+    explicitly. This stays outside the fallback catch hierarchy on purpose.
+    """
+
+
+class DagMlRefitParamsMigrationRequired(DagMlMigrationRequired):
+    """Legacy ``refit_params.use_all_partitions`` has no native refit equivalent."""
+
+
+class DagMlStatefulConcatTransformMigrationRequired(DagMlMigrationRequired):
+    """Legacy pre-CV stateful ``concat_transform`` semantics need an explicit migration."""
+
+
+class DagMlPipelinePreflightRequired(DagMlMigrationRequired):
+    """The active declarative pipeline cannot be inspected safely before native routing."""
 
 
 class DagMlExportRefusal(RuntimeError):

--- a/nirs4all/pipeline/dagml/migration_preflight.py
+++ b/nirs4all/pipeline/dagml/migration_preflight.py
@@ -29,6 +29,8 @@ _BRANCH_OPTION_KEYS = frozenset({"parallel", "n_jobs", "metadata", "params"})
 _OPAQUE_PAYLOAD_KEYS = frozenset({"model", "metadata", "params", "refit_params"})
 _RANDOM_COUNT_GENERATOR_KEYS = frozenset({"_or_", "_grid_", "_zip_", "_cartesian_"})
 _GENERATOR_KEYS = frozenset({"_or_", "_range_", "_log_range_", "_grid_", "_zip_", "_chain_", "_sample_", "_cartesian_"})
+_PIPELINE_CONFIGS_CLASS_MODULE = "nirs4all.pipeline.config.pipeline_config"
+_PIPELINE_CONFIGS_CLASS_QUALNAME = "PipelineConfigs"
 
 
 @dataclass(frozen=True)
@@ -69,6 +71,30 @@ def _minimal_step_config(value: Any) -> Any:
     except Exception:  # pragma: no cover - import is part of the installed package contract.
         return value
     return value.step_config if isinstance(value, MinimalPipelineStep) else value
+
+
+def _is_pipeline_configs(value: Any) -> bool:
+    """Recognize the canonical config object even if its module was reloaded.
+
+    ``PipelineConfigs`` is part of the public API.  A module reload can leave that public re-export
+    pointing at an older class object, so an ``isinstance`` check against a fresh import would silently
+    miss a valid configuration.  The implementation module and qualified class name are stable across
+    that reload; no arbitrary object protocol is accepted here.
+    """
+
+    return any(value_type.__module__ == _PIPELINE_CONFIGS_CLASS_MODULE and value_type.__qualname__ == _PIPELINE_CONFIGS_CLASS_QUALNAME for value_type in type(value).__mro__)
+
+
+def _pipeline_configs_steps(pipeline: Any) -> list[Any]:
+    """Read the concrete PipelineConfigs variants without turning a bad form into a safe pipeline."""
+
+    try:
+        steps = pipeline.steps
+    except Exception as error:  # noqa: BLE001 - this named public form must not bypass preflight.
+        _raise_uninspectable("PipelineConfigs.steps", error)
+    if not isinstance(steps, list) or any(not isinstance(item, list) for item in steps):
+        _raise_uninspectable("PipelineConfigs.steps")
+    return steps
 
 
 def _effective_seed(generator: Mapping[str, Any], root_seed: int | None) -> Any:
@@ -614,14 +640,14 @@ def _looks_like_pipeline_step(value: Any) -> bool:
     return bool(hasattr(value, "__class__") and value.__class__.__module__.startswith("nirs4all"))
 
 
-def _batch_status(value: list[Any], pipeline_configs_type: type[Any]) -> tuple[bool, int | None]:
+def _batch_status(value: list[Any]) -> tuple[bool, int | None]:
     """Return ``(is_batch, opaque_member_index)`` for the public outer-list grammar."""
 
     saw_pipeline_spec = False
     saw_step = False
     opaque_member: int | None = None
     for index, item in enumerate(value):
-        if isinstance(item, (pipeline_configs_type, str, Path, list)) or (isinstance(item, Mapping) and any(key in item for key in ("pipeline", "steps"))):
+        if _is_pipeline_configs(item) or isinstance(item, (str, Path, list)) or (isinstance(item, Mapping) and any(key in item for key in ("pipeline", "steps"))):
             saw_pipeline_spec = True
         elif _looks_like_pipeline_step(item):
             saw_step = True
@@ -635,18 +661,18 @@ def _batch_status(value: list[Any], pipeline_configs_type: type[Any]) -> tuple[b
 def _public_variants(pipeline: Any, active_batches: set[int] | None = None) -> list[tuple[list[Any], int | None]]:
     """Return every inspectable public pipeline member and its generator root seed."""
 
-    from nirs4all.pipeline.config.pipeline_config import PipelineConfigs
-
-    if isinstance(pipeline, PipelineConfigs):
-        steps = pipeline.steps
-        if not isinstance(steps, list) or any(not isinstance(item, list) for item in steps):
-            _raise_uninspectable("PipelineConfigs.steps")
-        seed = pipeline.random_state if type(pipeline.random_state) is int else None
+    if _is_pipeline_configs(pipeline):
+        steps = _pipeline_configs_steps(pipeline)
+        try:
+            random_state = pipeline.random_state
+        except Exception as error:  # noqa: BLE001 - a broken config object cannot bypass a concat boundary.
+            _raise_uninspectable("PipelineConfigs.random_state", error)
+        seed = random_state if type(random_state) is int else None
         return [(list(item), seed) for item in steps]
     if not isinstance(pipeline, list):
         return [_raw_steps_and_seed(pipeline)]
 
-    is_batch, opaque_member = _batch_status(pipeline, PipelineConfigs)
+    is_batch, opaque_member = _batch_status(pipeline)
     if opaque_member is not None:
         _raise_uninspectable(f"pipeline batch item {opaque_member}")
     if not is_batch:
@@ -802,6 +828,17 @@ def _value_may_contain_stateful_pre_cv_concat(value: Any, seen_splitter: bool, a
     """Conservatively find the one semantic boundary without interpreting payloads."""
 
     value = _minimal_step_config(value)
+    if _is_pipeline_configs(value):
+        try:
+            return _value_may_contain_stateful_pre_cv_concat(
+                _pipeline_configs_steps(value),
+                seen_splitter,
+                active,
+            )
+        except DagMlMigrationRequired:
+            raise
+        except Exception as error:  # noqa: BLE001 - named config inspection must never look safe after failure.
+            _raise_uninspectable("PipelineConfigs.steps", error)
     if isinstance(value, (list, tuple)):
         marker = id(value)
         if marker in active:
@@ -835,15 +872,14 @@ def _value_may_contain_stateful_pre_cv_concat(value: Any, seen_splitter: bool, a
 def _pipeline_may_contain_stateful_pre_cv_concat(pipeline: Any) -> bool:
     """Whether the supplied public form needs concat semantic preflight at all.
 
-    This deliberately returns false for unreadable or malformed public forms: they belong to the
-    ordinary compatibility/error path unless a valid active concat boundary can be identified.
+    This deliberately returns false for unreadable raw public forms: they belong to the ordinary
+    compatibility/error path unless a valid active concat boundary can be identified. The structural
+    walker recognizes a named ``PipelineConfigs`` object at every public nesting level; its serialized
+    variants are already executable legacy input, so an inspection failure is never turned into a safe
+    pass.
     """
 
     try:
-        from nirs4all.pipeline.config.pipeline_config import PipelineConfigs
-
-        if isinstance(pipeline, PipelineConfigs):
-            return _value_may_contain_stateful_pre_cv_concat(pipeline.steps, False, set())
         if isinstance(pipeline, Path):
             pipeline = str(pipeline)
         if isinstance(pipeline, str):

--- a/nirs4all/pipeline/dagml/migration_preflight.py
+++ b/nirs4all/pipeline/dagml/migration_preflight.py
@@ -1,0 +1,898 @@
+"""Fail-closed semantic migration checks before DAG-ML routing.
+
+This module is deliberately narrower than a second pipeline parser.  It only proves two legacy
+semantics that may not use ``allow_legacy_fallback``: refitting with held-out partitions, and a
+stateful ``concat_transform`` materialized before cross-validation.  All ordinary unsupported
+shapes continue through the existing capability fallback path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, NoReturn
+
+import yaml
+
+from .errors import (
+    DagMlMigrationRequired,
+    DagMlPipelinePreflightRequired,
+    DagMlRefitParamsMigrationRequired,
+    DagMlStatefulConcatTransformMigrationRequired,
+)
+
+_MAX_PREFLIGHT_VARIANTS = 10_000
+_SERIALIZED_COMPONENT_KEYS = frozenset({"class", "function", "module", "object", "instance"})
+_SEPARATION_BRANCH_KEYS = frozenset({"by_tag", "by_metadata", "by_filter", "by_source"})
+_BRANCH_OPTION_KEYS = frozenset({"parallel", "n_jobs", "metadata", "params"})
+_RANDOM_COUNT_GENERATOR_KEYS = frozenset({"_or_", "_grid_", "_zip_", "_cartesian_"})
+_GENERATOR_KEYS = frozenset({"_or_", "_range_", "_log_range_", "_grid_", "_zip_", "_chain_", "_sample_", "_cartesian_"})
+
+
+@dataclass(frozen=True)
+class _Opaque:
+    """Preserve a payload's identity while keeping generator expansion out of it."""
+
+    value: Any
+
+
+def _raise_uninspectable(context: str, cause: BaseException | None = None) -> NoReturn:
+    """Refuse an active DSL shape whose semantic boundary cannot be proven safely."""
+
+    error = DagMlPipelinePreflightRequired(
+        f"engine='dag-ml' cannot inspect {context} before semantic migration preflight. "
+        "Automatic legacy fallback is disabled for this active pipeline form; provide a documented "
+        "list/dict/YAML-or-JSON/Path/PipelineConfigs pipeline, or select engine='legacy' explicitly."
+    )
+    if cause is None:
+        raise error
+    raise error from cause
+
+
+def _is_serialized_component(value: Mapping[str, Any]) -> bool:
+    """Whether a mapping is an atomic serialized operator rather than a workflow step."""
+
+    return bool(_SERIALIZED_COMPONENT_KEYS & value.keys())
+
+
+def _unwrap(value: Any) -> Any:
+    return value.value if isinstance(value, _Opaque) else value
+
+
+def _minimal_step_config(value: Any) -> Any:
+    """Unwrap trace replay steps without treating arbitrary payload objects as DSL nodes."""
+
+    try:
+        from nirs4all.pipeline.trace.extractor import MinimalPipelineStep
+    except Exception:  # pragma: no cover - import is part of the installed package contract.
+        return value
+    return value.step_config if isinstance(value, MinimalPipelineStep) else value
+
+
+def _effective_seed(generator: Mapping[str, Any], root_seed: int | None) -> Any:
+    """Match generator-core's per-node seed lookup without inventing seed propagation.
+
+    A mixed ``_or_`` is expanded by ``_expand_mixed_or_node`` rather than ``OrStrategy``. That helper
+    leaves ``_seed_`` in the base payload, so only its caller seed affects selection. Treating the
+    payload key as effective here would let a duplication branch hide an unsafe candidate.
+    """
+
+    if "_or_" in generator:
+        from nirs4all.pipeline.config._generator.keywords import PURE_OR_KEYS
+
+        if not set(generator).issubset(PURE_OR_KEYS):
+            return root_seed
+
+    return generator.get("_seed_", root_seed)
+
+
+def _random_count_is_unseeded(value: Mapping[str, Any], root_seed: int | None) -> bool:
+    """Whether a generator's positive count can randomly hide an otherwise active variant."""
+
+    count = value.get("count")
+    return type(count) is int and count > 0 and bool(_RANDOM_COUNT_GENERATOR_KEYS & value.keys()) and _effective_seed(value, root_seed) is None
+
+
+def _unseeded_choice_sample(value: Mapping[str, Any], root_seed: int | None) -> list[Any] | None:
+    """Return every possible value of an unseeded choice sample, or ``None`` when not applicable."""
+
+    sample = value.get("_sample_")
+    if _effective_seed(value, root_seed) is not None or not isinstance(sample, Mapping):
+        return None
+    if sample.get("distribution", "uniform") != "choice":
+        return None
+    choices = sample.get("values", [])
+    num = sample.get("num", 10)
+    count = value.get("count")
+    if not isinstance(choices, list) or type(num) is not int or num < 0 or (count is not None and type(count) is not int):
+        _raise_uninspectable("an unseeded _sample_ generator")
+    emitted = min(num, count) if count is not None and count > 0 else num
+    return choices if emitted > 0 else []
+
+
+def _has_unprojectable_unseeded_sample(value: Any, root_seed: int | None, active: set[int] | None = None) -> bool:
+    """Whether a relevant ZipStrategy column retains unbounded random sampling.
+
+    An unseeded choice sample is rewritten exhaustively by ``_project_for_expansion``. Other sample
+    distributions produce fresh values on every expansion and cannot prove a semantic boundary from
+    one draw, so their relevant column must use the generic preflight refusal instead.
+    """
+
+    if isinstance(value, _Opaque) or not isinstance(value, (Mapping, list, tuple)):
+        return False
+    if active is None:
+        active = set()
+    marker = id(value)
+    if marker in active:
+        return True
+    active.add(marker)
+    try:
+        if isinstance(value, Mapping):
+            if "_sample_" in value and _effective_seed(value, root_seed) is None:
+                sample = value.get("_sample_")
+                if not isinstance(sample, Mapping) or sample.get("distribution", "uniform") != "choice":
+                    return True
+            return any(_has_unprojectable_unseeded_sample(item, root_seed, active) for item in value.values())
+        return any(_has_unprojectable_unseeded_sample(item, root_seed, active) for item in value)
+    finally:
+        active.remove(marker)
+
+
+def _opaque_with_shape(value: Any) -> Any:
+    """Keep ZipStrategy's list cardinality while leaving payloads inactive."""
+
+    # ``ZipStrategy`` treats only a list as a value column.  A tuple is one scalar value, so
+    # projecting it as several opaque values would fabricate an alignment that legacy never has.
+    if isinstance(value, list):
+        return [_Opaque(item) for item in value]
+    return _Opaque(value)
+
+
+def _zip_column_values(value: Any, root_seed: int | None) -> list[Any] | None:
+    """Return all values a relevant ZipStrategy column can emit safely.
+
+    ``None`` means the column's active result set is too large or malformed to prove.  It is used
+    only to decide whether an opaque generated sibling can hide a tracked migration; it never
+    substitutes an invented cardinality into the projected generator. Unseeded random choices are
+    first projected exhaustively, matching the main pipeline scan rather than sampling once.
+    """
+
+    if isinstance(value, list):
+        # ZipStrategy deliberately does not recursively expand list members. Duplication branches do
+        # perform a later nested-generator phase, though, so inspect every possible deferred member
+        # here instead of allowing that later phase to introduce a tracked migration unseen.
+        try:
+            from nirs4all.pipeline.config._generator.keywords import has_nested_generator_keywords
+
+            values: list[Any] = []
+            for item in value:
+                if not isinstance(item, dict) or not has_nested_generator_keywords(item):
+                    values.append(item)
+                    continue
+                expanded_item = _zip_column_values(item, root_seed)
+                if expanded_item is None:
+                    return None
+                values.extend(expanded_item)
+            return values
+        except Exception:  # noqa: BLE001 - a later branch expansion cannot be sampled once here.
+            return None
+    if not isinstance(value, dict):
+        return [value]
+    if _has_unprojectable_unseeded_sample(value, root_seed):
+        return None
+    try:
+        from nirs4all.pipeline.config.generator import count_combinations, expand_spec
+
+        projected = _project_for_expansion(value, root_seed)
+        count = count_combinations(projected)
+        if type(count) is not int or count > _MAX_PREFLIGHT_VARIANTS:
+            return None
+        values = expand_spec(projected, seed=root_seed)
+    except Exception:  # noqa: BLE001 - an unprovable relevant column must not hide a migration.
+        return None
+    if not isinstance(values, list) or len(values) > _MAX_PREFLIGHT_VARIANTS:
+        return None
+    return values
+
+
+def _zip_refit_column_may_require_migration(value: Any, root_seed: int | None) -> bool:
+    """Whether a ZipStrategy refit column can emit the held-out-refit override."""
+
+    values = _zip_column_values(value, root_seed)
+    if values is None:
+        return True
+    return any(isinstance(item, Mapping) and item.get("use_all_partitions") is True for item in values)
+
+
+def _zip_concat_column_may_require_migration(value: Any, root_seed: int | None) -> bool:
+    """Whether a ZipStrategy concat column can emit a stateful configuration."""
+
+    values = _zip_column_values(value, root_seed)
+    if values is None:
+        return True
+    try:
+        return any(_concat_requires_migration(item) for item in values)
+    except Exception:  # noqa: BLE001 - only the generic preflight boundary is sound here.
+        return True
+
+
+def _has_opaque_generated_mapping(value: Mapping[str, Any]) -> bool:
+    """Whether an opaque payload mapping is itself active generator input."""
+
+    try:
+        from nirs4all.pipeline.config._generator.keywords import has_nested_generator_keywords
+
+        return any(isinstance(item, dict) and has_nested_generator_keywords(item) for key, item in value.items() if key in {"model", "metadata", "params"})
+    except Exception:  # noqa: BLE001 - only relevant unknown columns are fail-closed below.
+        return any(isinstance(item, dict) for key, item in value.items() if key in {"model", "metadata", "params"})
+
+
+def _generator_columns_may_require_migration(value: Mapping[str, Any], root_seed: int | None, pre_cv_possible: bool) -> bool:
+    """Whether one grid/zip column map can produce either tracked semantic shape."""
+
+    return ("model" in value and "refit_params" in value and _zip_refit_column_may_require_migration(value["refit_params"], root_seed)) or (
+        pre_cv_possible and "concat_transform" in value and _zip_concat_column_may_require_migration(value["concat_transform"], root_seed)
+    )
+
+
+def _generator_columns_need_preflight(
+    value: Mapping[str, Any],
+    root_seed: int | None,
+    pre_cv_possible: bool,
+    generator_key: str,
+    selection_context: bool,
+) -> bool:
+    """Fail closed when opacity can alter a selected grid/zip candidate population."""
+
+    if not _has_opaque_generated_mapping(value):
+        return False
+    # Zip truncates by alignment even without ``count``. Grid is otherwise exhaustive unless a
+    # current or enclosing selector retains only part of its candidate population.
+    if generator_key != "_zip_" and not selection_context:
+        return False
+    return _generator_columns_may_require_migration(value, root_seed, pre_cv_possible)
+
+
+def _step_refit_may_require_migration(value: Any, root_seed: int | None) -> bool:
+    """Whether a direct step-level refit configuration can enable held-out refitting."""
+
+    values = _zip_column_values(value, root_seed)
+    if values is None:
+        return True
+    return any(isinstance(item, Mapping) and item.get("use_all_partitions") is True for item in values)
+
+
+def _step_concat_may_require_migration(value: Any, root_seed: int | None) -> bool:
+    """Whether a direct step-level concat configuration can be stateful."""
+
+    if not isinstance(value, dict):
+        try:
+            return _concat_requires_migration(value)
+        except Exception:  # noqa: BLE001 - a relevant unresolved concat is uninspectable.
+            return True
+    values = _zip_column_values(value, root_seed)
+    if values is None:
+        return True
+    try:
+        return any(_concat_requires_migration(item) for item in values)
+    except Exception:  # noqa: BLE001 - a relevant unresolved concat is uninspectable.
+        return True
+
+
+def _mapping_may_require_migration(value: Mapping[str, Any], root_seed: int | None, pre_cv_possible: bool) -> bool:
+    """Inspect direct and mixed-OR step candidates without interpreting unrelated payloads."""
+
+    def candidate_may_require_migration(candidate: Mapping[str, Any]) -> bool:
+        return ("model" in candidate and "refit_params" in candidate and _step_refit_may_require_migration(candidate["refit_params"], root_seed)) or (
+            pre_cv_possible and "concat_transform" in candidate and _step_concat_may_require_migration(candidate["concat_transform"], root_seed)
+        )
+
+    if candidate_may_require_migration(value):
+        return True
+    choices = value.get("_or_")
+    if not isinstance(choices, list):
+        return False
+    from nirs4all.pipeline.config._generator.keywords import PURE_OR_KEYS
+
+    base = {key: item for key, item in value.items() if key not in PURE_OR_KEYS}
+    return any(candidate_may_require_migration({**base, **choice}) for choice in choices if isinstance(choice, Mapping))
+
+
+def _selection_can_change_population(value: Mapping[str, Any], root_seed: int | None) -> bool:
+    """Whether this generator may retain only an order/cardinality-sensitive subset."""
+
+    if "_zip_" in value:
+        return True
+    count = value.get("count")
+    if type(count) is not int or count <= 0:
+        return False
+    if "_chain_" in value:
+        # Unseeded chains take the first N items; seeded chains sample N items.
+        return True
+    return bool({"_or_", "_grid_", "_cartesian_"} & value.keys()) and _effective_seed(value, root_seed) is not None
+
+
+def _selector_population_has_opaque_generator(value: Any, active: set[int] | None = None) -> bool:
+    """Whether one selected population contains an opaque mapping that expands its size/order."""
+
+    if not isinstance(value, (Mapping, list, tuple)):
+        return False
+    if active is None:
+        active = set()
+    marker = id(value)
+    if marker in active:
+        return True
+    active.add(marker)
+    try:
+        if isinstance(value, Mapping):
+            if _is_serialized_component(value) or _has_opaque_generated_mapping(value):
+                return _has_opaque_generated_mapping(value)
+            return any(_selector_population_has_opaque_generator(item, active) for key, item in value.items() if key not in {"model", "metadata", "params"})
+        return any(_selector_population_has_opaque_generator(item, active) for item in value)
+    finally:
+        active.remove(marker)
+
+
+def _selector_population_may_require_migration(
+    value: Any,
+    root_seed: int | None,
+    pre_cv_possible: bool,
+    active: set[int] | None = None,
+) -> bool:
+    """Whether any selected candidate can carry one of the two semantic migrations."""
+
+    if not isinstance(value, (Mapping, list, tuple)):
+        return False
+    if active is None:
+        active = set()
+    marker = id(value)
+    if marker in active:
+        return True
+    active.add(marker)
+    try:
+        if isinstance(value, Mapping):
+            if _is_serialized_component(value):
+                return False
+            if _mapping_may_require_migration(value, root_seed, pre_cv_possible):
+                return True
+            return any(_selector_population_may_require_migration(item, root_seed, pre_cv_possible, active) for key, item in value.items() if key not in {"model", "metadata", "params"})
+        return any(_selector_population_may_require_migration(item, root_seed, pre_cv_possible, active) for item in value)
+    finally:
+        active.remove(marker)
+
+
+def _selected_population_needs_preflight(value: Mapping[str, Any], root_seed: int | None, pre_cv_possible: bool) -> bool:
+    """Whether an opaque sibling can change which migration-bearing candidate selection retains."""
+
+    return _selection_can_change_population(value, root_seed) and _selector_population_has_opaque_generator(value) and _selector_population_may_require_migration(value, root_seed, pre_cv_possible)
+
+
+def _project_generator_columns(
+    value: Mapping[str, Any],
+    root_seed: int | None,
+    active: set[int],
+    block_inherited_seed: bool,
+    generator_key: str,
+    pre_cv_possible: bool,
+    selection_context: bool,
+) -> dict[str, Any]:
+    """Preserve map-generator alignment while making model and parameter payloads opaque."""
+
+    marker = id(value)
+    if marker in active:
+        _raise_uninspectable("a cyclic active generator")
+    active.add(marker)
+    try:
+        if _generator_columns_need_preflight(
+            value,
+            root_seed,
+            pre_cv_possible,
+            generator_key,
+            selection_context,
+        ):
+            _raise_uninspectable("a selected generator whose opaque generated mapping can change a migration-bearing candidate")
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in {"model", "metadata", "params"}:
+                result[key] = _opaque_with_shape(item)
+            else:
+                result[key] = _project_for_expansion(
+                    item,
+                    root_seed,
+                    active,
+                    block_inherited_seed,
+                    pre_cv_possible,
+                    selection_context,
+                )
+        return result
+    finally:
+        active.remove(marker)
+
+
+def _project_branch_for_expansion(
+    value: Any,
+    root_seed: int | None,
+    active: set[int],
+    pre_cv_possible: bool,
+    selection_context: bool,
+) -> Any:
+    """Project a branch with the seed contract of the controller that expands it."""
+
+    if isinstance(value, Mapping) and _SEPARATION_BRANCH_KEYS & value.keys():
+        # PipelineConfigs expands separation-branch generators at its top level, carrying the root seed.
+        return _project_for_expansion(
+            value,
+            root_seed,
+            active,
+            pre_cv_possible=pre_cv_possible,
+            selection_context=selection_context,
+        )
+    # Duplication branches are expanded later by BranchController, which calls expand_spec() without
+    # PipelineConfigs.random_state. A ``_seed_: None`` sentinel must be projected onto each of their
+    # generator nodes, otherwise the OUTER expand_spec(..., seed=root_seed) would re-inherit that seed.
+    # Their local explicit _seed_ remains meaningful.
+    return _project_for_expansion(
+        value,
+        None,
+        active,
+        block_inherited_seed=True,
+        pre_cv_possible=pre_cv_possible,
+        selection_context=selection_context,
+    )
+
+
+def _project_for_expansion(
+    value: Any,
+    root_seed: int | None,
+    active: set[int] | None = None,
+    block_inherited_seed: bool = False,
+    pre_cv_possible: bool = True,
+    selection_context: bool = False,
+) -> Any:
+    """Copy only active DSL structure for generator expansion.
+
+    ``metadata`` and component ``params`` are opaque payloads: their keys must never create a semantic
+    refusal.  Keeping them opaque also means a cycle in metadata cannot poison the active-DSL check.
+    """
+
+    if active is None:
+        active = set()
+    value = _minimal_step_config(value)
+    if isinstance(value, _Opaque):
+        return value
+    if isinstance(value, (list, tuple)):
+        marker = id(value)
+        if marker in active:
+            _raise_uninspectable("a cyclic active pipeline sequence")
+        active.add(marker)
+        try:
+            return [
+                _project_for_expansion(
+                    item,
+                    root_seed,
+                    active,
+                    block_inherited_seed,
+                    pre_cv_possible,
+                    selection_context,
+                )
+                for item in value
+            ]
+        finally:
+            active.remove(marker)
+    if not isinstance(value, Mapping):
+        return value
+    if _is_serialized_component(value):
+        return _Opaque(value)
+
+    marker = id(value)
+    if marker in active:
+        _raise_uninspectable("a cyclic active pipeline mapping")
+    active.add(marker)
+    try:
+        is_selector = _selection_can_change_population(value, root_seed)
+        if _selected_population_needs_preflight(value, root_seed, pre_cv_possible):
+            _raise_uninspectable("a selected generator whose opaque sibling can change a migration-bearing candidate")
+        selection_context = selection_context or is_selector
+        if selection_context and _has_opaque_generated_mapping(value) and _mapping_may_require_migration(value, root_seed, pre_cv_possible):
+            _raise_uninspectable("a selected generator whose opaque generated mapping can change a migration-bearing candidate")
+        sampled_choices = _unseeded_choice_sample(value, root_seed)
+        if sampled_choices is not None:
+            # A raw pipeline is normalized again by the legacy runner.  An unseeded choice can change
+            # between this preflight and that later normalization, so inspect every possible choice.
+            sampled_result: dict[str, Any] = {
+                "_or_": [
+                    _project_for_expansion(
+                        choice,
+                        root_seed,
+                        active,
+                        block_inherited_seed,
+                        pre_cv_possible,
+                        selection_context,
+                    )
+                    for choice in sampled_choices
+                ]
+            }
+            if block_inherited_seed:
+                sampled_result["_seed_"] = None
+            return sampled_result
+
+        remove_random_count = _random_count_is_unseeded(value, root_seed)
+        if remove_random_count and "_or_" in value and "_weights_" in value:
+            # A weighted selection can make a syntactically unsafe option unreachable (for example a
+            # zero-weight candidate). Reproducing its support exactly across nested expansion is a
+            # separate grammar problem, so fail closed as *uninspectable* rather than falsely call that
+            # candidate an active semantic migration.
+            _raise_uninspectable("an unseeded weighted _or_ generator")
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if key == "count" and remove_random_count:
+                # ``_or_``, grid, zip, and cartesian sample a positive count at random when unseeded.
+                # Enumerating their full legal output is the only stable proof before a later legacy run.
+                continue
+            if key in {"metadata", "params", "model"}:
+                result[key] = _Opaque(item)
+            elif key == "branch":
+                result[key] = _project_branch_for_expansion(
+                    item,
+                    root_seed,
+                    active,
+                    pre_cv_possible,
+                    selection_context,
+                )
+            elif key in {"_grid_", "_zip_"} and isinstance(item, Mapping):
+                result[key] = _project_generator_columns(
+                    item,
+                    root_seed,
+                    active,
+                    block_inherited_seed,
+                    generator_key=key,
+                    pre_cv_possible=pre_cv_possible,
+                    selection_context=selection_context,
+                )
+            else:
+                result[key] = _project_for_expansion(
+                    item,
+                    root_seed,
+                    active,
+                    block_inherited_seed,
+                    pre_cv_possible,
+                    selection_context,
+                )
+        if block_inherited_seed and "_seed_" not in result and _GENERATOR_KEYS & value.keys():
+            result["_seed_"] = None
+        return result
+    finally:
+        active.remove(marker)
+
+
+def _project_pipeline_sequence(steps: list[Any], root_seed: int | None) -> list[Any]:
+    """Project top-level steps while retaining the definite pre-CV prefix boundary.
+
+    A generated splitter is not proof that every output has entered CV, so only an already concrete
+    splitter closes the prefix. This deliberately keeps uncertain nested control flow fail-closed.
+    """
+
+    active: set[int] = set()
+    marker = id(steps)
+    active.add(marker)
+    try:
+        projected: list[Any] = []
+        pre_cv_possible = True
+        for step in steps:
+            projected.append(_project_for_expansion(step, root_seed, active, pre_cv_possible=pre_cv_possible))
+            pre_cv_possible = pre_cv_possible and not _is_splitter(_minimal_step_config(_unwrap(step)))
+        return projected
+    finally:
+        active.remove(marker)
+
+
+def _load_string_definition(value: str) -> Any:
+    """Load the documented YAML/JSON path or literal form while retaining root ``random_state``."""
+
+    path = Path(value)
+    suffix = path.suffix.lower()
+    if suffix in {".json", ".yaml", ".yml"}:
+        if not path.is_file():
+            _raise_uninspectable(f"pipeline configuration path {value!r}")
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text) if suffix == ".json" else yaml.safe_load(text)
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return yaml.safe_load(value)
+
+
+def _raw_steps_and_seed(pipeline: Any) -> tuple[list[Any], int | None]:
+    """Normalize one public definition just far enough to inspect its active template."""
+
+    if isinstance(pipeline, Path):
+        pipeline = str(pipeline)
+    try:
+        definition = _load_string_definition(pipeline) if isinstance(pipeline, str) else pipeline
+        if isinstance(definition, list):
+            return list(definition), None
+        if not isinstance(definition, Mapping):
+            _raise_uninspectable("pipeline")
+        key = "pipeline" if "pipeline" in definition else "steps" if "steps" in definition else None
+        if key is None or not isinstance(definition[key], list):
+            _raise_uninspectable("pipeline wrapper")
+        seed = definition.get("random_state")
+        return list(definition[key]), seed if type(seed) is int else None
+    except DagMlMigrationRequired:
+        raise
+    except Exception as error:  # noqa: BLE001 - this is the fail-closed public boundary.
+        _raise_uninspectable("pipeline configuration", error)
+
+
+def _looks_like_pipeline_step(value: Any) -> bool:
+    """Mirror the public list/batch disambiguation without importing the public API module."""
+
+    if value is None or isinstance(value, (dict, type)):
+        return True
+    if hasattr(value, "fit") or hasattr(value, "transform") or hasattr(value, "predict") or hasattr(value, "split"):
+        return True
+    return bool(hasattr(value, "__class__") and value.__class__.__module__.startswith("nirs4all"))
+
+
+def _batch_status(value: list[Any], pipeline_configs_type: type[Any]) -> tuple[bool, int | None]:
+    """Return ``(is_batch, opaque_member_index)`` for the public outer-list grammar."""
+
+    saw_pipeline_spec = False
+    saw_step = False
+    opaque_member: int | None = None
+    for index, item in enumerate(value):
+        if isinstance(item, (pipeline_configs_type, str, Path, list)) or (isinstance(item, Mapping) and any(key in item for key in ("pipeline", "steps"))):
+            saw_pipeline_spec = True
+        elif _looks_like_pipeline_step(item):
+            saw_step = True
+        elif opaque_member is None:
+            opaque_member = index
+    if saw_pipeline_spec and opaque_member is not None:
+        return False, opaque_member
+    return saw_pipeline_spec and not saw_step, None
+
+
+def _public_variants(pipeline: Any, active_batches: set[int] | None = None) -> list[tuple[list[Any], int | None]]:
+    """Return every inspectable public pipeline member and its generator root seed."""
+
+    from nirs4all.pipeline.config.pipeline_config import PipelineConfigs
+
+    if isinstance(pipeline, PipelineConfigs):
+        steps = pipeline.steps
+        if not isinstance(steps, list) or any(not isinstance(item, list) for item in steps):
+            _raise_uninspectable("PipelineConfigs.steps")
+        seed = pipeline.random_state if type(pipeline.random_state) is int else None
+        return [(list(item), seed) for item in steps]
+    if not isinstance(pipeline, list):
+        return [_raw_steps_and_seed(pipeline)]
+
+    is_batch, opaque_member = _batch_status(pipeline, PipelineConfigs)
+    if opaque_member is not None:
+        _raise_uninspectable(f"pipeline batch item {opaque_member}")
+    if not is_batch:
+        return [(list(pipeline), None)]
+
+    if active_batches is None:
+        active_batches = set()
+    marker = id(pipeline)
+    if marker in active_batches:
+        _raise_uninspectable("a cyclic public pipeline batch")
+    active_batches.add(marker)
+    try:
+        variants: list[tuple[list[Any], int | None]] = []
+        for item in pipeline:
+            variants.extend(_public_variants(item, active_batches))
+        return variants
+    finally:
+        active_batches.remove(marker)
+
+
+def _expanded_variants(steps: list[Any], root_seed: int | None) -> list[list[Any]]:
+    """Expand the same generator grammar legacy uses, with exhaustive unseeded choices."""
+
+    from nirs4all.pipeline.config.generator import count_combinations, expand_spec
+
+    projected = _project_pipeline_sequence(steps, root_seed)
+    try:
+        count = count_combinations(projected)
+        if type(count) is not int or count > _MAX_PREFLIGHT_VARIANTS:
+            _raise_uninspectable("a generator set larger than the inspectable preflight bound")
+        expanded = expand_spec(projected, seed=root_seed)
+    except DagMlMigrationRequired:
+        raise
+    except Exception as error:  # noqa: BLE001 - an opaque active generator is not a fallback path.
+        _raise_uninspectable("an active pipeline generator", error)
+    if len(expanded) > _MAX_PREFLIGHT_VARIANTS or any(not isinstance(item, list) for item in expanded):
+        _raise_uninspectable("expanded pipeline variants")
+    return expanded
+
+
+def _is_splitter(value: Any) -> bool:
+    """Recognize raw and serialized splitter steps without descending into their params."""
+
+    value = _unwrap(value)
+    if hasattr(value, "split"):
+        return True
+    if not isinstance(value, (str, Mapping)):
+        return False
+    try:
+        from nirs4all.pipeline.config.component_serialization import deserialize_component
+
+        return hasattr(deserialize_component(value), "split")
+    except Exception:  # noqa: BLE001 - an unknown component cannot prove that CV already began.
+        return False
+
+
+def _operator_is_stateless(value: Any) -> bool:
+    """Resolve serialized concat leaves before reusing the existing conservative stateless probe."""
+
+    value = _unwrap(value)
+    if value is None:
+        return True
+    if isinstance(value, (str, Mapping)):
+        try:
+            from nirs4all.pipeline.config.component_serialization import deserialize_component
+
+            value = deserialize_component(value)
+        except Exception:  # noqa: BLE001 - unresolved leaves are not proven stateless.
+            return False
+    try:
+        from .run_paths import _operator_is_stateless as probe
+
+        return probe(value)
+    except Exception:  # noqa: BLE001 - the probe itself is intentionally fail-closed.
+        return False
+
+
+def _concat_requires_migration(config: Any, active: set[int] | None = None) -> bool:
+    """Whether one active concat configuration contains a learned or opaque leaf."""
+
+    if active is None:
+        active = set()
+    config = _unwrap(config)
+    if isinstance(config, (list, tuple, Mapping)):
+        marker = id(config)
+        if marker in active:
+            _raise_uninspectable("a cyclic active concat_transform")
+        active.add(marker)
+    else:
+        marker = None
+    try:
+        if isinstance(config, Mapping) and "concat_transform" in config:
+            return _concat_requires_migration(config["concat_transform"], active)
+        if isinstance(config, Mapping):
+            # Legacy's concat controller also accepts a named-operation map such as
+            # {"snv": StandardNormalVariate()}; without an explicit ``operations`` key, every value
+            # is an operation rather than an opaque configuration payload.
+            operations = config.get("operations") if "operations" in config else list(config.values())
+        else:
+            operations = config
+        if not isinstance(operations, (list, tuple)):
+            return True
+        for operation in operations:
+            operation = _unwrap(operation)
+            if isinstance(operation, (list, tuple)):
+                if _concat_requires_migration(operation, active):
+                    return True
+            elif isinstance(operation, Mapping) and "concat_transform" in operation:
+                if _concat_requires_migration(operation["concat_transform"], active):
+                    return True
+            elif not _operator_is_stateless(operation):
+                return True
+        return False
+    finally:
+        if marker is not None:
+            active.remove(marker)
+
+
+def _raise_refit_migration() -> None:
+    raise DagMlRefitParamsMigrationRequired(
+        "engine='dag-ml' refuses refit_params.use_all_partitions=True: legacy may refit on held-out "
+        "test partitions, while DAG-ML fixes REFIT FullTrain to FoldSet sample IDs. This is an explicit "
+        "migration requirement, not a legacy-fallback boundary; remove the override or select "
+        "engine='legacy' explicitly."
+    )
+
+
+def _raise_concat_migration() -> None:
+    raise DagMlStatefulConcatTransformMigrationRequired(
+        "engine='dag-ml' refuses a stateful concat_transform before CV: legacy materializes learned "
+        "features globally, while native FeatureConcat fits them fold-locally. This is an explicit "
+        "migration requirement, not a legacy-fallback boundary; use a native-equivalent pipeline or "
+        "select engine='legacy' explicitly."
+    )
+
+
+def _scan_branch(branch: Any, seen_splitter: bool, active: set[int]) -> None:
+    """Inspect only executable branch bodies, never branch metadata or selectors."""
+
+    branch = _unwrap(branch)
+    if isinstance(branch, list):
+        for entry in branch:
+            entry = _unwrap(entry)
+            if isinstance(entry, Mapping) and "steps" in entry:
+                _scan_sequence(entry["steps"], seen_splitter, active)
+            else:
+                _scan_step(entry, seen_splitter, active)
+        return
+    if not isinstance(branch, Mapping):
+        _scan_step(branch, seen_splitter, active)
+        return
+    if _SEPARATION_BRANCH_KEYS & branch.keys():
+        body = branch.get("steps")
+        if isinstance(body, Mapping):
+            for item in body.values():
+                _scan_step(item, seen_splitter, active)
+        elif body is not None:
+            _scan_step(body, seen_splitter, active)
+        return
+    for name, body in branch.items():
+        if not isinstance(name, str) or name.startswith("_") or name in _BRANCH_OPTION_KEYS:
+            continue
+        _scan_step(body, seen_splitter, active)
+
+
+def _scan_step(value: Any, seen_splitter: bool, active: set[int]) -> bool:
+    """Inspect one expanded step and return whether its containing sequence has reached CV."""
+
+    value = _minimal_step_config(_unwrap(value))
+    if isinstance(value, list):
+        return _scan_sequence(value, seen_splitter, active)
+    if not isinstance(value, Mapping):
+        return seen_splitter or _is_splitter(value)
+    if _is_serialized_component(value):
+        return seen_splitter or _is_splitter(value)
+
+    marker = id(value)
+    if marker in active:
+        _raise_uninspectable("a cyclic active pipeline mapping")
+    active.add(marker)
+    try:
+        if "model" in value:
+            refit = _unwrap(value.get("refit_params"))
+            if isinstance(refit, Mapping) and refit.get("use_all_partitions") is True:
+                _raise_refit_migration()
+        if "concat_transform" in value and not seen_splitter and _concat_requires_migration(value["concat_transform"]):
+            _raise_concat_migration()
+        if "branch" in value:
+            _scan_branch(value["branch"], seen_splitter, active)
+        if "feature_augmentation" in value:
+            _scan_step(value["feature_augmentation"], seen_splitter, active)
+        return seen_splitter or _is_splitter(value)
+    finally:
+        active.remove(marker)
+
+
+def _scan_sequence(steps: Any, seen_splitter: bool, active: set[int] | None = None) -> bool:
+    """Scan a concrete pipeline sequence in execution order to identify the pre-CV prefix."""
+
+    steps = _unwrap(steps)
+    if not isinstance(steps, (list, tuple)):
+        return _scan_step(steps, seen_splitter, active or set())
+    if active is None:
+        active = set()
+    marker = id(steps)
+    if marker in active:
+        _raise_uninspectable("a cyclic active pipeline sequence")
+    active.add(marker)
+    try:
+        for step in steps:
+            seen_splitter = _scan_step(step, seen_splitter, active)
+        return seen_splitter
+    finally:
+        active.remove(marker)
+
+
+def preflight_dagml_pipeline_migration(pipeline: Any) -> None:
+    """Refuse semantic migrations before backend availability, datasets, or legacy fallback can run.
+
+    Raw definitions use the library's generator expander.  Deterministic generators are inspected in
+    their exact legacy expansion; unseeded random selections are expanded conservatively across every
+    possible candidate, since a later legacy normalization may choose a different result.
+    """
+
+    for steps, root_seed in _public_variants(pipeline):
+        for variant in _expanded_variants(steps, root_seed):
+            _scan_sequence(variant, seen_splitter=False)

--- a/nirs4all/pipeline/dagml/migration_preflight.py
+++ b/nirs4all/pipeline/dagml/migration_preflight.py
@@ -1,9 +1,9 @@
 """Fail-closed semantic migration checks before DAG-ML routing.
 
-This module is deliberately narrower than a second pipeline parser.  It only proves two legacy
-semantics that may not use ``allow_legacy_fallback``: refitting with held-out partitions, and a
-stateful ``concat_transform`` materialized before cross-validation.  All ordinary unsupported
-shapes continue through the existing capability fallback path.
+This module is deliberately narrower than a second pipeline parser. It proves
+only one legacy semantic that may not use ``allow_legacy_fallback``: a stateful
+``concat_transform`` materialized before cross-validation. All ordinary
+unsupported shapes continue through the existing capability fallback path.
 """
 
 from __future__ import annotations
@@ -19,7 +19,6 @@ import yaml
 from .errors import (
     DagMlMigrationRequired,
     DagMlPipelinePreflightRequired,
-    DagMlRefitParamsMigrationRequired,
     DagMlStatefulConcatTransformMigrationRequired,
 )
 
@@ -27,6 +26,7 @@ _MAX_PREFLIGHT_VARIANTS = 10_000
 _SERIALIZED_COMPONENT_KEYS = frozenset({"class", "function", "module", "object", "instance"})
 _SEPARATION_BRANCH_KEYS = frozenset({"by_tag", "by_metadata", "by_filter", "by_source"})
 _BRANCH_OPTION_KEYS = frozenset({"parallel", "n_jobs", "metadata", "params"})
+_OPAQUE_PAYLOAD_KEYS = frozenset({"model", "metadata", "params", "refit_params"})
 _RANDOM_COUNT_GENERATOR_KEYS = frozenset({"_or_", "_grid_", "_zip_", "_cartesian_"})
 _GENERATOR_KEYS = frozenset({"_or_", "_range_", "_log_range_", "_grid_", "_zip_", "_chain_", "_sample_", "_cartesian_"})
 
@@ -39,12 +39,12 @@ class _Opaque:
 
 
 def _raise_uninspectable(context: str, cause: BaseException | None = None) -> NoReturn:
-    """Refuse an active DSL shape whose semantic boundary cannot be proven safely."""
+    """Refuse only concat-relevant generator uncertainty before a fallback can occur."""
 
     error = DagMlPipelinePreflightRequired(
-        f"engine='dag-ml' cannot inspect {context} before semantic migration preflight. "
-        "Automatic legacy fallback is disabled for this active pipeline form; provide a documented "
-        "list/dict/YAML-or-JSON/Path/PipelineConfigs pipeline, or select engine='legacy' explicitly."
+        f"engine='dag-ml' cannot determine whether {context} selects a stateful concat_transform before CV. "
+        "Automatic legacy fallback is disabled only for this concat-semantic uncertainty; provide a "
+        "documented list/dict/YAML-or-JSON/Path/PipelineConfigs pipeline, or select engine='legacy' explicitly."
     )
     if cause is None:
         raise error
@@ -197,15 +197,6 @@ def _zip_column_values(value: Any, root_seed: int | None) -> list[Any] | None:
     return values
 
 
-def _zip_refit_column_may_require_migration(value: Any, root_seed: int | None) -> bool:
-    """Whether a ZipStrategy refit column can emit the held-out-refit override."""
-
-    values = _zip_column_values(value, root_seed)
-    if values is None:
-        return True
-    return any(isinstance(item, Mapping) and item.get("use_all_partitions") is True for item in values)
-
-
 def _zip_concat_column_may_require_migration(value: Any, root_seed: int | None) -> bool:
     """Whether a ZipStrategy concat column can emit a stateful configuration."""
 
@@ -224,17 +215,15 @@ def _has_opaque_generated_mapping(value: Mapping[str, Any]) -> bool:
     try:
         from nirs4all.pipeline.config._generator.keywords import has_nested_generator_keywords
 
-        return any(isinstance(item, dict) and has_nested_generator_keywords(item) for key, item in value.items() if key in {"model", "metadata", "params"})
+        return any(isinstance(item, dict) and has_nested_generator_keywords(item) for key, item in value.items() if key in _OPAQUE_PAYLOAD_KEYS)
     except Exception:  # noqa: BLE001 - only relevant unknown columns are fail-closed below.
-        return any(isinstance(item, dict) for key, item in value.items() if key in {"model", "metadata", "params"})
+        return any(isinstance(item, dict) for key, item in value.items() if key in _OPAQUE_PAYLOAD_KEYS)
 
 
 def _generator_columns_may_require_migration(value: Mapping[str, Any], root_seed: int | None, pre_cv_possible: bool) -> bool:
-    """Whether one grid/zip column map can produce either tracked semantic shape."""
+    """Whether one grid/zip column map can produce a stateful pre-CV concat."""
 
-    return ("model" in value and "refit_params" in value and _zip_refit_column_may_require_migration(value["refit_params"], root_seed)) or (
-        pre_cv_possible and "concat_transform" in value and _zip_concat_column_may_require_migration(value["concat_transform"], root_seed)
-    )
+    return pre_cv_possible and "concat_transform" in value and _zip_concat_column_may_require_migration(value["concat_transform"], root_seed)
 
 
 def _generator_columns_need_preflight(
@@ -253,15 +242,6 @@ def _generator_columns_need_preflight(
     if generator_key != "_zip_" and not selection_context:
         return False
     return _generator_columns_may_require_migration(value, root_seed, pre_cv_possible)
-
-
-def _step_refit_may_require_migration(value: Any, root_seed: int | None) -> bool:
-    """Whether a direct step-level refit configuration can enable held-out refitting."""
-
-    values = _zip_column_values(value, root_seed)
-    if values is None:
-        return True
-    return any(isinstance(item, Mapping) and item.get("use_all_partitions") is True for item in values)
 
 
 def _step_concat_may_require_migration(value: Any, root_seed: int | None) -> bool:
@@ -285,9 +265,7 @@ def _mapping_may_require_migration(value: Mapping[str, Any], root_seed: int | No
     """Inspect direct and mixed-OR step candidates without interpreting unrelated payloads."""
 
     def candidate_may_require_migration(candidate: Mapping[str, Any]) -> bool:
-        return ("model" in candidate and "refit_params" in candidate and _step_refit_may_require_migration(candidate["refit_params"], root_seed)) or (
-            pre_cv_possible and "concat_transform" in candidate and _step_concat_may_require_migration(candidate["concat_transform"], root_seed)
-        )
+        return pre_cv_possible and "concat_transform" in candidate and _step_concat_may_require_migration(candidate["concat_transform"], root_seed)
 
     if candidate_may_require_migration(value):
         return True
@@ -329,7 +307,7 @@ def _selector_population_has_opaque_generator(value: Any, active: set[int] | Non
         if isinstance(value, Mapping):
             if _is_serialized_component(value) or _has_opaque_generated_mapping(value):
                 return _has_opaque_generated_mapping(value)
-            return any(_selector_population_has_opaque_generator(item, active) for key, item in value.items() if key not in {"model", "metadata", "params"})
+            return any(_selector_population_has_opaque_generator(item, active) for key, item in value.items() if key not in _OPAQUE_PAYLOAD_KEYS)
         return any(_selector_population_has_opaque_generator(item, active) for item in value)
     finally:
         active.remove(marker)
@@ -341,7 +319,7 @@ def _selector_population_may_require_migration(
     pre_cv_possible: bool,
     active: set[int] | None = None,
 ) -> bool:
-    """Whether any selected candidate can carry one of the two semantic migrations."""
+    """Whether any selected candidate can carry a stateful pre-CV concat."""
 
     if not isinstance(value, (Mapping, list, tuple)):
         return False
@@ -357,7 +335,7 @@ def _selector_population_may_require_migration(
                 return False
             if _mapping_may_require_migration(value, root_seed, pre_cv_possible):
                 return True
-            return any(_selector_population_may_require_migration(item, root_seed, pre_cv_possible, active) for key, item in value.items() if key not in {"model", "metadata", "params"})
+            return any(_selector_population_may_require_migration(item, root_seed, pre_cv_possible, active) for key, item in value.items() if key not in _OPAQUE_PAYLOAD_KEYS)
         return any(_selector_population_may_require_migration(item, root_seed, pre_cv_possible, active) for item in value)
     finally:
         active.remove(marker)
@@ -395,7 +373,7 @@ def _project_generator_columns(
             _raise_uninspectable("a selected generator whose opaque generated mapping can change a migration-bearing candidate")
         result: dict[str, Any] = {}
         for key, item in value.items():
-            if key in {"model", "metadata", "params"}:
+            if key in _OPAQUE_PAYLOAD_KEYS:
                 result[key] = _opaque_with_shape(item)
             else:
                 result[key] = _project_for_expansion(
@@ -531,7 +509,7 @@ def _project_for_expansion(
                 # ``_or_``, grid, zip, and cartesian sample a positive count at random when unseeded.
                 # Enumerating their full legal output is the only stable proof before a later legacy run.
                 continue
-            if key in {"metadata", "params", "model"}:
+            if key in _OPAQUE_PAYLOAD_KEYS:
                 result[key] = _Opaque(item)
             elif key == "branch":
                 result[key] = _project_branch_for_expansion(
@@ -787,15 +765,6 @@ def _concat_requires_migration(config: Any, active: set[int] | None = None) -> b
             active.remove(marker)
 
 
-def _raise_refit_migration() -> None:
-    raise DagMlRefitParamsMigrationRequired(
-        "engine='dag-ml' refuses refit_params.use_all_partitions=True: legacy may refit on held-out "
-        "test partitions, while DAG-ML fixes REFIT FullTrain to FoldSet sample IDs. This is an explicit "
-        "migration requirement, not a legacy-fallback boundary; remove the override or select "
-        "engine='legacy' explicitly."
-    )
-
-
 def _raise_concat_migration() -> None:
     raise DagMlStatefulConcatTransformMigrationRequired(
         "engine='dag-ml' refuses a stateful concat_transform before CV: legacy materializes learned "
@@ -803,6 +772,85 @@ def _raise_concat_migration() -> None:
         "migration requirement, not a legacy-fallback boundary; use a native-equivalent pipeline or "
         "select engine='legacy' explicitly."
     )
+
+
+def _concat_config_may_be_stateful(config: Any) -> bool:
+    """Whether a raw concat config makes the semantic preflight relevant at all."""
+
+    try:
+        return _concat_requires_migration(config)
+    except DagMlPipelinePreflightRequired:
+        return True
+
+
+def _branch_may_contain_stateful_pre_cv_concat(branch: Any, seen_splitter: bool, active: set[int]) -> bool:
+    """Check executable branch bodies without descending into metadata-like payloads."""
+
+    if isinstance(branch, list):
+        return any(_value_may_contain_stateful_pre_cv_concat(entry, seen_splitter, active) for entry in branch)
+    if not isinstance(branch, Mapping):
+        return _value_may_contain_stateful_pre_cv_concat(branch, seen_splitter, active)
+    if _SEPARATION_BRANCH_KEYS & branch.keys():
+        body = branch.get("steps")
+        if isinstance(body, Mapping):
+            return any(_value_may_contain_stateful_pre_cv_concat(item, seen_splitter, active) for item in body.values())
+        return _value_may_contain_stateful_pre_cv_concat(body, seen_splitter, active) if body is not None else False
+    return any(_value_may_contain_stateful_pre_cv_concat(body, seen_splitter, active) for name, body in branch.items() if isinstance(name, str) and not name.startswith("_") and name not in _BRANCH_OPTION_KEYS)
+
+
+def _value_may_contain_stateful_pre_cv_concat(value: Any, seen_splitter: bool, active: set[int]) -> bool:
+    """Conservatively find the one semantic boundary without interpreting payloads."""
+
+    value = _minimal_step_config(value)
+    if isinstance(value, (list, tuple)):
+        marker = id(value)
+        if marker in active:
+            return False
+        active.add(marker)
+        try:
+            for item in value:
+                if _value_may_contain_stateful_pre_cv_concat(item, seen_splitter, active):
+                    return True
+                seen_splitter = seen_splitter or _is_splitter(_minimal_step_config(item))
+            return False
+        finally:
+            active.remove(marker)
+    if not isinstance(value, Mapping) or _is_serialized_component(value):
+        return False
+
+    marker = id(value)
+    if marker in active:
+        return False
+    active.add(marker)
+    try:
+        if not seen_splitter and "concat_transform" in value and _concat_config_may_be_stateful(value["concat_transform"]):
+            return True
+        if "branch" in value and _branch_may_contain_stateful_pre_cv_concat(value["branch"], seen_splitter, active):
+            return True
+        return any(_value_may_contain_stateful_pre_cv_concat(item, seen_splitter, active) for key, item in value.items() if key not in _OPAQUE_PAYLOAD_KEYS | {"branch", "concat_transform"})
+    finally:
+        active.remove(marker)
+
+
+def _pipeline_may_contain_stateful_pre_cv_concat(pipeline: Any) -> bool:
+    """Whether the supplied public form needs concat semantic preflight at all.
+
+    This deliberately returns false for unreadable or malformed public forms: they belong to the
+    ordinary compatibility/error path unless a valid active concat boundary can be identified.
+    """
+
+    try:
+        from nirs4all.pipeline.config.pipeline_config import PipelineConfigs
+
+        if isinstance(pipeline, PipelineConfigs):
+            return _value_may_contain_stateful_pre_cv_concat(pipeline.steps, False, set())
+        if isinstance(pipeline, Path):
+            pipeline = str(pipeline)
+        if isinstance(pipeline, str):
+            pipeline = _load_string_definition(pipeline)
+    except Exception:  # noqa: BLE001 - malformed non-concat forms must keep their ordinary path.
+        return False
+    return _value_may_contain_stateful_pre_cv_concat(pipeline, False, set())
 
 
 def _scan_branch(branch: Any, seen_splitter: bool, active: set[int]) -> None:
@@ -850,10 +898,6 @@ def _scan_step(value: Any, seen_splitter: bool, active: set[int]) -> bool:
         _raise_uninspectable("a cyclic active pipeline mapping")
     active.add(marker)
     try:
-        if "model" in value:
-            refit = _unwrap(value.get("refit_params"))
-            if isinstance(refit, Mapping) and refit.get("use_all_partitions") is True:
-                _raise_refit_migration()
         if "concat_transform" in value and not seen_splitter and _concat_requires_migration(value["concat_transform"]):
             _raise_concat_migration()
         if "branch" in value:
@@ -892,6 +936,9 @@ def preflight_dagml_pipeline_migration(pipeline: Any) -> None:
     their exact legacy expansion; unseeded random selections are expanded conservatively across every
     possible candidate, since a later legacy normalization may choose a different result.
     """
+
+    if not _pipeline_may_contain_stateful_pre_cv_concat(pipeline):
+        return
 
     for steps, root_seed in _public_variants(pipeline):
         for variant in _expanded_variants(steps, root_seed):

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -60,6 +60,7 @@ from .finetune_lowering import (
     reject_native_training_param_overrides,
 )
 from .folds import _build_folds, _build_group_folds, _is_repetition_dataset, _repetition_groups_for_pool
+from .migration_preflight import preflight_dagml_pipeline_migration
 from .native_results import native_results_enabled, write_native_results
 from .result import _project_operator_sweep, _scores_to_run_result
 from .run_paths import (
@@ -117,6 +118,7 @@ __all__ = [
     "_run_by_source_distinct_preproc_concat",
     "_run_rep_fusion",
     "_run_source_concat_merge",
+    "preflight_dagml_pipeline_migration",
     "preflight_dagml_backend",
     "run_via_dagml",
 ]
@@ -363,6 +365,12 @@ def run_via_dagml(
         A :class:`~nirs4all.api.result.RunResult` whose ``best_rmse`` is the native final-test score
         and ``cv_best_score`` is the native cross-fold OOF average.
     """
+    # Semantic migration requirements come before every catchable capability check: an explicit native
+    # request must never appear to succeed through legacy fallback when it changes the refit identity or
+    # pre-CV concat semantics. The check reads pipeline configuration only; it does not probe a backend,
+    # construct a PipelineRunner, or materialize the dataset.
+    preflight_dagml_pipeline_migration(pipeline)
+
     # Validate the run() options the scores-only in-memory path cannot honor BEFORE any work: a
     # non-honorable non-default raises DagMlUnsupported so run() falls back to legacy (never a silent
     # drop). Defaults pass through untouched, so a plain engine='dag-ml' run is unaffected.

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -366,8 +366,8 @@ def run_via_dagml(
         and ``cv_best_score`` is the native cross-fold OOF average.
     """
     # Semantic migration requirements come before every catchable capability check: an explicit native
-    # request must never appear to succeed through legacy fallback when it changes the refit identity or
-    # pre-CV concat semantics. The check reads pipeline configuration only; it does not probe a backend,
+    # request must never appear to succeed through legacy fallback when it changes pre-CV concat semantics.
+    # The check reads pipeline configuration only; it does not probe a backend,
     # construct a PipelineRunner, or materialize the dataset.
     preflight_dagml_pipeline_migration(pipeline)
 

--- a/tests/integration/parity/_authority.py
+++ b/tests/integration/parity/_authority.py
@@ -25,6 +25,7 @@ from ._registry import all_cases
 from .test_conformance_dual_engine import (
     CV_BEST_SCORE_DIVERGENCE,
     EXPECTED_FALLBACK,
+    EXPECTED_PREFLIGHT_REFUSAL,
     KNOWN_DIVERGENCES,
     NUM_PREDICTIONS_DIVERGENCE,
     RUNRESULT_SCORE_DIVERGENCE,
@@ -46,6 +47,7 @@ def validate_compatibility_ledger(ledger: dict[str, Any] | None = None) -> None:
     _validate_tolerance_bands(data)
     _validate_authority_entries(data)
     _validate_expected_fallback(data)
+    _validate_expected_preflight_refusal(data)
     _validate_num_prediction_divergences(data)
     _validate_cv_best_score_divergences(data)
     _validate_runresult_score_divergences(data)
@@ -156,6 +158,25 @@ def _validate_expected_fallback(data: dict[str, Any]) -> None:
         raise AssertionError(f"expected_fallback entries must be owned by L5: {bad_owner}")
 
 
+def _validate_expected_preflight_refusal(data: dict[str, Any]) -> None:
+    actual = {row["case"]: row for row in data["expected_preflight_refusal"]}
+    expected = EXPECTED_PREFLIGHT_REFUSAL
+    if set(actual) != set(expected):
+        raise AssertionError(
+            "EXPECTED_PREFLIGHT_REFUSAL ledger drift: "
+            f"expected={sorted(expected)} actual={sorted(actual)}"
+        )
+    overlap = set(actual) & set(EXPECTED_FALLBACK)
+    if overlap:
+        raise AssertionError(f"preflight refusal cases must not remain fallback cases: {sorted(overlap)}")
+    for case_name, expected_refusal_type in expected.items():
+        row = actual[case_name]
+        if row.get("error_type") != expected_refusal_type.__name__:
+            raise AssertionError(f"preflight refusal error type drifted for {case_name}")
+        if row.get("owner_lane") != "L5":
+            raise AssertionError(f"preflight refusal {case_name} must be owned by L5")
+
+
 def _validate_num_prediction_divergences(data: dict[str, Any]) -> None:
     actual = {row["case"]: row for row in data["num_predictions_divergence"]}
     if set(actual) != set(NUM_PREDICTIONS_DIVERGENCE):
@@ -252,7 +273,8 @@ def _validate_coverage_meter(data: dict[str, Any]) -> None:
         "non_runnable": non_runnable,
         "runnable": len(cases) - non_runnable,
         "fallback": len(EXPECTED_FALLBACK),
-        "native": len(cases) - non_runnable - len(EXPECTED_FALLBACK),
+        "preflight_refusal": len(EXPECTED_PREFLIGHT_REFUSAL),
+        "native": len(cases) - non_runnable - len(EXPECTED_FALLBACK) - len(EXPECTED_PREFLIGHT_REFUSAL),
         "xfail_strict": len(KNOWN_DIVERGENCES) + legacy_bug_count,
         "skip": skip_count,
         "num_predictions_divergence": len(NUM_PREDICTIONS_DIVERGENCE),

--- a/tests/integration/parity/cases_augmentation.py
+++ b/tests/integration/parity/cases_augmentation.py
@@ -152,7 +152,8 @@ register(
     PipelineCase(
         name="concat_transform_pca_svd_plsr",
         description="SNV → concat_transform([PCA(15), TruncatedSVD(10)]) → PLSR. "
-        "Tests concat_transform with two dimensionality-reducers stacked column-wise.",
+        "The DAG-ML compatibility boundary must raise a typed preflight migration refusal because legacy "
+        "materializes these reducers before CV.",
         keywords=("concat_transform", "model"),
         capabilities=(
             "preprocessing_transform",

--- a/tests/integration/parity/cases_refit_predict.py
+++ b/tests/integration/parity/cases_refit_predict.py
@@ -105,9 +105,8 @@ def _factory_refit_params() -> list[Any]:
 register(
     PipelineCase(
         name="refit_params_use_all_partitions",
-        description="`refit_params: {use_all_partitions: True}` forces refit on train + val + test. "
-        "The DAG-ML compatibility boundary must raise a typed preflight migration refusal rather than "
-        "auto-fallback to legacy.",
+        description="Legacy `refit_params: {use_all_partitions: True}` compatibility no-op → PLSR. "
+        "The DAG-ML path keeps this legacy-only key on the ordinary fallback boundary.",
         keywords=("refit_params", "model", "name"),
         capabilities=(
             "preprocessing_transform",

--- a/tests/integration/parity/cases_refit_predict.py
+++ b/tests/integration/parity/cases_refit_predict.py
@@ -106,7 +106,8 @@ register(
     PipelineCase(
         name="refit_params_use_all_partitions",
         description="`refit_params: {use_all_partitions: True}` forces refit on train + val + test. "
-        "Exercises the explicit refit-policy override the bridge must surface.",
+        "The DAG-ML compatibility boundary must raise a typed preflight migration refusal rather than "
+        "auto-fallback to legacy.",
         keywords=("refit_params", "model", "name"),
         capabilities=(
             "preprocessing_transform",

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -47,7 +47,6 @@ import pytest
 import nirs4all
 from nirs4all.pipeline.dagml.errors import (
     DagMlMigrationRequired,
-    DagMlRefitParamsMigrationRequired,
     DagMlStatefulConcatTransformMigrationRequired,
 )
 from nirs4all.pipeline.engine import legacy_fallback_metrics
@@ -392,6 +391,10 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # native dag-ml path does not serialize/execute `finetune_params` yet, so the
     # public strict path rejects it rather than silently run the untuned model.
     "generator_finetune_params_optuna",
+    # ``refit_params.use_all_partitions`` is a legacy compatibility no-op. DAG-ML
+    # does not lower that legacy-only key, so the diagnostic rollback retains its
+    # historical behavior without inventing a semantic migration requirement.
+    "refit_params_use_all_partitions",
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_per_source_models_stacking",
 })
@@ -404,7 +407,6 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
 # data, emitted a fallback warning, or constructed PipelineRunner.
 EXPECTED_PREFLIGHT_REFUSAL: dict[str, type[DagMlMigrationRequired]] = {
     "concat_transform_pca_svd_plsr": DagMlStatefulConcatTransformMigrationRequired,
-    "refit_params_use_all_partitions": DagMlRefitParamsMigrationRequired,
 }
 
 

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -98,9 +98,9 @@ class _RunResultScoreDivergence(TypedDict):
 # removed (the suite goes RED until it is).
 #
 # The last remaining strict-xfail (`concat_transform_pca_svd_plsr`) was moved to
-# EXPECTED_FALLBACK: the dag-ml FeatureConcat path fits stateful PCA/SVD inside
-# each fold, while the Python oracle materializes concat_transform before CV.
-# That is a coverage boundary, not a native parity claim.
+# EXPECTED_PREFLIGHT_REFUSAL: the dag-ml FeatureConcat path fits stateful PCA/SVD
+# inside each fold, while the Python oracle materializes concat_transform before CV.
+# It is a typed semantic preflight refusal, not fallback or a native parity claim.
 # (generator_or_models_pls_ridge was here too — it is NOT a divergence in score/winner/winner-y_pred
 #  (all equal: best_rmse Δ≈2e-15, winner PLSRegression, winner y_pred Δ=0.0); its ONLY delta is
 #  num_predictions 34-legacy vs 32-native, an INTENTIONAL native-vs-legacy refit-policy divergence —

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -1,9 +1,9 @@
 """DUAL-ENGINE CONFORMANCE: the same case on legacy AND dag-ml, asserted equal.
 
 The single contract reference for the nirs4all-core → dag-ml migration. Every
-:class:`PipelineCase` in the registry is run on BOTH engines via
-:func:`_conformance_helpers.dual_engine_runner` and dispositioned by what the
-dag-ml engine actually did:
+:class:`PipelineCase` outside the explicit semantic-migration refusal registry
+runs on BOTH engines via :func:`_conformance_helpers.dual_engine_runner` and
+is dispositioned by what the dag-ml engine actually did:
 
 * **NATIVE** (``dagml_native is True``) — the dag-ml backend ran the pipeline
   itself. Assert FULL parity: score (within the case's tolerances), exact
@@ -15,6 +15,11 @@ dag-ml engine actually did:
   coverage-boundary: this case is not yet dag-ml-native. The day dag-ml gains
   native coverage, this assertion flips to a failure and forces the case into
   the NATIVE branch — the boundary can never silently widen.
+* **PREFLIGHT REFUSAL** — the requested legacy semantics would differ from the
+  native contract. It raises a dedicated migration error before data work,
+  fallback warnings, or legacy ``PipelineRunner`` construction, even when the
+  caller supplies ``allow_legacy_fallback=True``. These cases make no parity
+  claim until an explicit native migration contract exists.
 
 Known cross-engine NON-EQUALITIES are marked ``xfail(strict=True)`` AT
 PARAMETRIZE TIME (NOT loosened tolerances). The case still RUNS on both engines
@@ -25,16 +30,27 @@ never goes silent. The ``legacy_bug`` registry cases are likewise strict-xfail
 ``fixture`` / ``unknown_semantics`` cases ``skip`` — mirroring
 ``test_parity_smoke``.
 
-Slow: each case runs twice (legacy + dag-ml). Gated by the ``slow`` marker.
+Slow: ordinary conformance cases run twice (legacy + dag-ml). Gated by the
+``slow`` marker; preflight refusals return before either engine consumes data.
 
     pytest tests/integration/parity/test_conformance_dual_engine.py -q
 """
 
 from __future__ import annotations
 
+import importlib
+import warnings
 from typing import NotRequired, TypedDict
 
 import pytest
+
+import nirs4all
+from nirs4all.pipeline.dagml.errors import (
+    DagMlMigrationRequired,
+    DagMlRefitParamsMigrationRequired,
+    DagMlStatefulConcatTransformMigrationRequired,
+)
+from nirs4all.pipeline.engine import legacy_fallback_metrics
 
 from . import _conformance_helpers as H
 from ._registry import PipelineCase, all_cases
@@ -107,8 +123,8 @@ KNOWN_DIVERGENCES: dict[str, str] = {
     # path is not equivalent to the Python oracle for stateful concat transforms:
     # legacy materializes the concat_transform output before CV, while dag-ml's
     # FeatureConcat lowering fits PCA/SVD fold-locally. It is therefore an
-    # explicit EXPECTED_FALLBACK boundary until backlog #27 can preserve the
-    # pre-CV materialized semantics natively.
+    # explicit preflight migration refusal until a native contract can preserve
+    # the pre-CV materialized semantics.
     # NOTE: the three tree-ensemble cases (baseline_savgol_rf_kfold,
     # baseline_detrend_firstderiv_gbr, baseline_classification_rf_stratified) were REMOVED
     # from this dict — they reach Δ=0.0 now. Their old "fold-materialization/row-order"
@@ -376,19 +392,20 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # native dag-ml path does not serialize/execute `finetune_params` yet, so the
     # public strict path rejects it rather than silently run the untuned model.
     "generator_finetune_params_optuna",
-    # Stateful concat_transform sub-operations (PCA/SVD/scalers) are materialized
-    # pre-CV by the Python oracle; dag-ml's current FeatureConcat lowering fits
-    # them fold-locally, so native execution would compare the wrong semantics.
-    "concat_transform_pca_svd_plsr",
-    # Legacy `refit_params: {use_all_partitions: True}` can expand the terminal
-    # refit universe beyond the CV train/validation pool. dag-ml deliberately
-    # enforces `REFIT FullTrain == fold_set.sample_ids` and structurally excludes
-    # held-out test samples from refit, so the strict path rejects the override
-    # rather than ignore it or emulate the legacy leakage-prone shape.
-    "refit_params_use_all_partitions",
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_per_source_models_stacking",
 })
+
+
+# PREFLIGHT-REFUSAL authority: legacy semantics that the DAG-ML contract must
+# not silently reinterpret or re-run through Python. Unlike EXPECTED_FALLBACK,
+# these requests propagate a dedicated RuntimeError even with
+# allow_legacy_fallback=True. The test below proves they have not materialized
+# data, emitted a fallback warning, or constructed PipelineRunner.
+EXPECTED_PREFLIGHT_REFUSAL: dict[str, type[DagMlMigrationRequired]] = {
+    "concat_transform_pca_svd_plsr": DagMlStatefulConcatTransformMigrationRequired,
+    "refit_params_use_all_partitions": DagMlRefitParamsMigrationRequired,
+}
 
 
 def _params() -> list:
@@ -406,6 +423,8 @@ def _params() -> list:
     """
     params = []
     for case in all_cases():
+        if case.name in EXPECTED_PREFLIGHT_REFUSAL:
+            continue
         marks = []
         if case.skip_reason:
             if case.skip_kind == "legacy_bug":
@@ -423,18 +442,29 @@ def _params() -> list:
     return params
 
 
-def _runnable_cases() -> list:
-    """All cases that can actually be exercised (no registry ``skip_reason``).
+def _fallback_boundary_cases() -> list:
+    """Runnable cases that use the catchable fallback/native boundary.
 
     The ``fixture`` / ``unknown_semantics`` / ``legacy_bug`` registry skips can't
     construct or can't run (missing fixture, unconfirmed semantics, a legacy
-    crash), so they are excluded from the boundary test entirely — there is no
-    dag-ml leg to observe for them.
+    crash), so they are excluded entirely. Semantic migration refusals are
+    checked by :func:`test_native_preflight_refusal_boundary`, not through the
+    fallback detector: they intentionally do not return a ``RunResult``.
     """
-    return [pytest.param(c, id=c.name) for c in all_cases() if not c.skip_reason]
+    return [
+        pytest.param(case, id=case.name)
+        for case in all_cases()
+        if not case.skip_reason and case.name not in EXPECTED_PREFLIGHT_REFUSAL
+    ]
 
 
-@pytest.mark.parametrize("case", _runnable_cases())
+def _preflight_refusal_cases() -> list:
+    """Registered cases whose native path must refuse without running legacy."""
+    cases = {case.name: case for case in all_cases()}
+    return [pytest.param(cases[name], id=name) for name in EXPECTED_PREFLIGHT_REFUSAL]
+
+
+@pytest.mark.parametrize("case", _fallback_boundary_cases())
 def test_native_fallback_boundary(case: PipelineCase) -> None:
     """The dag-ml native/fallback status EXACTLY matches the EXPECTED_FALLBACK allowlist.
 
@@ -466,6 +496,45 @@ def test_native_fallback_boundary(case: PipelineCase) -> None:
             "— native-coverage regression (a shape that used to run native now rejects), or a new "
             "fallback that must be triaged + allowlisted with a reason"
         )
+
+
+@pytest.mark.parametrize("case", _preflight_refusal_cases())
+def test_native_preflight_refusal_boundary(case: PipelineCase, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Semantic migration rows refuse before data work or any legacy rollback.
+
+    This is intentionally stronger than a strict ``engine='dag-ml'`` request:
+    the caller supplies ``allow_legacy_fallback=True`` and the test makes any
+    fallback, host dataset materialization, or ``PipelineRunner`` construction
+    fail immediately. A migration boundary must remain explicit until its
+    native semantics are implemented and attested.
+    """
+    expected = EXPECTED_PREFLIGHT_REFUSAL[case.name]
+
+    def _legacy_runner(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError(f"{case.name}: constructed PipelineRunner after a migration refusal")
+
+    def _materialize_dataset(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError(f"{case.name}: materialized a dataset after a migration refusal")
+
+    run_module = importlib.import_module("nirs4all.api.run")
+    run_backend = importlib.import_module("nirs4all.pipeline.dagml.run_backend")
+    monkeypatch.setattr(run_module, "PipelineRunner", _legacy_runner)
+    monkeypatch.setattr(run_backend, "_materialize_dataset", _materialize_dataset)
+    before = legacy_fallback_metrics()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(expected, match="explicit migration requirement"):
+            nirs4all.run(
+                pipeline=case.pipeline,
+                dataset=H.make_dataset(case),
+                verbose=0,
+                engine="dag-ml",
+                allow_legacy_fallback=True,
+            )
+
+    assert not any("falling back to the legacy engine" in str(warning.message) for warning in caught)
+    assert legacy_fallback_metrics() == before
 
 
 @pytest.mark.parametrize("case", _params())

--- a/tests/unit/pipeline/dagml/test_migration_preflight.py
+++ b/tests/unit/pipeline/dagml/test_migration_preflight.py
@@ -1,0 +1,650 @@
+"""Regression locks for semantic DAG-ML migration refusal before legacy fallback."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sklearn.cross_decomposition import PLSRegression
+from sklearn.decomposition import PCA
+from sklearn.model_selection import KFold
+
+import nirs4all
+from nirs4all.controllers.data.branch import BranchController
+from nirs4all.operators.transforms import StandardNormalVariate
+from nirs4all.pipeline import PipelineConfigs
+from nirs4all.pipeline.config.generator import expand_spec
+from nirs4all.pipeline.dagml.errors import (
+    DagMlPipelinePreflightRequired,
+    DagMlRefitParamsMigrationRequired,
+    DagMlStatefulConcatTransformMigrationRequired,
+)
+from nirs4all.pipeline.dagml.migration_preflight import preflight_dagml_pipeline_migration
+from nirs4all.pipeline.engine import legacy_fallback_metrics
+
+
+def _refit_pipeline() -> list[Any]:
+    return [
+        KFold(n_splits=2),
+        {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}},
+    ]
+
+
+def _stateful_concat_pipeline() -> list[Any]:
+    return [
+        {"concat_transform": [PCA(n_components=1)]},
+        KFold(n_splits=2),
+        {"model": PLSRegression(n_components=1)},
+    ]
+
+
+def _safe_pipeline() -> list[Any]:
+    return [
+        {"concat_transform": [StandardNormalVariate()]},
+        KFold(n_splits=2),
+        {"model": PLSRegression(n_components=1)},
+    ]
+
+
+def _serialized_refit_pipeline() -> dict[str, Any]:
+    return {
+        "steps": [
+            {"class": "sklearn.model_selection.KFold", "params": {"n_splits": 2}},
+            {
+                "model": {"class": "sklearn.cross_decomposition.PLSRegression", "params": {"n_components": 1}},
+                "refit_params": {"use_all_partitions": True},
+            },
+        ]
+    }
+
+
+def _assert_public_refusal(pipeline: Any, expected: type[RuntimeError], monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prove every public wrapper refuses before native, data, or legacy work begins."""
+
+    run_module = importlib.import_module("nirs4all.api.run")
+    run_backend = importlib.import_module("nirs4all.pipeline.dagml.run_backend")
+    reached: list[str] = []
+
+    def _bomb(label: str):
+        def fail(*_args: Any, **_kwargs: Any) -> None:
+            reached.append(label)
+            raise AssertionError(f"semantic preflight unexpectedly reached {label}")
+
+        return fail
+
+    monkeypatch.setattr(run_module, "PipelineRunner", _bomb("legacy-runner"))
+    monkeypatch.setattr(run_backend, "run_via_dagml", _bomb("native-run"))
+    monkeypatch.setattr(run_backend, "preflight_dagml_backend", _bomb("native-backend"))
+    monkeypatch.setattr(run_backend, "_materialize_dataset", _bomb("dataset-materialization"))
+    before = legacy_fallback_metrics()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(expected, match="migration"):
+            nirs4all.run(
+                pipeline=pipeline,
+                dataset=object(),
+                engine="dag-ml",
+                allow_legacy_fallback=True,
+                verbose=0,
+            )
+
+    assert reached == []
+    assert not any("falling back to the legacy engine" in str(item.message) for item in caught)
+    assert legacy_fallback_metrics() == before
+
+
+@pytest.mark.parametrize(
+    ("form", "expected"),
+    [
+        ("list", DagMlRefitParamsMigrationRequired),
+        ("dict_steps", DagMlRefitParamsMigrationRequired),
+        ("dict_pipeline", DagMlStatefulConcatTransformMigrationRequired),
+        ("pipeline_configs", DagMlStatefulConcatTransformMigrationRequired),
+        ("json_path", DagMlRefitParamsMigrationRequired),
+        ("yaml_path", DagMlRefitParamsMigrationRequired),
+        ("batch", DagMlRefitParamsMigrationRequired),
+    ],
+)
+def test_public_pipeline_forms_refuse_before_fallback(
+    form: str,
+    expected: type[RuntimeError],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """List/dict/path/config/batch forms all hit the non-catchable boundary first."""
+
+    if form == "list":
+        pipeline: Any = _refit_pipeline()
+    elif form == "dict_steps":
+        pipeline = {"steps": _refit_pipeline()}
+    elif form == "dict_pipeline":
+        pipeline = {"pipeline": _stateful_concat_pipeline()}
+    elif form == "pipeline_configs":
+        pipeline = PipelineConfigs(_stateful_concat_pipeline())
+    elif form == "json_path":
+        path = tmp_path / "refit.json"
+        path.write_text(json.dumps(_serialized_refit_pipeline()), encoding="utf-8")
+        pipeline = path
+    elif form == "yaml_path":
+        path = tmp_path / "refit.yaml"
+        path.write_text(json.dumps(_serialized_refit_pipeline()), encoding="utf-8")
+        pipeline = str(path)
+    else:
+        pipeline = [_safe_pipeline(), _refit_pipeline()]
+
+    _assert_public_refusal(pipeline, expected, monkeypatch)
+
+
+def test_direct_backend_refuses_before_backend_or_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The direct seam has the same ordering guarantee as the public API."""
+
+    run_backend = importlib.import_module("nirs4all.pipeline.dagml.run_backend")
+
+    def fail(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("semantic preflight unexpectedly performed backend or dataset work")
+
+    monkeypatch.setattr(run_backend, "preflight_dagml_backend", fail)
+    monkeypatch.setattr(run_backend, "_materialize_dataset", fail)
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        run_backend.run_via_dagml(_refit_pipeline(), object())
+
+
+@pytest.mark.parametrize("extra", [{"tuning": {}}, {"tuning": {}, "calibration": {}}])
+def test_tuning_and_calibration_refuse_before_their_early_dagml_route(extra: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    """The early native tuning route cannot bypass semantic migration refusal."""
+
+    run_module = importlib.import_module("nirs4all.api.run")
+    reached: list[str] = []
+
+    def fail(*_args: Any, **_kwargs: Any) -> None:
+        reached.append("tuning-route")
+        raise AssertionError("semantic preflight unexpectedly reached the native tuning route")
+
+    monkeypatch.setattr(run_module, "_run_single_estimator_tuning_subset", fail)
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        nirs4all.run(
+            pipeline=_refit_pipeline(),
+            dataset=object(),
+            engine="dag-ml",
+            allow_legacy_fallback=True,
+            verbose=0,
+            **extra,
+        )
+
+    assert reached == []
+
+
+def test_unseeded_sample_is_exhaustive_but_unseeded_chain_keeps_its_order() -> None:
+    """Random legacy re-normalization cannot hide an unsafe sample, without false-positive chain scans."""
+
+    safe_model = {"model": PLSRegression(n_components=1)}
+    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration([{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}])
+
+    preflight_dagml_pipeline_migration([{"_chain_": [safe_model, unsafe_model], "count": 1}])
+
+
+def test_seeded_samples_are_exact_and_unseeded_cartesian_counts_are_exhaustive() -> None:
+    """Honor the public root seed, but inspect every later-random cartesian candidate."""
+
+    safe_model = {"model": PLSRegression(n_components=1)}
+    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
+
+    # ``random.Random(1).choice([safe, unsafe])`` chooses the safe entry. The root configuration
+    # seed is the one PipelineConfigs passes to generator-core, so preflight must preserve it.
+    preflight_dagml_pipeline_migration(
+        {
+            "random_state": 1,
+            "steps": [{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}],
+        }
+    )
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            [
+                {
+                    "_cartesian_": [
+                        {"_or_": [KFold(n_splits=2)]},
+                        {"_or_": [safe_model, unsafe_model]},
+                    ],
+                    "count": 1,
+                }
+            ]
+        )
+
+
+def test_duplication_branch_generators_do_not_inherit_the_root_seed() -> None:
+    """BranchController expands duplication generators later and without PipelineConfigs.random_state."""
+
+    safe_model = {"model": PLSRegression(n_components=1)}
+    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            {
+                "random_state": 1,
+                "steps": [
+                    {
+                        "branch": [
+                            {
+                                "name": "late-generator",
+                                "steps": [{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}],
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+
+    # generator-core's mixed-``_or_`` helper keeps `_seed_` as payload and therefore ignores it for
+    # selection. The preflight must likewise consider this duplication branch unseeded.
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            {
+                "random_state": 0,
+                "steps": [
+                    {
+                        "branch": [
+                            {
+                                "name": "late-mixed-or",
+                                "steps": [
+                                    {
+                                        "_or_": [unsafe_model, safe_model],
+                                        "count": 1,
+                                        "_seed_": 1,
+                                        "name": "mixed",
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+
+    # A branch ``_chain_`` uses its first item when unseeded. The outer root seed 0 would make
+    # generator-core sample the safe item unless the duplication subtree blocks inherited seeding.
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            {
+                "random_state": 0,
+                "steps": [
+                    {
+                        "branch": [
+                            {
+                                "name": "late-chain",
+                                "steps": [{"_chain_": [unsafe_model, safe_model], "count": 1}],
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+
+
+def test_weighted_unseeded_or_is_uninspectable_not_an_active_unsafe_choice() -> None:
+    """A zero-weight unsafe option must not be reported as an active semantic migration."""
+
+    safe_model = {"model": PLSRegression(n_components=1)}
+    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([{"_or_": [unsafe_model, safe_model], "count": 1, "_weights_": [0.0, 1.0]}])
+
+
+def test_grid_and_zip_preserve_active_variant_semantics() -> None:
+    """Grid unsafe values refuse, while a zip-truncated unsafe tail remains inactive."""
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            [
+                {
+                    "_grid_": {
+                        "model": [PLSRegression(n_components=1)],
+                        "refit_params": [{"use_all_partitions": True}],
+                    }
+                }
+            ]
+        )
+
+    preflight_dagml_pipeline_migration(
+        [
+            {
+                "_zip_": {
+                    "model": [PLSRegression(n_components=1)],
+                    "refit_params": [{"use_all_partitions": False}, {"use_all_partitions": True}],
+                }
+            }
+        ]
+    )
+
+
+def test_zip_with_opaque_generated_column_refuses_only_when_it_can_hide_a_migration() -> None:
+    """An opaque generated ``params`` map cannot shorten a relevant ZipStrategy scan."""
+
+    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
+    unsafe_zip = {
+        "_zip_": {
+            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
+            "params": opaque_params,
+            "refit_params": [
+                {"use_all_partitions": False},
+                {"use_all_partitions": True},
+            ],
+        }
+    }
+
+    # Runtime expands two aligned variants, but the preflight intentionally keeps ``params``
+    # semantically opaque. It must therefore refuse as uninspectable instead of silently dropping
+    # the second held-out-refit candidate or misreporting it as definitely active.
+    assert [variant[0]["refit_params"]["use_all_partitions"] for variant in expand_spec([unsafe_zip])] == [False, True]
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([unsafe_zip])
+
+    # The same opaque cardinality is harmless when every reachable refit override is safe.
+    preflight_dagml_pipeline_migration(
+        [
+            {
+                "_zip_": {
+                    "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
+                    "params": opaque_params,
+                    "refit_params": [
+                        {"use_all_partitions": False},
+                        {"use_all_partitions": False},
+                    ],
+                }
+            }
+        ]
+    )
+
+    # Nor does a generated opaque column by itself become a semantic-migration refusal.
+    preflight_dagml_pipeline_migration(
+        [
+            {
+                "_zip_": {
+                    "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
+                    "params": opaque_params,
+                }
+            }
+        ]
+    )
+
+
+def test_zip_opaque_alignment_keeps_concat_refusal_within_the_pre_cv_prefix() -> None:
+    """A hidden stateful concat is generic preflight only before a concrete splitter."""
+
+    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
+    concat_zip = {
+        "_zip_": {
+            "params": opaque_params,
+            "concat_transform": [[StandardNormalVariate()], [PCA(n_components=1)]],
+        }
+    }
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([concat_zip])
+
+    preflight_dagml_pipeline_migration([KFold(n_splits=2), concat_zip])
+
+
+def test_unseeded_zip_migration_columns_are_never_decided_from_one_random_draw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Relevant zip columns expand all unseeded choices before their opaque alignment is assessed."""
+
+    sampler = importlib.import_module("nirs4all.pipeline.config._generator.strategies.or_strategy")
+
+    def pick_first(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
+        del seed, weights
+        return list(population[:count])
+
+    def pick_last(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
+        del seed, weights
+        return list(population[-count:])
+
+    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
+    refit_zip = {
+        "_zip_": {
+            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
+            "params": opaque_params,
+            "refit_params": {
+                "_or_": [
+                    {"use_all_partitions": False},
+                    {"use_all_partitions": True},
+                ],
+                "count": 1,
+            },
+        }
+    }
+    concat_zip = {
+        "_zip_": {
+            "params": opaque_params,
+            "concat_transform": {
+                "_or_": [[StandardNormalVariate()], [PCA(n_components=1)]],
+                "count": 1,
+            },
+        }
+    }
+
+    # This is the old false-negative direction: one raw preflight draw was safe. The new guard
+    # must refuse before consuming the sampler at all, because a later legacy expansion can differ.
+    monkeypatch.setattr(sampler, "sample_with_seed", pick_first)
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([refit_zip])
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([concat_zip])
+
+    # The same unseeded source can select the unsafe item at runtime.
+    monkeypatch.setattr(sampler, "sample_with_seed", pick_last)
+    assert expand_spec([refit_zip])[0][0]["refit_params"]["use_all_partitions"] is True
+    assert isinstance(expand_spec([concat_zip])[0][0]["concat_transform"][0], PCA)
+
+
+def test_seeded_grid_population_with_an_opaque_generated_mapping_is_generic_preflight() -> None:
+    """A deterministic count still cannot use a projection with a different candidate population."""
+
+    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
+    seeded_grid = {
+        "_grid_": {
+            "model": [PLSRegression(n_components=1)],
+            "params": opaque_params,
+            "refit_params": [
+                {"use_all_partitions": False},
+                {"use_all_partitions": True},
+            ],
+        },
+        "count": 1,
+        "_seed_": 1,
+    }
+
+    assert expand_spec([seeded_grid])[0][0]["refit_params"]["use_all_partitions"] is True
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([seeded_grid])
+
+    # The same seeded selection remains admissible when no tracked semantic field is present.
+    preflight_dagml_pipeline_migration(
+        [
+            {
+                "_grid_": {
+                    "model": [PLSRegression(n_components=1)],
+                    "params": opaque_params,
+                },
+                "count": 1,
+                "_seed_": 1,
+            }
+        ]
+    )
+
+
+def test_selected_cartesian_and_mixed_or_guard_opaque_migration_candidates() -> None:
+    """The bounded population rule also reaches enclosing cartesian and mixed-OR selectors."""
+
+    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
+    mixed_or = {
+        "model": PLSRegression(n_components=1),
+        "params": opaque_params,
+        "_or_": [
+            {"refit_params": {"use_all_partitions": False}},
+            {"refit_params": {"use_all_partitions": True}},
+        ],
+        "count": 1,
+    }
+    cartesian = {
+        "_cartesian_": [
+            {
+                "model": PLSRegression(n_components=1),
+                "params": opaque_params,
+                "refit_params": {"_or_": [{"use_all_partitions": False}, {"use_all_partitions": True}]},
+            }
+        ],
+        "count": 1,
+        "_seed_": 1,
+    }
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration({"random_state": 1, "steps": [mixed_or]})
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([cartesian])
+
+
+def test_selected_or_aggregates_opaque_and_migration_across_siblings() -> None:
+    """An opaque safe sibling can still shift a seeded choice onto an unsafe sibling."""
+
+    safe = {
+        "model": {"_or_": [PLSRegression(n_components=1), PLSRegression(n_components=1)]},
+        "refit_params": {"use_all_partitions": False},
+    }
+    unsafe = {
+        "model": PLSRegression(n_components=1),
+        "refit_params": {"use_all_partitions": True},
+    }
+    selector = {"_or_": [safe, unsafe], "count": 1, "_seed_": 6}
+
+    assert expand_spec([selector])[0][0]["refit_params"]["use_all_partitions"] is True
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([selector])
+
+    preflight_dagml_pipeline_migration(
+        [
+            {
+                "_or_": [
+                    safe,
+                    {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": False}},
+                ],
+                "count": 1,
+                "_seed_": 6,
+            }
+        ]
+    )
+
+
+def test_duplication_branch_later_expansion_cannot_hide_a_zip_refit_choice(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """BranchController's second generator phase is included in the zip uncertainty boundary."""
+
+    sampler = importlib.import_module("nirs4all.pipeline.config._generator.strategies.or_strategy")
+
+    def pick_last(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
+        del seed, weights
+        return list(population[-count:])
+
+    nested_zip = {
+        "_zip_": {
+            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
+            "params": {"_or_": [{"alpha": 1}, {"alpha": 2}]},
+            "refit_params": [
+                {
+                    "_or_": [
+                        {"use_all_partitions": False},
+                        {"use_all_partitions": True},
+                    ],
+                    "count": 1,
+                }
+            ],
+        }
+    }
+    pipeline = [{"branch": [{"name": "late-zip", "steps": [nested_zip]}]}]
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration(pipeline)
+
+    monkeypatch.setattr(sampler, "sample_with_seed", pick_last)
+    runtime_variants = BranchController.__new__(BranchController)._expand_list_with_generators([nested_zip])
+    assert runtime_variants[0][0]["refit_params"]["use_all_partitions"] is True
+
+
+def test_concat_refusal_is_limited_to_the_pre_cv_prefix() -> None:
+    """A stateful concat after a splitter remains an ordinary native capability boundary."""
+
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        preflight_dagml_pipeline_migration(_stateful_concat_pipeline())
+
+    preflight_dagml_pipeline_migration([KFold(n_splits=2), {"concat_transform": [PCA(n_components=1)]}, {"model": PLSRegression(n_components=1)}])
+
+
+def test_named_concat_operation_dict_is_scanned_without_an_operations_wrapper() -> None:
+    """Legacy accepts named operation maps, which are not automatically stateful."""
+
+    preflight_dagml_pipeline_migration(
+        [
+            {"concat_transform": {"snv": StandardNormalVariate()}},
+            KFold(n_splits=2),
+            {"model": PLSRegression(n_components=1)},
+        ]
+    )
+
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            [
+                {"concat_transform": {"pca": PCA(n_components=1)}},
+                KFold(n_splits=2),
+                {"model": PLSRegression(n_components=1)},
+            ]
+        )
+
+
+def test_active_branch_body_is_visible_but_metadata_and_params_are_opaque() -> None:
+    """Semantic-looking payload fields cannot create a false refusal or cycle failure."""
+
+    with pytest.raises(DagMlRefitParamsMigrationRequired):
+        preflight_dagml_pipeline_migration([{"branch": [{"name": "unsafe", "steps": [_refit_pipeline()[-1]]}]}])
+
+    metadata_cycle: dict[str, Any] = {"_or_": []}
+    metadata_cycle["_or_"].append(metadata_cycle)
+    preflight_dagml_pipeline_migration(
+        [
+            {"concat_transform": [StandardNormalVariate()], "metadata": {"concat_transform": [PCA(n_components=1)]}},
+            KFold(n_splits=2),
+            {
+                "model": {
+                    "class": "sklearn.cross_decomposition.PLSRegression",
+                    "params": {
+                        "n_components": 1,
+                        "refit_params": {"use_all_partitions": True},
+                        "concat_transform": [PCA(n_components=1)],
+                    },
+                },
+                "metadata": {"refit_params": metadata_cycle},
+            },
+        ]
+    )
+
+
+def test_active_cycle_refuses_before_any_fallback() -> None:
+    """A cycle in the declarative grammar is uncertain, unlike a metadata cycle."""
+
+    cycle: dict[str, Any] = {"_or_": []}
+    cycle["_or_"].append(cycle)
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([cycle])

--- a/tests/unit/pipeline/dagml/test_migration_preflight.py
+++ b/tests/unit/pipeline/dagml/test_migration_preflight.py
@@ -10,7 +10,7 @@ from typing import Any
 
 import pytest
 from sklearn.cross_decomposition import PLSRegression
-from sklearn.decomposition import PCA
+from sklearn.decomposition import PCA, TruncatedSVD
 from sklearn.model_selection import KFold
 
 import nirs4all
@@ -18,7 +18,7 @@ from nirs4all.operators.transforms import StandardNormalVariate
 from nirs4all.pipeline import PipelineConfigs
 from nirs4all.pipeline.config.generator import expand_spec
 from nirs4all.pipeline.dagml.errors import DagMlPipelinePreflightRequired, DagMlStatefulConcatTransformMigrationRequired
-from nirs4all.pipeline.dagml.migration_preflight import preflight_dagml_pipeline_migration
+from nirs4all.pipeline.dagml.migration_preflight import _operator_is_stateless, preflight_dagml_pipeline_migration
 from nirs4all.pipeline.engine import legacy_fallback_metrics
 
 
@@ -124,6 +124,50 @@ def test_public_pipeline_forms_refuse_before_fallback(
         pipeline = [_safe_pipeline(), _stateful_concat_pipeline()]
 
     _assert_public_refusal(pipeline, monkeypatch)
+
+
+def test_reloaded_pipeline_configs_refuse_serialized_stateful_concat_before_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale public re-export remains a PipelineConfigs input after its implementation reloads."""
+
+    from nirs4all.pipeline.config import pipeline_config as pipeline_config_module
+
+    stale_pipeline_configs = PipelineConfigs
+    importlib.reload(pipeline_config_module)
+    assert stale_pipeline_configs is not pipeline_config_module.PipelineConfigs
+    try:
+
+        class ReloadedPipelineConfigs(stale_pipeline_configs):
+            pass
+
+        pipeline = ReloadedPipelineConfigs(
+            [
+                {"concat_transform": [PCA(n_components=1), TruncatedSVD(n_components=1)]},
+                KFold(n_splits=2),
+                {"model": PLSRegression(n_components=1)},
+            ]
+        )
+        operations = pipeline.steps[0][0]["concat_transform"]
+        assert [operation["class"].rsplit(".", 1)[-1] for operation in operations] == ["PCA", "TruncatedSVD"]
+        assert all(not _operator_is_stateless(operation) for operation in operations)
+
+        _assert_public_refusal(pipeline, monkeypatch)
+        _assert_public_refusal([_safe_pipeline(), pipeline], monkeypatch)
+    finally:
+        # Restore the implementation binding so this regression does not leave a distinct class identity
+        # behind for unrelated tests. The public re-export intentionally stays the held stale reference.
+        pipeline_config_module.PipelineConfigs = stale_pipeline_configs
+
+
+def test_malformed_nominal_pipeline_configs_requires_preflight() -> None:
+    """A recognized config object with invalid serialized variants cannot pass as a safe pipeline."""
+
+    malformed = object.__new__(PipelineConfigs)
+    malformed.steps = [{"concat_transform": [PCA(n_components=1)]}]
+
+    with pytest.raises(DagMlPipelinePreflightRequired, match="PipelineConfigs.steps"):
+        preflight_dagml_pipeline_migration(malformed)
 
 
 def test_direct_backend_refuses_before_backend_or_dataset(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/pipeline/dagml/test_migration_preflight.py
+++ b/tests/unit/pipeline/dagml/test_migration_preflight.py
@@ -1,4 +1,4 @@
-"""Regression locks for semantic DAG-ML migration refusal before legacy fallback."""
+"""Regression locks for the stateful-concat DAG-ML migration refusal."""
 
 from __future__ import annotations
 
@@ -14,24 +14,12 @@ from sklearn.decomposition import PCA
 from sklearn.model_selection import KFold
 
 import nirs4all
-from nirs4all.controllers.data.branch import BranchController
 from nirs4all.operators.transforms import StandardNormalVariate
 from nirs4all.pipeline import PipelineConfigs
 from nirs4all.pipeline.config.generator import expand_spec
-from nirs4all.pipeline.dagml.errors import (
-    DagMlPipelinePreflightRequired,
-    DagMlRefitParamsMigrationRequired,
-    DagMlStatefulConcatTransformMigrationRequired,
-)
+from nirs4all.pipeline.dagml.errors import DagMlPipelinePreflightRequired, DagMlStatefulConcatTransformMigrationRequired
 from nirs4all.pipeline.dagml.migration_preflight import preflight_dagml_pipeline_migration
 from nirs4all.pipeline.engine import legacy_fallback_metrics
-
-
-def _refit_pipeline() -> list[Any]:
-    return [
-        KFold(n_splits=2),
-        {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}},
-    ]
 
 
 def _stateful_concat_pipeline() -> list[Any]:
@@ -50,19 +38,33 @@ def _safe_pipeline() -> list[Any]:
     ]
 
 
-def _serialized_refit_pipeline() -> dict[str, Any]:
+def _refit_noop_pipeline() -> list[Any]:
+    return [
+        KFold(n_splits=2),
+        {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}},
+    ]
+
+
+def _serialized_stateful_concat_pipeline() -> dict[str, Any]:
     return {
         "steps": [
+            {
+                "concat_transform": [
+                    {"class": "sklearn.decomposition.PCA", "params": {"n_components": 1}},
+                ]
+            },
             {"class": "sklearn.model_selection.KFold", "params": {"n_splits": 2}},
             {
-                "model": {"class": "sklearn.cross_decomposition.PLSRegression", "params": {"n_components": 1}},
-                "refit_params": {"use_all_partitions": True},
+                "model": {
+                    "class": "sklearn.cross_decomposition.PLSRegression",
+                    "params": {"n_components": 1},
+                }
             },
         ]
     }
 
 
-def _assert_public_refusal(pipeline: Any, expected: type[RuntimeError], monkeypatch: pytest.MonkeyPatch) -> None:
+def _assert_public_refusal(pipeline: Any, monkeypatch: pytest.MonkeyPatch) -> None:
     """Prove every public wrapper refuses before native, data, or legacy work begins."""
 
     run_module = importlib.import_module("nirs4all.api.run")
@@ -84,7 +86,7 @@ def _assert_public_refusal(pipeline: Any, expected: type[RuntimeError], monkeypa
 
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        with pytest.raises(expected, match="migration"):
+        with pytest.raises(DagMlStatefulConcatTransformMigrationRequired, match="migration"):
             nirs4all.run(
                 pipeline=pipeline,
                 dataset=object(),
@@ -98,46 +100,30 @@ def _assert_public_refusal(pipeline: Any, expected: type[RuntimeError], monkeypa
     assert legacy_fallback_metrics() == before
 
 
-@pytest.mark.parametrize(
-    ("form", "expected"),
-    [
-        ("list", DagMlRefitParamsMigrationRequired),
-        ("dict_steps", DagMlRefitParamsMigrationRequired),
-        ("dict_pipeline", DagMlStatefulConcatTransformMigrationRequired),
-        ("pipeline_configs", DagMlStatefulConcatTransformMigrationRequired),
-        ("json_path", DagMlRefitParamsMigrationRequired),
-        ("yaml_path", DagMlRefitParamsMigrationRequired),
-        ("batch", DagMlRefitParamsMigrationRequired),
-    ],
-)
+@pytest.mark.parametrize("form", ["list", "dict_steps", "dict_pipeline", "pipeline_configs", "json_path", "yaml_path", "batch"])
 def test_public_pipeline_forms_refuse_before_fallback(
     form: str,
-    expected: type[RuntimeError],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """List/dict/path/config/batch forms all hit the non-catchable boundary first."""
+    """Every documented wrapper reaches the non-catchable concat boundary first."""
 
     if form == "list":
-        pipeline: Any = _refit_pipeline()
+        pipeline: Any = _stateful_concat_pipeline()
     elif form == "dict_steps":
-        pipeline = {"steps": _refit_pipeline()}
+        pipeline = {"steps": _stateful_concat_pipeline()}
     elif form == "dict_pipeline":
         pipeline = {"pipeline": _stateful_concat_pipeline()}
     elif form == "pipeline_configs":
         pipeline = PipelineConfigs(_stateful_concat_pipeline())
-    elif form == "json_path":
-        path = tmp_path / "refit.json"
-        path.write_text(json.dumps(_serialized_refit_pipeline()), encoding="utf-8")
-        pipeline = path
-    elif form == "yaml_path":
-        path = tmp_path / "refit.yaml"
-        path.write_text(json.dumps(_serialized_refit_pipeline()), encoding="utf-8")
-        pipeline = str(path)
+    elif form in {"json_path", "yaml_path"}:
+        path = tmp_path / f"stateful_concat.{form.split('_')[0]}"
+        path.write_text(json.dumps(_serialized_stateful_concat_pipeline()), encoding="utf-8")
+        pipeline = path if form == "json_path" else str(path)
     else:
-        pipeline = [_safe_pipeline(), _refit_pipeline()]
+        pipeline = [_safe_pipeline(), _stateful_concat_pipeline()]
 
-    _assert_public_refusal(pipeline, expected, monkeypatch)
+    _assert_public_refusal(pipeline, monkeypatch)
 
 
 def test_direct_backend_refuses_before_backend_or_dataset(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -151,13 +137,16 @@ def test_direct_backend_refuses_before_backend_or_dataset(monkeypatch: pytest.Mo
     monkeypatch.setattr(run_backend, "preflight_dagml_backend", fail)
     monkeypatch.setattr(run_backend, "_materialize_dataset", fail)
 
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        run_backend.run_via_dagml(_refit_pipeline(), object())
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        run_backend.run_via_dagml(_stateful_concat_pipeline(), object())
 
 
 @pytest.mark.parametrize("extra", [{"tuning": {}}, {"tuning": {}, "calibration": {}}])
-def test_tuning_and_calibration_refuse_before_their_early_dagml_route(extra: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
-    """The early native tuning route cannot bypass semantic migration refusal."""
+def test_tuning_and_calibration_refuse_before_their_early_dagml_route(
+    extra: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The early native tuning route cannot bypass the concat migration refusal."""
 
     run_module = importlib.import_module("nirs4all.api.run")
     reached: list[str] = []
@@ -168,9 +157,9 @@ def test_tuning_and_calibration_refuse_before_their_early_dagml_route(extra: dic
 
     monkeypatch.setattr(run_module, "_run_single_estimator_tuning_subset", fail)
 
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
         nirs4all.run(
-            pipeline=_refit_pipeline(),
+            pipeline=_stateful_concat_pipeline(),
             dataset=object(),
             engine="dag-ml",
             allow_legacy_fallback=True,
@@ -181,415 +170,39 @@ def test_tuning_and_calibration_refuse_before_their_early_dagml_route(extra: dic
     assert reached == []
 
 
-def test_unseeded_sample_is_exhaustive_but_unseeded_chain_keeps_its_order() -> None:
-    """Random legacy re-normalization cannot hide an unsafe sample, without false-positive chain scans."""
+def test_refit_params_use_all_partitions_is_not_a_preflight_boundary() -> None:
+    """The legacy compatibility no-op must never become a typed migration refusal."""
 
-    safe_model = {"model": PLSRegression(n_components=1)}
-    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
-
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration([{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}])
-
-    preflight_dagml_pipeline_migration([{"_chain_": [safe_model, unsafe_model], "count": 1}])
-
-
-def test_seeded_samples_are_exact_and_unseeded_cartesian_counts_are_exhaustive() -> None:
-    """Honor the public root seed, but inspect every later-random cartesian candidate."""
-
-    safe_model = {"model": PLSRegression(n_components=1)}
-    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
-
-    # ``random.Random(1).choice([safe, unsafe])`` chooses the safe entry. The root configuration
-    # seed is the one PipelineConfigs passes to generator-core, so preflight must preserve it.
-    preflight_dagml_pipeline_migration(
-        {
-            "random_state": 1,
-            "steps": [{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}],
-        }
-    )
-
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration(
-            [
-                {
-                    "_cartesian_": [
-                        {"_or_": [KFold(n_splits=2)]},
-                        {"_or_": [safe_model, unsafe_model]},
-                    ],
-                    "count": 1,
-                }
-            ]
-        )
-
-
-def test_duplication_branch_generators_do_not_inherit_the_root_seed() -> None:
-    """BranchController expands duplication generators later and without PipelineConfigs.random_state."""
-
-    safe_model = {"model": PLSRegression(n_components=1)}
-    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
-
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration(
-            {
-                "random_state": 1,
-                "steps": [
-                    {
-                        "branch": [
-                            {
-                                "name": "late-generator",
-                                "steps": [{"_sample_": {"distribution": "choice", "values": [safe_model, unsafe_model], "num": 1}}],
-                            }
-                        ]
-                    }
-                ],
-            }
-        )
-
-    # generator-core's mixed-``_or_`` helper keeps `_seed_` as payload and therefore ignores it for
-    # selection. The preflight must likewise consider this duplication branch unseeded.
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration(
-            {
-                "random_state": 0,
-                "steps": [
-                    {
-                        "branch": [
-                            {
-                                "name": "late-mixed-or",
-                                "steps": [
-                                    {
-                                        "_or_": [unsafe_model, safe_model],
-                                        "count": 1,
-                                        "_seed_": 1,
-                                        "name": "mixed",
-                                    }
-                                ],
-                            }
-                        ]
-                    }
-                ],
-            }
-        )
-
-    # A branch ``_chain_`` uses its first item when unseeded. The outer root seed 0 would make
-    # generator-core sample the safe item unless the duplication subtree blocks inherited seeding.
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration(
-            {
-                "random_state": 0,
-                "steps": [
-                    {
-                        "branch": [
-                            {
-                                "name": "late-chain",
-                                "steps": [{"_chain_": [unsafe_model, safe_model], "count": 1}],
-                            }
-                        ]
-                    }
-                ],
-            }
-        )
-
-
-def test_weighted_unseeded_or_is_uninspectable_not_an_active_unsafe_choice() -> None:
-    """A zero-weight unsafe option must not be reported as an active semantic migration."""
-
-    safe_model = {"model": PLSRegression(n_components=1)}
-    unsafe_model = {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": True}}
-
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([{"_or_": [unsafe_model, safe_model], "count": 1, "_weights_": [0.0, 1.0]}])
-
-
-def test_grid_and_zip_preserve_active_variant_semantics() -> None:
-    """Grid unsafe values refuse, while a zip-truncated unsafe tail remains inactive."""
-
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration(
-            [
-                {
-                    "_grid_": {
-                        "model": [PLSRegression(n_components=1)],
-                        "refit_params": [{"use_all_partitions": True}],
-                    }
-                }
-            ]
-        )
-
-    preflight_dagml_pipeline_migration(
-        [
-            {
-                "_zip_": {
-                    "model": [PLSRegression(n_components=1)],
-                    "refit_params": [{"use_all_partitions": False}, {"use_all_partitions": True}],
-                }
-            }
-        ]
-    )
-
-
-def test_zip_with_opaque_generated_column_refuses_only_when_it_can_hide_a_migration() -> None:
-    """An opaque generated ``params`` map cannot shorten a relevant ZipStrategy scan."""
-
-    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
-    unsafe_zip = {
-        "_zip_": {
-            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
-            "params": opaque_params,
-            "refit_params": [
-                {"use_all_partitions": False},
-                {"use_all_partitions": True},
-            ],
-        }
-    }
-
-    # Runtime expands two aligned variants, but the preflight intentionally keeps ``params``
-    # semantically opaque. It must therefore refuse as uninspectable instead of silently dropping
-    # the second held-out-refit candidate or misreporting it as definitely active.
-    assert [variant[0]["refit_params"]["use_all_partitions"] for variant in expand_spec([unsafe_zip])] == [False, True]
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([unsafe_zip])
-
-    # The same opaque cardinality is harmless when every reachable refit override is safe.
-    preflight_dagml_pipeline_migration(
-        [
-            {
-                "_zip_": {
-                    "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
-                    "params": opaque_params,
-                    "refit_params": [
-                        {"use_all_partitions": False},
-                        {"use_all_partitions": False},
-                    ],
-                }
-            }
-        ]
-    )
-
-    # Nor does a generated opaque column by itself become a semantic-migration refusal.
-    preflight_dagml_pipeline_migration(
-        [
-            {
-                "_zip_": {
-                    "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
-                    "params": opaque_params,
-                }
-            }
-        ]
-    )
-
-
-def test_zip_opaque_alignment_keeps_concat_refusal_within_the_pre_cv_prefix() -> None:
-    """A hidden stateful concat is generic preflight only before a concrete splitter."""
-
-    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
-    concat_zip = {
-        "_zip_": {
-            "params": opaque_params,
-            "concat_transform": [[StandardNormalVariate()], [PCA(n_components=1)]],
-        }
-    }
-
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([concat_zip])
-
-    preflight_dagml_pipeline_migration([KFold(n_splits=2), concat_zip])
-
-
-def test_unseeded_zip_migration_columns_are_never_decided_from_one_random_draw(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Relevant zip columns expand all unseeded choices before their opaque alignment is assessed."""
-
-    sampler = importlib.import_module("nirs4all.pipeline.config._generator.strategies.or_strategy")
-
-    def pick_first(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
-        del seed, weights
-        return list(population[:count])
-
-    def pick_last(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
-        del seed, weights
-        return list(population[-count:])
-
-    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
-    refit_zip = {
-        "_zip_": {
-            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
-            "params": opaque_params,
-            "refit_params": {
-                "_or_": [
-                    {"use_all_partitions": False},
-                    {"use_all_partitions": True},
-                ],
-                "count": 1,
-            },
-        }
-    }
-    concat_zip = {
-        "_zip_": {
-            "params": opaque_params,
-            "concat_transform": {
-                "_or_": [[StandardNormalVariate()], [PCA(n_components=1)]],
-                "count": 1,
-            },
-        }
-    }
-
-    # This is the old false-negative direction: one raw preflight draw was safe. The new guard
-    # must refuse before consuming the sampler at all, because a later legacy expansion can differ.
-    monkeypatch.setattr(sampler, "sample_with_seed", pick_first)
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([refit_zip])
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([concat_zip])
-
-    # The same unseeded source can select the unsafe item at runtime.
-    monkeypatch.setattr(sampler, "sample_with_seed", pick_last)
-    assert expand_spec([refit_zip])[0][0]["refit_params"]["use_all_partitions"] is True
-    assert isinstance(expand_spec([concat_zip])[0][0]["concat_transform"][0], PCA)
-
-
-def test_seeded_grid_population_with_an_opaque_generated_mapping_is_generic_preflight() -> None:
-    """A deterministic count still cannot use a projection with a different candidate population."""
-
-    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
-    seeded_grid = {
-        "_grid_": {
-            "model": [PLSRegression(n_components=1)],
-            "params": opaque_params,
-            "refit_params": [
-                {"use_all_partitions": False},
-                {"use_all_partitions": True},
-            ],
-        },
-        "count": 1,
-        "_seed_": 1,
-    }
-
-    assert expand_spec([seeded_grid])[0][0]["refit_params"]["use_all_partitions"] is True
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([seeded_grid])
-
-    # The same seeded selection remains admissible when no tracked semantic field is present.
-    preflight_dagml_pipeline_migration(
-        [
-            {
-                "_grid_": {
-                    "model": [PLSRegression(n_components=1)],
-                    "params": opaque_params,
-                },
-                "count": 1,
-                "_seed_": 1,
-            }
-        ]
-    )
-
-
-def test_selected_cartesian_and_mixed_or_guard_opaque_migration_candidates() -> None:
-    """The bounded population rule also reaches enclosing cartesian and mixed-OR selectors."""
-
-    opaque_params = {"_or_": [{"alpha": 1}, {"alpha": 2}]}
-    mixed_or = {
-        "model": PLSRegression(n_components=1),
-        "params": opaque_params,
+    generator_payload = {
         "_or_": [
-            {"refit_params": {"use_all_partitions": False}},
-            {"refit_params": {"use_all_partitions": True}},
+            {"use_all_partitions": False},
+            {"use_all_partitions": True},
         ],
         "count": 1,
     }
-    cartesian = {
-        "_cartesian_": [
-            {
-                "model": PLSRegression(n_components=1),
-                "params": opaque_params,
-                "refit_params": {"_or_": [{"use_all_partitions": False}, {"use_all_partitions": True}]},
-            }
-        ],
-        "count": 1,
-        "_seed_": 1,
-    }
+    cyclic_payload: dict[str, Any] = {"use_all_partitions": True}
+    cyclic_payload["self"] = cyclic_payload
 
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration({"random_state": 1, "steps": [mixed_or]})
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([cartesian])
-
-
-def test_selected_or_aggregates_opaque_and_migration_across_siblings() -> None:
-    """An opaque safe sibling can still shift a seeded choice onto an unsafe sibling."""
-
-    safe = {
-        "model": {"_or_": [PLSRegression(n_components=1), PLSRegression(n_components=1)]},
-        "refit_params": {"use_all_partitions": False},
-    }
-    unsafe = {
-        "model": PLSRegression(n_components=1),
-        "refit_params": {"use_all_partitions": True},
-    }
-    selector = {"_or_": [safe, unsafe], "count": 1, "_seed_": 6}
-
-    assert expand_spec([selector])[0][0]["refit_params"]["use_all_partitions"] is True
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([selector])
-
-    preflight_dagml_pipeline_migration(
-        [
-            {
-                "_or_": [
-                    safe,
-                    {"model": PLSRegression(n_components=1), "refit_params": {"use_all_partitions": False}},
-                ],
-                "count": 1,
-                "_seed_": 6,
-            }
-        ]
-    )
-
-
-def test_duplication_branch_later_expansion_cannot_hide_a_zip_refit_choice(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """BranchController's second generator phase is included in the zip uncertainty boundary."""
-
-    sampler = importlib.import_module("nirs4all.pipeline.config._generator.strategies.or_strategy")
-
-    def pick_last(population: list[Any], count: int, seed: int | None = None, weights: list[float] | None = None) -> list[Any]:
-        del seed, weights
-        return list(population[-count:])
-
-    nested_zip = {
-        "_zip_": {
-            "model": [PLSRegression(n_components=1), PLSRegression(n_components=1)],
-            "params": {"_or_": [{"alpha": 1}, {"alpha": 2}]},
-            "refit_params": [
-                {
-                    "_or_": [
-                        {"use_all_partitions": False},
-                        {"use_all_partitions": True},
-                    ],
-                    "count": 1,
-                }
-            ],
-        }
-    }
-    pipeline = [{"branch": [{"name": "late-zip", "steps": [nested_zip]}]}]
-
-    with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration(pipeline)
-
-    monkeypatch.setattr(sampler, "sample_with_seed", pick_last)
-    runtime_variants = BranchController.__new__(BranchController)._expand_list_with_generators([nested_zip])
-    assert runtime_variants[0][0]["refit_params"]["use_all_partitions"] is True
+    preflight_dagml_pipeline_migration(_refit_noop_pipeline())
+    preflight_dagml_pipeline_migration([{"model": PLSRegression(n_components=1), "refit_params": generator_payload}])
+    preflight_dagml_pipeline_migration([{"model": PLSRegression(n_components=1), "refit_params": cyclic_payload}])
+    preflight_dagml_pipeline_migration([{"_zip_": {"params": {"_or_": [{"alpha": 1}, {"alpha": 2}]}}}])
 
 
 def test_concat_refusal_is_limited_to_the_pre_cv_prefix() -> None:
-    """A stateful concat after a splitter remains an ordinary native capability boundary."""
+    """A stateful concat after a splitter remains an ordinary capability boundary."""
 
     with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
         preflight_dagml_pipeline_migration(_stateful_concat_pipeline())
 
-    preflight_dagml_pipeline_migration([KFold(n_splits=2), {"concat_transform": [PCA(n_components=1)]}, {"model": PLSRegression(n_components=1)}])
+    preflight_dagml_pipeline_migration(
+        [
+            KFold(n_splits=2),
+            {"concat_transform": [PCA(n_components=1)]},
+            {"model": PLSRegression(n_components=1)},
+        ]
+    )
+    preflight_dagml_pipeline_migration(_safe_pipeline())
 
 
 def test_named_concat_operation_dict_is_scanned_without_an_operations_wrapper() -> None:
@@ -613,38 +226,155 @@ def test_named_concat_operation_dict_is_scanned_without_an_operations_wrapper() 
         )
 
 
-def test_active_branch_body_is_visible_but_metadata_and_params_are_opaque() -> None:
-    """Semantic-looking payload fields cannot create a false refusal or cycle failure."""
+def test_unseeded_choices_and_late_branch_generators_cannot_hide_stateful_concat() -> None:
+    """Preflight mirrors the differing top-level and duplication-branch seed contracts."""
 
-    with pytest.raises(DagMlRefitParamsMigrationRequired):
-        preflight_dagml_pipeline_migration([{"branch": [{"name": "unsafe", "steps": [_refit_pipeline()[-1]]}]}])
+    safe = {"concat_transform": [StandardNormalVariate()]}
+    unsafe = {"concat_transform": [PCA(n_components=1)]}
 
-    metadata_cycle: dict[str, Any] = {"_or_": []}
-    metadata_cycle["_or_"].append(metadata_cycle)
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        preflight_dagml_pipeline_migration([{"_sample_": {"distribution": "choice", "values": [safe, unsafe], "num": 1}}])
+
+    # The top-level random_state is honored by PipelineConfigs and chooses the safe option here.
+    preflight_dagml_pipeline_migration(
+        {
+            "random_state": 1,
+            "steps": [{"_sample_": {"distribution": "choice", "values": [safe, unsafe], "num": 1}}],
+        }
+    )
+
+    # BranchController expands duplication generators later without PipelineConfigs.random_state;
+    # a root seed must therefore not hide the unsafe first chain item.
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        preflight_dagml_pipeline_migration(
+            {
+                "random_state": 0,
+                "steps": [
+                    {
+                        "branch": [
+                            {
+                                "name": "late-chain",
+                                "steps": [{"_chain_": [unsafe, safe], "count": 1}],
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+
+
+def test_weighted_unseeded_choice_is_uninspectable_not_a_false_concat_refusal() -> None:
+    """A zero-weight stateful option is not reported as definitely active."""
+
+    safe = {"concat_transform": [StandardNormalVariate()]}
+    unsafe = {"concat_transform": [PCA(n_components=1)]}
+
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([{"_or_": [unsafe, safe], "count": 1, "_weights_": [0.0, 1.0]}])
+
+
+def test_opaque_zip_concat_column_is_never_decided_from_one_random_draw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An opaque generated sibling cannot truncate a stateful concat candidate."""
+
+    sampler = importlib.import_module("nirs4all.pipeline.config._generator.strategies.or_strategy")
+
+    def pick_first(
+        population: list[Any],
+        count: int,
+        seed: int | None = None,
+        weights: list[float] | None = None,
+    ) -> list[Any]:
+        del seed, weights
+        return list(population[:count])
+
+    def pick_last(
+        population: list[Any],
+        count: int,
+        seed: int | None = None,
+        weights: list[float] | None = None,
+    ) -> list[Any]:
+        del seed, weights
+        return list(population[-count:])
+
+    concat_zip = {
+        "_zip_": {
+            "params": {"_or_": [{"alpha": 1}, {"alpha": 2}]},
+            "concat_transform": {
+                "_or_": [[StandardNormalVariate()], [PCA(n_components=1)]],
+                "count": 1,
+            },
+        }
+    }
+
+    monkeypatch.setattr(sampler, "sample_with_seed", pick_first)
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([concat_zip])
+
+    monkeypatch.setattr(sampler, "sample_with_seed", pick_last)
+    assert isinstance(expand_spec([concat_zip])[0][0]["concat_transform"][0], PCA)
+
+    # A concrete splitter closes the pre-CV semantic boundary.
+    preflight_dagml_pipeline_migration([KFold(n_splits=2), concat_zip])
+
+
+def test_selected_generator_population_aggregates_opaque_and_concat_siblings() -> None:
+    """Opaque expansion anywhere in a selector protects stateful concat anywhere in it."""
+
+    safe = {
+        "model": {"_or_": [PLSRegression(n_components=1), PLSRegression(n_components=1)]},
+        "concat_transform": [StandardNormalVariate()],
+    }
+    unsafe = {
+        "model": PLSRegression(n_components=1),
+        "concat_transform": [PCA(n_components=1)],
+    }
+    selector = {"_or_": [safe, unsafe], "count": 1, "_seed_": 6}
+
+    assert isinstance(expand_spec([selector])[0][0]["concat_transform"][0], PCA)
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([selector])
+
+    seeded_grid = {
+        "_grid_": {
+            "params": {"_or_": [{"alpha": 1}, {"alpha": 2}]},
+            "concat_transform": [[StandardNormalVariate()], [PCA(n_components=1)]],
+        },
+        "count": 1,
+        "_seed_": 1,
+    }
+    with pytest.raises(DagMlPipelinePreflightRequired):
+        preflight_dagml_pipeline_migration([seeded_grid])
+
+
+def test_active_branch_body_is_visible_but_payloads_remain_opaque() -> None:
+    """Executable branch bodies are scanned without mistaking payload keys for workflow steps."""
+
+    with pytest.raises(DagMlStatefulConcatTransformMigrationRequired):
+        preflight_dagml_pipeline_migration([{"branch": [{"name": "unsafe", "steps": [{"concat_transform": [PCA(n_components=1)]}]}]}])
+
+    metadata_cycle: dict[str, Any] = {"concat_transform": [PCA(n_components=1)]}
+    metadata_cycle["self"] = metadata_cycle
     preflight_dagml_pipeline_migration(
         [
-            {"concat_transform": [StandardNormalVariate()], "metadata": {"concat_transform": [PCA(n_components=1)]}},
+            {"concat_transform": [StandardNormalVariate()], "metadata": metadata_cycle},
             KFold(n_splits=2),
-            {
-                "model": {
-                    "class": "sklearn.cross_decomposition.PLSRegression",
-                    "params": {
-                        "n_components": 1,
-                        "refit_params": {"use_all_partitions": True},
-                        "concat_transform": [PCA(n_components=1)],
-                    },
-                },
-                "metadata": {"refit_params": metadata_cycle},
-            },
+            {"model": PLSRegression(n_components=1)},
         ]
     )
 
 
-def test_active_cycle_refuses_before_any_fallback() -> None:
-    """A cycle in the declarative grammar is uncertain, unlike a metadata cycle."""
+def test_only_concat_relevant_cycles_trigger_generic_preflight() -> None:
+    """Nontracked grammar cycles keep their ordinary path; concat cycles fail closed."""
 
     cycle: dict[str, Any] = {"_or_": []}
     cycle["_or_"].append(cycle)
 
+    preflight_dagml_pipeline_migration([cycle])
+
+    concat_cycle: dict[str, Any] = {"concat_transform": []}
+    concat_cycle["concat_transform"].append(concat_cycle)
+
     with pytest.raises(DagMlPipelinePreflightRequired):
-        preflight_dagml_pipeline_migration([cycle])
+        preflight_dagml_pipeline_migration([concat_cycle])


### PR DESCRIPTION
Summary:
- Add fail-closed DAG-ML preflight for the one attested semantic mismatch: stateful concat_transform before CV.
- Refuse before backend, dataset materialization, PipelineRunner, warnings, or legacy fallback.
- Keep refit_params.use_all_partitions as its documented legacy no-op fallback; no default-engine change.
- Reconcile parity evidence to 9 fallback / 1 preflight refusal / 85 native cases.

Validation:
- Sol hostile review accepted the final SHA.
- Focused preflight, ledger, conformance, selector, Ruff, targeted mypy, JSON sync, and diff checks passed.

Notes:
- The rejected metadata FeatureJoin experiment is not included.