### PR TITLE
docs(native): record live Methods witness evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add an audit-only, process-local live Methods execution observation on
+  `NativeMethodsRunResult`. Close/detach invalidates that live observation;
+  the retained witness/result are non-serializable, and the claim does not
+  replace the signed outcome or portable package. Core Archive V2 export
+  remains available after release of the live facade.
+- Add an installed-wheel Methods gate for released `dag-ml==0.3.20` and
+  `nirs4all-methods==1.0.13`, proving the live claim → close → Archive V2
+  lifecycle without `N4M_LIB_PATH`.
+
+The public default engine remains `legacy`; this evidence does not promote the
+native lane or alter the explicit rollback boundary.
+
 ---
 
 ## [0.12.10] — 2026-08-27

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -254,7 +254,7 @@ as a reminder that the public score scalars are *pinned*
 
 ## §D — Cross-engine surface ledger (EXISTS / PARTIAL / GAP)
 
-The numerical pipeline parity above is proven. These five *cross-engine
+The numerical pipeline parity above is proven. These *cross-engine
 surfaces* are tracked separately; GAPs are `LOCK-PYREF` G5–G9 work (see the A2
 report §4 and SW5 §6 for the concrete test specs).
 
@@ -265,7 +265,7 @@ report §4 and SW5 §6 for the concrete test specs).
 | Workspace cross-engine (legacy SQLite/Parquet/manifest read via runtime V1; native-results triple round-trip) | **GAP** (PYREF-009b) | engines write non-overlapping formats (`test_dagml_native_results.py:210-219` asserts legacy ignores the native dir) | `cross_impl_score` (target) | L17 + L5 |
 | Error / refusal parity (same invalid pipeline → same refusal on both engines) | **GAP** (PYREF-err) | every `pytest.raises` in the parity dir is single-engine dag-ml-only | n/a | L17 |
 | Studio rides the oracle (records resolved engine; one pipeline through both engines) | **GAP** (PYREF-008) | adapter reads native triple correctly, but Studio never passes/records `engine=`; 4 backend routes re-implement nirs4all logic | `cross_impl_score` (target) | L17 + L12 |
-| methods-installed lane (n4m parity) | **PARTIAL** | `test_n4m_ops.py` exists (SNV `1e-12`, PLS `<1e-9`) but is `importorskip("n4m")` and not pinned in CI | `kernel_snv` / `kernel_pls` | L17 + L9 |
+| methods-installed lane (n4m parity and strict Methods lifecycle) | **PARTIAL** | `methods-installed.yml` pins released `dag-ml==0.3.20` and `nirs4all-methods==1.0.13`, requires N4M, removes `N4M_LIB_PATH`, and runs `test_n4m_ops.py` plus `test_native_methods_witness.py` (live claim → close → Core Archive V2). | `kernel_snv` / `kernel_pls` for the numerical kernel checks; lifecycle has no numeric tolerance | L17 + L9 |
 | nirs4all-side wheel / `.so` freshness | **GAP** (PYREF-011) | dag-ml has `scripts/check_so_freshness.py`; nirs4all tracks no artifact and has no consumer-side freshness gate | n/a | L17 + L9 |
 
 ---

--- a/docs/source/api/module_api.md
+++ b/docs/source/api/module_api.md
@@ -157,6 +157,18 @@ with nirs4all.session(pipeline, engine="native") as native:
     result.export("model.n4a")
 ```
 
+##### Live Methods execution observation
+
+Before a strict native result is closed, `result.native_execution_claim` gives
+an immutable, audit-only description of the local callback-free
+`dag_ml.execute_methods_training` call and
+`result.native_execution_is_live` reports whether its exact DAG-ML facade is
+still attached. This is deliberately process-local rather than a portable
+receipt: `result.close()`, `result.detach()`, or closing the owning native
+session invalidates the claim. The signed outcome and portable package are the
+durable evidence, so `result.export("model.n4a")` remains valid after that
+live observation has been released.
+
 The native tuning request is ``{"engine": "methods-hpo", "trials": N}``.
 It may additionally select ``sampler="random"|"tpe"`` and
 ``pruner="none"|"median"``. It uses the DAG-ML Methods controller with the

--- a/docs/source/developer/r2_native_recovery_audit.md
+++ b/docs/source/developer/r2_native_recovery_audit.md
@@ -16,6 +16,23 @@ fail-closed par défaut ; un rollback legacy demande explicitement
 `allow_legacy_fallback=True`. Cette frontière ne doit pas être inversée avant
 que toutes les capacités déclarées R2 disposent d'une preuve native.
 
+## Évidence de cycle intégrée après l'audit historique
+
+Le lot #122 (merge `0f612509`) ajoute une preuve locale pour le sous-ensemble
+Methods strict déjà déclaré : le résultat expose un témoin vivant, lié à la
+façade `dag_ml.TrainingResult`, qui observe l'appel callback-free
+`dag_ml.execute_methods_training`. Ce témoin est volontairement non
+sérialisable et cesse d'être utilisable après `close()`/`detach()` ; l'outcome
+signé et le package portable restent les seules preuves durables, et permettent
+l'export Archive V2 après cette fermeture.
+
+À l'instant historique du lot #122, la CI `methods-installed.yml` installait
+les roues publiées `dag-ml==0.3.19` et `nirs4all-methods==1.0.13`, retirait
+`N4M_LIB_PATH`, puis vérifiait le cycle réel claim → close → Archive V2. Cette
+preuve renforce la forme `run(..., engine="native")` déjà supportée ; elle ne rend
+pas R2 complet,
+ne change pas le défaut `legacy` et ne justifie aucune bascule de moteur.
+
 ## Méthode
 
 Pour chaque branche candidate, on utilise `git range-diff` contre son merge

--- a/docs/source/reference/public_interfaces.md
+++ b/docs/source/reference/public_interfaces.md
@@ -259,10 +259,24 @@ semantic authority for these dispositions. The table below is the human-readable
 R2 companion; callers should branch on it rather than inferring support from
 the broader legacy API.
 
+### Local strict-execution observation
+
+A successful portable Methods `run(..., engine="native")` returns a
+`NativeMethodsRunResult` with `native_execution_claim` and
+`native_execution_is_live`.  The claim is an audit-only, process-local
+observation that the strict callback-free
+`dag_ml.execute_methods_training` route produced the attached result; it is
+not a portable attestation or a substitute for the signed outcome and package.
+Calling `result.close()` or `result.detach()` (including through
+`NativeMethodsSession.close()`) releases that live facade: the claim then fails
+closed and `native_execution_is_live` becomes false.  The durable native
+outcome/package remain valid, so `result.export("model.n4a")` may still write
+the Core Archive V2 after the live observation has closed.
+
 | Lifecycle operation | Native status | Exact boundary |
 | --- | --- | --- |
-| `run(..., engine="native")` | Supported subset | Explicit raw mapping `{"X", "y", "sample_ids"}`, portable Methods pipeline, native refit, and no legacy workspace/cache/project/result path. Nested stacking requires a partitioned outer CV (for example `KFold`): repeated or overlapping validation such as `ShuffleSplit` is refused before execution because it cannot provide one outer-OOF row per sample. Unsupported shapes stop before a legacy run. |
-| `session(pipeline, engine="native")` | Supported subset | Returns `NativeMethodsSession`: native train, identity-bound prediction, Archive V2 export, close, and one selected full refit that returns a V3 child. It does not create a `PipelineRunner`. |
+| `run(..., engine="native")` | Supported subset | Explicit raw mapping `{"X", "y", "sample_ids"}`, portable Methods pipeline, native refit, and no legacy workspace/cache/project/result path. Its in-memory result starts with the local strict-execution observation described above. Nested stacking requires a partitioned outer CV (for example `KFold`): repeated or overlapping validation such as `ShuffleSplit` is refused before execution because it cannot provide one outer-OOF row per sample. Unsupported shapes stop before a legacy run. |
+| `session(pipeline, engine="native")` | Supported subset | Returns `NativeMethodsSession`: native train, identity-bound prediction, Archive V2 export, close, and one selected full refit that returns a V3 child. Closing it releases the local live observation before it drops the result reference; it does not create a `PipelineRunner`. |
 | `predict(..., engine="native")` | Supported subset | Requires an explicitly identified cohort. It accepts an in-memory `NativeMethodsRunResult`, a trained `NativeMethodsSession`, a V3 refit result, or a validated Methods Archive V2/V3 session. In-memory results call the already-attested estimator directly; archive/session replay rehydrates N4MM for that invocation only. |
 | `load_session(path, engine="native")` | Supported, PREDICT-only | Validates Core Archive V2/Package V2 or Archive V3/Package V3 before data/model hydration, then returns `NativeArchiveSession`. It has no train, retrain, save, or legacy fallback capability. |
 | `retrain(source, data, mode="full", engine="native")` | Supported subset | Source must be an in-memory `NativeMethodsRunResult` with a completed selected refit and attested seed. The selected PLS variant is copied exactly and the child outcome persists signed parent lineage. |

--- a/nirs4all/native_capability_matrix.v1.json
+++ b/nirs4all/native_capability_matrix.v1.json
@@ -14,7 +14,8 @@
         "tests/unit/api/test_engine_transition.py",
         "tests/unit/api/test_generate.py",
         "tests/unit/api/test_native_archive_session.py",
-        "tests/unit/api/test_native_session.py"
+        "tests/unit/api/test_native_session.py",
+        "tests/unit/api/test_native_witness.py"
       ],
       "role": "native_lifecycle_verification"
     }
@@ -34,7 +35,7 @@
     "export": {
       "forms": {
         "archive_v2": {
-          "boundary": "Exports a NativeMethodsRunResult as a Core Archive V2 after native package validation.",
+          "boundary": "Exports a NativeMethodsRunResult as a Core Archive V2 after native package validation; it remains available after the process-local live execution claim has been detached or closed.",
           "disposition": "native",
           "fallback": "forbidden",
           "public_api": "nirs4all.NativeMethodsRunResult.export"
@@ -138,7 +139,7 @@
     "run": {
       "forms": {
         "portable_methods": {
-          "boundary": "Requires an explicit raw mapping, a documented portable Methods topology, native refit, and no workspace, cache, project, or result-path state.",
+          "boundary": "Requires an explicit raw mapping, a documented portable Methods topology, native refit, and no workspace, cache, project, or result-path state. The returned result exposes an audit-only process-local live execution claim while its strict Methods facade remains attached.",
           "disposition": "native",
           "fallback": "forbidden",
           "public_api": "nirs4all.run"

--- a/tests/unit/api/test_native_capabilities.py
+++ b/tests/unit/api/test_native_capabilities.py
@@ -40,6 +40,13 @@ EXPECTED_FORMS: dict[str, dict[str, str]] = {
     "explain": {"native_request": "refused"},
     "generate": {"native_request": "refused"},
 }
+EXPECTED_RUNTIME_TESTS = {
+    "tests/unit/api/test_engine_transition.py",
+    "tests/unit/api/test_generate.py",
+    "tests/unit/api/test_native_archive_session.py",
+    "tests/unit/api/test_native_session.py",
+    "tests/unit/api/test_native_witness.py",
+}
 
 
 def _resolve_public_api(path: str) -> object:
@@ -86,7 +93,13 @@ def test_packaged_native_capability_matrix_is_complete_and_fail_closed() -> None
     assert "source_ledgers" not in matrix
     assert evidence["compatibility_context"]["role"] == "parity_tolerance_context_only"
     assert (REPOSITORY_ROOT / evidence["compatibility_context"]["path"]).is_file()
+    assert set(evidence["runtime_tests"]["paths"]) == EXPECTED_RUNTIME_TESTS
     assert all((REPOSITORY_ROOT / path).is_file() for path in evidence["runtime_tests"]["paths"])
+
+    portable_methods = matrix["operations"]["run"]["forms"]["portable_methods"]
+    assert "process-local live execution claim" in portable_methods["boundary"]
+    archive_v2 = matrix["operations"]["export"]["forms"]["archive_v2"]
+    assert "detached or closed" in archive_v2["boundary"]
 
     lifecycle = evidence["lifecycle_reference"]
     lifecycle_text = (REPOSITORY_ROOT / lifecycle["path"]).read_text(encoding="utf-8")

--- a/tests/unit/docs/test_native_methods_witness_docs.py
+++ b/tests/unit/docs/test_native_methods_witness_docs.py
@@ -1,0 +1,84 @@
+"""Documentation checks for the strict Methods live-execution evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+DOCS_ROOT = REPOSITORY_ROOT / "docs" / "source"
+PUBLIC_INTERFACES = DOCS_ROOT / "reference" / "public_interfaces.md"
+MODULE_API = DOCS_ROOT / "api" / "module_api.md"
+R2_AUDIT = DOCS_ROOT / "developer" / "r2_native_recovery_audit.md"
+CHANGELOG = REPOSITORY_ROOT / "CHANGELOG.md"
+COMPATIBILITY = REPOSITORY_ROOT / "docs" / "compatibility.md"
+DOCUMENTED_LEDGER = REPOSITORY_ROOT / "docs" / "compatibility.json"
+PACKAGED_LEDGER = REPOSITORY_ROOT / "nirs4all" / "compatibility_ledger.json"
+
+
+def _normalized(text: str) -> str:
+    return " ".join(text.split())
+
+
+def test_native_methods_live_witness_is_documented_as_local_and_non_durable() -> None:
+    """Public native docs distinguish the live observation from durable evidence."""
+
+    public_interfaces = _normalized(PUBLIC_INTERFACES.read_text(encoding="utf-8"))
+    module_api = _normalized(MODULE_API.read_text(encoding="utf-8"))
+
+    required_public_interfaces = (
+        "`native_execution_claim` and `native_execution_is_live`",
+        "audit-only, process-local observation",
+        "not a portable attestation",
+        "`result.close()` or `result.detach()`",
+        "`NativeMethodsSession.close()`",
+        '`result.export("model.n4a")` may still write the Core Archive V2',
+    )
+    required_module_api = (
+        "`result.native_execution_claim`",
+        "process-local rather than a portable receipt",
+        "`result.close()`, `result.detach()`",
+        '`result.export("model.n4a")` remains valid',
+    )
+
+    missing_public_interfaces = [phrase for phrase in required_public_interfaces if phrase not in public_interfaces]
+    missing_module_api = [phrase for phrase in required_module_api if phrase not in module_api]
+    assert not missing_public_interfaces, "public Interfaces missing:\n" + "\n".join(missing_public_interfaces)
+    assert not missing_module_api, "module API missing:\n" + "\n".join(missing_module_api)
+
+
+def test_installed_methods_evidence_and_r2_release_record_are_published() -> None:
+    """The documented CI proof preserves its narrow R2/default boundary."""
+
+    compatibility = _normalized(COMPATIBILITY.read_text(encoding="utf-8"))
+    changelog = _normalized(CHANGELOG.read_text(encoding="utf-8"))
+    r2_audit = _normalized(R2_AUDIT.read_text(encoding="utf-8"))
+
+    assert "not pinned in CI" not in compatibility
+    assert "`methods-installed.yml` pins released `dag-ml==0.3.20` and `nirs4all-methods==1.0.13`" in compatibility
+    assert "`test_native_methods_witness.py`" in compatibility
+    assert "| → fall back to legacy (`EXPECTED_FALLBACK`) | **9**" in compatibility
+    assert "| → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **1**" in compatibility
+    assert "| → run native on dag-ml | **85**" in compatibility
+
+    assert "process-local live Methods execution observation" in changelog
+    assert "`dag-ml==0.3.20` and `nirs4all-methods==1.0.13`" in changelog
+    assert "The public default engine remains `legacy`" in changelog
+
+    assert "Le lot #122 (merge `0f612509`)" in r2_audit
+    assert "À l'instant historique du lot #122" in r2_audit
+    assert "`dag-ml==0.3.19` et `nirs4all-methods==1.0.13`" in r2_audit
+    assert "ne rend pas R2 complet" in r2_audit
+    assert "ne change pas le défaut `legacy`" in r2_audit
+
+
+def test_documented_compatibility_counts_follow_the_packaged_ledger() -> None:
+    """The prose and byte-identical compatibility resources keep their scopes separate."""
+
+    assert DOCUMENTED_LEDGER.read_bytes() == PACKAGED_LEDGER.read_bytes()
+    ledger = json.loads(PACKAGED_LEDGER.read_text(encoding="utf-8"))
+    assert ledger["coverage_meter"]["fallback"] == 9
+    assert ledger["coverage_meter"]["preflight_refusal"] == 1
+    assert ledger["coverage_meter"]["native"] == 85
+    methods_installed = next(entry for entry in ledger["cross_engine_surfaces"] if entry["surface"] == "methods_installed")
+    assert methods_installed["status"] == "partial"


### PR DESCRIPTION
## Summary

Documents and qualifies the strict live Methods witness lane after the DAG-ML 0.3.20 update.

- distinguishes historical #122 validation on dag-ml 0.3.19 from the current installed Methods gate on 0.3.20;
- records the current R2 capability state: 85 native, 9 explicit fallback, 1 typed preflight refusal;
- keeps  and does not alter Studio or runtime routing.

## Validation

- independent Sol review: ACCEPT;
- focused docs/capabilities/witness/ledger tests: 24 passed;
- Ruff, Sphinx, JSON and diff checks passed.

The two compatibility ledgers remain byte-identical.