### PR TITLE
fix(dagml): lower proven refit no-op

### DIFF
--- a/.github/workflows/methods-installed.yml
+++ b/.github/workflows/methods-installed.yml
@@ -8,9 +8,28 @@ on:
       - "nirs4all/api/run.py"
       - "nirs4all/api/native_*.py"
       - "nirs4all/pipeline/dagml/**"
+      - "tests/unit/pipeline/dagml/test_finetune_lowering.py"
       - "tests/unit/api/test_native_witness.py"
       - "tests/unit/pipeline/dagml/test_terminal_predict_lowerer.py"
       - "tests/integration/api/test_native_methods_witness.py"
+      - "tests/integration/parity/cases_refit_predict.py"
+      - "tests/integration/parity/test_conformance_dual_engine.py"
+      - "tests/integration/parity/test_parity_compiles.py"
+      - "tests/integration/parity/test_parity_baseline.py"
+      - "tests/integration/parity/test_compatibility_ledger.py"
+      - "tests/integration/parity/_authority.py"
+      - "tests/integration/parity/_oracle.py"
+      - "tests/integration/parity/_registry.py"
+      - "tests/integration/parity/conftest.py"
+      - "tests/integration/parity/baselines/**"
+      - "nirs4all/pipeline/keyword_registry.py"
+      - "tests/unit/pipeline/test_keyword_registry.py"
+      - "tests/unit/docs/test_keyword_registry_extension.py"
+      - "nirs4all/compatibility_ledger.json"
+      - "docs/compatibility.json"
+      - "docs/compatibility.md"
+      - "tests/unit/docs/test_native_methods_witness_docs.py"
+      - "docs/source/reference/pipeline_keywords.md"
       - "pyproject.toml"
       - "requirements*.txt"
       - ".github/workflows/methods-installed.yml"
@@ -71,3 +90,14 @@ jobs:
           env -u N4M_LIB_PATH python -m pytest -m methods tests/unit/operators/methods/test_n4m_ops.py -q
           env -u N4M_LIB_PATH python -m pytest tests/unit/pipeline/dagml/test_terminal_predict_lowerer.py -q
           env -u N4M_LIB_PATH python -m pytest -m methods tests/integration/api/test_native_methods_witness.py -q
+          # The installed witness is the load-bearing n4m lifecycle proof.
+          # The remaining selectors are independent DAG-ML/ledger authority proofs; refit itself does not require n4m.
+          env -u N4M_LIB_PATH NIRS4ALL_REQUIRE_N4M=1 python -m pytest -q \
+            'tests/integration/api/test_native_methods_witness.py::test_installed_methods_witness_claim_closes_through_the_public_dagml_lifecycle' \
+            'tests/integration/parity/test_conformance_dual_engine.py::test_native_fallback_boundary[refit_params_use_all_partitions]' \
+            'tests/integration/parity/test_conformance_dual_engine.py::test_dual_engine_conformance[refit_params_use_all_partitions]' \
+            'tests/integration/parity/test_parity_compiles.py::test_pipeline_compiles[refit_params_use_all_partitions]' \
+            'tests/integration/parity/test_parity_baseline.py::test_every_runnable_case_has_committed_baseline' \
+            'tests/integration/parity/test_parity_baseline.py::test_legacy_gold_baseline[refit_params_use_all_partitions]' \
+            'tests/integration/parity/test_compatibility_ledger.py::test_compatibility_json_is_valid_json' \
+            'tests/integration/parity/test_compatibility_ledger.py::test_compatibility_json_matches_live_parity_authority'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `nirs4all-methods==1.0.13`, proving strict terminal lowerer preflight plus
   the live claim → close → Archive V2 lifecycle without `N4M_LIB_PATH`.
 
+### Fixed
+
+- Promote only the exact plain `PLSRegression` `refit_params`
+  `{'use_all_partitions': True}` compatibility no-op from the conformance
+  fallback allowlist to native DAG-ML; nearby `refit_params` forms remain
+  fail-closed on the fallback boundary.
+
 The public default engine remains `legacy`; this evidence does not promote the
 native lane or alter the explicit rollback boundary.
 

--- a/docs/compatibility.json
+++ b/docs/compatibility.json
@@ -173,11 +173,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "refit_params_use_all_partitions",
-      "shape": "refit_params",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
@@ -336,9 +331,9 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 9,
+    "fallback": 8,
     "preflight_refusal": 1,
-    "native": 85,
+    "native": 86,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -159,7 +159,7 @@ while the Python oracle materializes `concat_transform` before CV.
 
 ## §C — Orthogonal axes (NOT authority tiers; tracked so they don't pollute §B)
 
-### C.1 Native-coverage fallback boundary — `EXPECTED_FALLBACK` (9)
+### C.1 Native-coverage fallback boundary — `EXPECTED_FALLBACK` (8)
 
 Shapes the dag-ml host bridge does **not serialize yet**. A normal
 `engine="dag-ml"` request fails closed; the parity harness exercises these rows
@@ -179,8 +179,14 @@ Source: `test_conformance_dual_engine.py` (`EXPECTED_FALLBACK`).
 | branch (duplication) + merge → multi-model | `branch_dup_three_way_merge_predictions`, `branch_dup_named_with_metamodel`, `branch_dup_merge_all` |
 | branch separation by metadata/tag/filter | `branch_separation_by_metadata_auto`, `branch_separation_by_tag`, `branch_separation_by_filter` |
 | legacy Optuna finetuning | `generator_finetune_params_optuna` |
-| legacy `refit_params` compatibility no-op | `refit_params_use_all_partitions` |
 | by-source / per-source multi-source | `multi_source_per_source_models_stacking` |
+
+Only the exact plain `PLSRegression` model step with the built-in `dict`
+`{'use_all_partitions': True}` now runs natively; this is a legacy compatibility
+no-op, not general `refit_params` support. Near `refit_params` forms remain on
+the fail-closed fallback boundary: `False` or truthy non-`bool` values, extra
+keys or non-built-in mappings, subclasses or other models, and nested or
+aliased occurrences do not gain native coverage.
 
 **`EXPECTED_FALLBACK == ∅` is the `LOCK-DROP` D1 gate, owned by L5 — not a
 `LOCK-PYREF` gate.**
@@ -282,9 +288,9 @@ contract boundary.
 | Registered `PipelineCase`s | **95** | `cases_*.py` `register()` calls |
 | Non-runnable (`skip_reason` set) | **0** | no fixture/unknown/legacy-bug skips in the registry |
 | Runnable | **95** | 95 − 0 |
-| → fall back to legacy (`EXPECTED_FALLBACK`) | **9** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
+| → fall back to legacy (`EXPECTED_FALLBACK`) | **8** | boundary-asserted, no parity claim — **target → 0 (LOCK-DROP D1, L5)** |
 | → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **1** | typed error; no data work, legacy fallback, or `PipelineRunner` construction |
-| → run native on dag-ml | **85** | full parity asserted or parity-note pinned |
+| → run native on dag-ml | **86** | full parity asserted or parity-note pinned |
 | Strict-xfail (documented divergence) | **0** | `KNOWN_DIVERGENCES` is empty; no `legacy_bug` rows in the current registry |
 | `pytest.skip` (fixture) | **0** | fixture skips retired |
 | `NUM_PREDICTIONS_DIVERGENCE` parity-notes (PASS) | **2** | counts pinned |
@@ -293,11 +299,12 @@ contract boundary.
 
 > **Correction to prior counts:** the current machine-readable ledger and live
 > registry have no `legacy_bug`, `unknown_semantics`, or fixture skip rows. The
-> verified meter is **0** non-runnable / **95** runnable: **9** catchable
-> fallback rows, **1** typed semantic migration refusal, and **85** native rows.
+> verified meter is **0** non-runnable / **95** runnable: **8** catchable
+> fallback rows, **1** typed semantic migration refusal, and **86** native rows.
 > Stateful `concat_transform` requires an explicit native migration or
-> `engine="legacy"`; `refit_params.use_all_partitions` remains a legacy no-op
-> on the ordinary fallback boundary.
+> `engine="legacy"`; only the exact plain `PLSRegression`
+> `{'use_all_partitions': True}` no-op runs natively, while near `refit_params`
+> forms remain on the fail-closed fallback boundary.
 
 ---
 

--- a/docs/source/reference/pipeline_keywords.md
+++ b/docs/source/reference/pipeline_keywords.md
@@ -232,11 +232,19 @@ These similarly named dictionaries act at different lifecycle stages:
 3. Step-level `refit_params` overrides `train_params` only for the selected
    legacy winner's refit; missing values inherit from `train_params`.
 
-The current DAG-ML lowering rejects all fit-argument scopes that it cannot
-preserve: `finetune_params.train_params`, step-level `train_params`, and
-`refit_params`. Their DAG-ML support is explicitly `unsupported`, not partial.
-On the legacy path all three can change the deployed predictor. A conformal
-calibrator fitted before such a change is stale and must not be reused.
+DAG-ML still rejects `finetune_params.train_params` and step-level
+`train_params`. Step-level `refit_params` is **partial**: the sole accepted
+exception is the exact built-in `{"use_all_partitions": True}` no-op mapping on
+exactly one top-level model step whose model is exactly
+`sklearn.cross_decomposition.PLSRegression`; that step may carry only an
+optional `name` sibling. The pipeline is not mutated, so its original legacy
+configuration identity is retained.
+
+Every false, extra, or non-built-in payload; PLS subclass or other estimator;
+additional or nested model/refit step; and serialized or workflow step remains
+rejected before native execution. Outside that no-op, all three legacy scopes
+can change the deployed predictor. A conformal calibrator fitted before such a
+change is stale and must not be reused.
 
 (planned-full-dag-tuning)=
 ### Full-DAG tuning

--- a/nirs4all/compatibility_ledger.json
+++ b/nirs4all/compatibility_ledger.json
@@ -173,11 +173,6 @@
       "owner_lane": "L5"
     },
     {
-      "case": "refit_params_use_all_partitions",
-      "shape": "refit_params",
-      "owner_lane": "L5"
-    },
-    {
       "case": "multi_source_per_source_models_stacking",
       "shape": "multi_source",
       "owner_lane": "L5"
@@ -336,9 +331,9 @@
     "registered": 95,
     "non_runnable": 0,
     "runnable": 95,
-    "fallback": 9,
+    "fallback": 8,
     "preflight_refusal": 1,
-    "native": 85,
+    "native": 86,
     "xfail_strict": 0,
     "skip": 0,
     "num_predictions_divergence": 2,

--- a/nirs4all/pipeline/dagml/finetune_lowering.py
+++ b/nirs4all/pipeline/dagml/finetune_lowering.py
@@ -11,13 +11,171 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from nirs4all.pipeline.dagml_bridge import is_grid_param_generator_spec, is_param_generator_spec
-
 SUPPORTED_FINETUNE_META_KEYS = frozenset({"model_params", "metric", "direction", "eval_mode", "approach", "engine"})
 DETERMINISTIC_FINETUNE_ENGINES = frozenset({"", "dag-ml", "dagml", "native", "grid"})
 CORE_DAGML_SELECTION_METRICS = frozenset({"mse", "rmse", "mae", "r2", "accuracy", "balanced_accuracy"})
 PUBLIC_DAGML_SELECTION_METRICS = frozenset({"rmse", "accuracy", "balanced_accuracy"})
 UNSUPPORTED_NATIVE_TRAINING_PARAM_KEYS = frozenset({"train_params", "refit_params"})
+_REFIT_NOOP_MODEL_STEP_KEYS = frozenset({"name", "model", "refit_params"})
+_BRANCH_CONFIG_KEYS = frozenset({"parallel", "n_jobs"})
+_SEPARATION_BRANCH_KEYS = frozenset({"by_source", "by_tag", "by_metadata", "by_filter"})
+
+
+def _is_safe_refit_noop_direct_step(value: Any) -> bool:
+    """Whether a direct item is unambiguously non-model for the no-op proof."""
+
+    if value is None:
+        return True
+    if isinstance(value, (str, bytes, bytearray)):
+        return False
+    is_predictor = callable(getattr(value, "predict", None))
+    return (
+        callable(getattr(value, "split", None)) and not is_predictor
+    ) or (
+        callable(getattr(value, "transform", None)) and not is_predictor
+    )
+
+
+def _has_nested_structural_refit_params(steps: list[Any]) -> bool:
+    """Find refit keys only inside executable branch/wrapper/generator grammar.
+
+    Arbitrary estimator, preprocessing, metadata, and label payload mappings
+    remain opaque. The active identity stack makes malformed cyclic branch
+    payloads fail safely without treating aliases as a single occurrence.
+    """
+
+    from nirs4all.pipeline.config._generator.keywords import GENERATION_KEYWORDS
+
+    active_container_ids: set[int] = set()
+
+    def enter(value: Any) -> bool:
+        value_id = id(value)
+        if value_id in active_container_ids:
+            return False
+        active_container_ids.add(value_id)
+        return True
+
+    def visit_sequence(value: Any, *, branch_body: bool = False) -> bool:
+        if not isinstance(value, (list, tuple)):
+            return visit_step(value, branch_body=branch_body)
+        if not enter(value):
+            return False
+        try:
+            return any(visit_sequence(item, branch_body=branch_body) for item in value)
+        finally:
+            active_container_ids.remove(id(value))
+
+    def visit_step(value: Any, *, branch_body: bool = False, branch_list_wrapper: bool = False) -> bool:
+        if not isinstance(value, dict):
+            return False
+        if not enter(value):
+            return False
+        try:
+            if branch_list_wrapper and "steps" in value:
+                return visit_sequence(value["steps"], branch_body=True)
+            if branch_body and "refit_params" in value:
+                return True
+            if branch_body and any(key in GENERATION_KEYWORDS for key in value):
+                return visit_generator(value)
+            if "branch" in value:
+                return visit_branch(value["branch"])
+            if not branch_body and set(value) <= {"name", "pipeline"} and "pipeline" in value:
+                return visit_sequence(value["pipeline"], branch_body=True)
+            if not branch_body and set(value) <= {"name", "steps"} and "steps" in value:
+                return visit_sequence(value["steps"], branch_body=True)
+            return False
+        finally:
+            active_container_ids.remove(id(value))
+
+    def visit_generator(value: dict[Any, Any]) -> bool:
+        """Inspect generator choices, but never arbitrary sibling payload maps."""
+
+        return any(
+            visit_sequence(payload, branch_body=True)
+            for key, payload in value.items()
+            if key in GENERATION_KEYWORDS
+        )
+
+    def visit_separation_body(value: Any) -> bool:
+        if not isinstance(value, dict) or {"model", "branch", "refit_params"} & set(value):
+            return visit_sequence(value, branch_body=True)
+        if not enter(value):
+            return False
+        try:
+            return any(visit_sequence(body, branch_body=True) for body in value.values())
+        finally:
+            active_container_ids.remove(id(value))
+
+    def visit_branch(value: Any) -> bool:
+        if isinstance(value, (list, tuple)):
+            if not enter(value):
+                return False
+            try:
+                return any(
+                    visit_sequence(body, branch_body=True)
+                    if isinstance(body, (list, tuple))
+                    else visit_step(body, branch_body=True, branch_list_wrapper=True)
+                    for body in value
+                )
+            finally:
+                active_container_ids.remove(id(value))
+        if not isinstance(value, dict):
+            return visit_sequence(value, branch_body=True)
+        if not enter(value):
+            return False
+        try:
+            if any(key in GENERATION_KEYWORDS for key in value):
+                return visit_generator(value)
+            if _SEPARATION_BRANCH_KEYS & set(value):
+                return visit_separation_body(value.get("steps"))
+            return any(
+                visit_sequence(body, branch_body=True)
+                for name, body in value.items()
+                if isinstance(name, str) and not name.startswith("_") and name not in _BRANCH_CONFIG_KEYS
+            )
+        finally:
+            active_container_ids.remove(id(value))
+
+    return visit_sequence(steps)
+
+
+def _is_supported_native_refit_params_noop(steps: list[Any]) -> bool:
+    """Whether the sole legacy refit option is safe for native PLS to ignore.
+
+    ``use_all_partitions`` is a legacy controller no-op for exactly one plain,
+    top-level :class:`~sklearn.cross_decomposition.PLSRegression` model step.
+    Keep the proof deliberately narrow: cycles, aliases, bare estimators, a
+    subclass, another model, another occurrence, or any payload variation
+    remains on the fail-closed boundary.
+    """
+
+    from sklearn.cross_decomposition import PLSRegression
+
+    model_step: dict[Any, Any] | None = None
+    for step in steps:
+        if isinstance(step, dict):
+            if type(step) is not dict or model_step is not None:
+                return False
+            if set(step) - _REFIT_NOOP_MODEL_STEP_KEYS or {"model", "refit_params"} - set(step):
+                return False
+            if "name" in step and type(step["name"]) is not str:
+                return False
+            model_step = step
+        elif not _is_safe_refit_noop_direct_step(step):
+            return False
+
+    if model_step is None:
+        return False
+
+    model = model_step["model"]
+    if type(model) is not PLSRegression or "use_all_partitions" in model.get_params(deep=False):
+        return False
+
+    refit_params = model_step["refit_params"]
+    if type(refit_params) is not dict or len(refit_params) != 1:
+        return False
+    key, value = next(iter(refit_params.items()))
+    return type(key) is str and key == "use_all_partitions" and value is True
 
 
 def reject_native_training_param_overrides(
@@ -55,6 +213,8 @@ def lower_deterministic_finetune_params_to_generators(
         - trial counts, samplers, pruners and phases;
         - train/refit fit-argument sampling.
     """
+
+    from nirs4all.pipeline.dagml_bridge import is_grid_param_generator_spec, is_param_generator_spec
 
     lowered: list[Any] = []
     overrides: dict[str, str] = {}

--- a/nirs4all/pipeline/dagml/run_backend.py
+++ b/nirs4all/pipeline/dagml/run_backend.py
@@ -56,6 +56,8 @@ from .errors import DagMlUnavailable, DagMlUnsupported, _OperatorLoweringUnsuppo
 from .exclude import _excluded_from_pool, _resolve_exclude, _resolve_tags
 from .finetune_lowering import (
     PUBLIC_DAGML_SELECTION_METRICS,
+    _has_nested_structural_refit_params,
+    _is_supported_native_refit_params_noop,
     lower_deterministic_finetune_params_to_generators,
     reject_native_training_param_overrides,
 )
@@ -689,11 +691,16 @@ def _dispatch_run(
         if len(model_steps) == 1 and _model_controller_id(model_steps[0]["model"]) is not None
         else frozenset()
     )
+    refit_params_noop = _is_supported_native_refit_params_noop(pipeline)
+    if refit_params_noop:
+        allowed_training_param_keys |= frozenset({"refit_params"})
     reject_native_training_param_overrides(
         list(pipeline),
         context="engine='dag-ml'",
         allowed_keys=allowed_training_param_keys,
     )
+    if not refit_params_noop and _has_nested_structural_refit_params(pipeline):
+        raise NotImplementedError("engine='dag-ml' does not yet support nested step-level ['refit_params']; running natively would ignore refit arguments instead of preserving legacy parity.")
     config_name = _derive_config_name(pipeline, name)
     # The ordered legacy per-variant config names for a SWEEP (empty for a single concrete pipeline). The
     # native-generation and operator-expand paths below project EVERY variant's CV rows (legacy

--- a/nirs4all/pipeline/keyword_registry.py
+++ b/nirs4all/pipeline/keyword_registry.py
@@ -95,7 +95,7 @@ class KeywordRegistry(TypedDict):
 
 KEYWORD_REGISTRY_SCHEMA_ID: Final = "https://nirs4all.org/schemas/keyword-effects/v1"
 KEYWORD_REGISTRY_SCHEMA_VERSION: Final = 1
-KEYWORD_REGISTRY_VERSION: Final = "1.0.0"
+KEYWORD_REGISTRY_VERSION: Final = "1.0.1"
 
 _OBJECT_SCHEMA: Final[dict[str, Any]] = {"type": "object"}
 _STRING_SCHEMA: Final[dict[str, Any]] = {"type": "string", "minLength": 1}
@@ -553,8 +553,12 @@ _ENTRIES: Final[tuple[KeywordEntry, ...]] = (
         "reads": ["development"],
         "changes": ["final_predictor"],
         "invalidates_calibration": "always",
-        "engine_support": {"legacy": "supported", "dag-ml": "unsupported"},
-        "summary": "Overrides train_params only during legacy winner refit; DAG-ML currently rejects it before native execution.",
+        "engine_support": {"legacy": "supported", "dag-ml": "partial"},
+        "summary": (
+            "Overrides train_params only during legacy winner refit. DAG-ML accepts only the exact "
+            "{'use_all_partitions': True} no-op on one top-level exact PLSRegression model step "
+            "(optional name only); every other refit_params shape is rejected before native execution."
+        ),
         "docs_anchor": "three-training-parameter-scopes",
         "ui": {"label": "Winner refit parameters", "group": "training", "control": "object", "order": 80},
     },

--- a/tests/integration/parity/cases_refit_predict.py
+++ b/tests/integration/parity/cases_refit_predict.py
@@ -106,7 +106,7 @@ register(
     PipelineCase(
         name="refit_params_use_all_partitions",
         description="Legacy `refit_params: {use_all_partitions: True}` compatibility no-op → PLSR. "
-        "The DAG-ML path keeps this legacy-only key on the ordinary fallback boundary.",
+        "The native DAG-ML path accepts exactly this no-op while retaining the original pipeline identity.",
         keywords=("refit_params", "model", "name"),
         capabilities=(
             "preprocessing_transform",

--- a/tests/integration/parity/test_conformance_dual_engine.py
+++ b/tests/integration/parity/test_conformance_dual_engine.py
@@ -391,10 +391,6 @@ EXPECTED_FALLBACK: frozenset[str] = frozenset({
     # native dag-ml path does not serialize/execute `finetune_params` yet, so the
     # public strict path rejects it rather than silently run the untuned model.
     "generator_finetune_params_optuna",
-    # ``refit_params.use_all_partitions`` is a legacy compatibility no-op. DAG-ML
-    # does not lower that legacy-only key, so the diagnostic rollback retains its
-    # historical behavior without inventing a semantic migration requirement.
-    "refit_params_use_all_partitions",
     # by-source separation / per-source models / source-concat multi-source shapes.
     "multi_source_per_source_models_stacking",
 })

--- a/tests/unit/docs/test_keyword_registry_extension.py
+++ b/tests/unit/docs/test_keyword_registry_extension.py
@@ -38,8 +38,12 @@ def test_keyword_registry_extension_writes_static_json_artifact(tmp_path) -> Non
     tuning_summary_schema = json.loads((tmp_path / "html" / "_static" / "tuning-summary.schema.json").read_text(encoding="utf-8"))
     assert payload["schema_id"] == "https://nirs4all.org/schemas/keyword-effects/v1"
     assert any(entry["id"] == "robustness.scenarios.kind" for entry in payload["entries"])
-    assert hashlib.sha256(raw_payload.encode("utf-8")).hexdigest() == "8c3fec221ee3657a26f7558dfcee4fb5a432dc7c873b1a7dd89a5b8f61c91689"
+    assert hashlib.sha256(raw_payload.encode("utf-8")).hexdigest() == "bdbf554755652b3c148ca377bea4ce6480ef6c2ce5a194f45e371d75794d0a73"
     entries = {entry["id"]: entry for entry in payload["entries"]}
+    refit_params = entries["pipeline.step.refit_params"]
+    assert refit_params["engine_support"]["dag-ml"] == "partial"
+    assert "exact {'use_all_partitions': True} no-op" in refit_params["summary"]
+    assert "one top-level exact PLSRegression model step" in refit_params["summary"]
     assert entries["calibrate.calibration_data.sample_ids"]["aliases"] == [
         {"kind": "token", "name": "calibration_sample_ids", "canonical": "sample_ids", "mode": "read_only"},
         {"kind": "token", "name": "prediction_sample_ids", "canonical": "sample_ids", "mode": "read_only"},

--- a/tests/unit/docs/test_native_methods_witness_docs.py
+++ b/tests/unit/docs/test_native_methods_witness_docs.py
@@ -74,13 +74,18 @@ def test_installed_methods_evidence_and_r2_release_record_are_published() -> Non
     assert "`methods-installed.yml` pins released `dag-ml==0.3.22` and `nirs4all-methods==1.0.13`" in compatibility
     assert "`test_terminal_predict_lowerer.py`" in compatibility
     assert "`test_native_methods_witness.py`" in compatibility
-    assert "| → fall back to legacy (`EXPECTED_FALLBACK`) | **9**" in compatibility
+    assert "| → fall back to legacy (`EXPECTED_FALLBACK`) | **8**" in compatibility
     assert "| → semantic preflight refusal (`EXPECTED_PREFLIGHT_REFUSAL`) | **1**" in compatibility
-    assert "| → run native on dag-ml | **85**" in compatibility
+    assert "| → run native on dag-ml | **86**" in compatibility
+    assert "Only the exact plain `PLSRegression` model step with the built-in `dict`" in compatibility
+    assert "`{'use_all_partitions': True}` now runs natively" in compatibility
+    assert "Near `refit_params` forms remain on the fail-closed fallback boundary" in compatibility
 
     assert "process-local live Methods execution observation" in changelog
     assert "`dag-ml==0.3.22` and `nirs4all-methods==1.0.13`" in changelog
     assert "strict terminal lowerer preflight" in changelog
+    assert "exact plain `PLSRegression`" in changelog
+    assert "nearby `refit_params` forms remain fail-closed on the fallback boundary" in changelog
     assert "The public default engine remains `legacy`" in changelog
 
     assert "Le lot #122 (merge `0f612509`)" in r2_audit
@@ -107,8 +112,10 @@ def test_documented_compatibility_counts_follow_the_packaged_ledger() -> None:
 
     assert DOCUMENTED_LEDGER.read_bytes() == PACKAGED_LEDGER.read_bytes()
     ledger = json.loads(PACKAGED_LEDGER.read_text(encoding="utf-8"))
-    assert ledger["coverage_meter"]["fallback"] == 9
+    assert ledger["coverage_meter"]["fallback"] == 8
     assert ledger["coverage_meter"]["preflight_refusal"] == 1
-    assert ledger["coverage_meter"]["native"] == 85
+    assert ledger["coverage_meter"]["native"] == 86
+    assert len(ledger["expected_fallback"]) == 8
+    assert "refit_params_use_all_partitions" not in {entry["case"] for entry in ledger["expected_fallback"]}
     methods_installed = next(entry for entry in ledger["cross_engine_surfaces"] if entry["surface"] == "methods_installed")
     assert methods_installed["status"] == "partial"

--- a/tests/unit/pipeline/dagml/test_finetune_lowering.py
+++ b/tests/unit/pipeline/dagml/test_finetune_lowering.py
@@ -2,19 +2,52 @@
 
 from __future__ import annotations
 
+from collections import UserDict
 from pathlib import Path
-from typing import Any
+from types import MappingProxyType
+from typing import Any, cast
 
 import numpy as np
 import pytest
 from sklearn.cross_decomposition import PLSRegression
-from sklearn.model_selection import KFold
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import KFold, ShuffleSplit
 
+from nirs4all.operators.transforms import StandardNormalVariate as SNV
 from nirs4all.pipeline.dagml.detect import _generation_kind
 from nirs4all.pipeline.dagml.finetune_lowering import (
+    _is_supported_native_refit_params_noop,
     lower_deterministic_finetune_params_to_generators,
+    reject_native_training_param_overrides,
 )
-from nirs4all.pipeline.dagml.run_backend import _training_loss_generation_kind
+from nirs4all.pipeline.dagml.run_backend import _derive_config_name, _training_loss_generation_kind
+
+
+class _PLSRegressionSubclass(PLSRegression):
+    pass
+
+
+class _CustomEstimator:
+    pass
+
+
+class _RefitParamsDict(dict[str, Any]):
+    pass
+
+
+class _StringSubclass(str):
+    pass
+
+
+class _FitPredictSplit:
+    def fit(self) -> _FitPredictSplit:
+        return self
+
+    def predict(self) -> None:
+        return None
+
+    def split(self) -> tuple[()]:
+        return ()
 
 
 def test_local_loss_routing_treats_allowed_train_params_as_concrete_metadata() -> None:
@@ -27,6 +60,505 @@ def test_local_loss_routing_treats_allowed_train_params_as_concrete_metadata() -
 
     assert _generation_kind(pipeline) == "operator"
     assert _training_loss_generation_kind(pipeline) == "none"
+
+
+def test_native_refit_noop_proof_is_exact_and_preserves_original_config() -> None:
+    """The accepted legacy no-op keeps the untouched pipeline as hash authority."""
+
+    model = PLSRegression(n_components=8)
+    refit_params = {"use_all_partitions": True}
+    model_step = {"name": "PLS_with_refit", "model": model, "refit_params": refit_params}
+    pipeline = [SNV(), ShuffleSplit(n_splits=3, random_state=42), model_step]
+
+    assert _is_supported_native_refit_params_noop(pipeline)
+    assert pipeline[2] is model_step
+    assert model_step["model"] is model
+    assert model_step["refit_params"] is refit_params
+    assert _derive_config_name(pipeline, "") == "config_b2d6a46d"
+
+
+def test_public_dispatch_routes_proven_refit_noop_without_mutating_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The accepted key reaches native lowering unchanged and retains its legacy hash."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    class FakeSpectro:
+        name = "regression"
+
+        def y(self, query: dict[str, str]) -> np.ndarray:
+            assert query == {"partition": "train"}
+            return np.asarray([0.1, 1.5, 2.7, 3.9])
+
+        def features_sources(self) -> int:
+            return 1
+
+    model = PLSRegression(n_components=8)
+    refit_params = {"use_all_partitions": True}
+    model_step = {"name": "PLS_with_refit", "model": model, "refit_params": refit_params}
+    pipeline = [SNV(), ShuffleSplit(n_splits=3, random_state=42), model_step]
+    captured: dict[str, Any] = {}
+
+    def fake_run_concrete_scores(variant: list[Any], *_args: Any, **_kwargs: Any) -> tuple[Any, str, bool, list[Any], dict[str, Any], list[Any]]:
+        captured["variant"] = variant
+        return object(), "PLSRegression", False, [], {}, []
+
+    def fake_scores_to_run_result(*_args: Any, **kwargs: Any) -> str:
+        captured["config_name"] = kwargs["config_name"]
+        return "native-result"
+
+    monkeypatch.setattr(run_backend, "_is_repetition_dataset", lambda _spectro: False)
+    monkeypatch.setattr(run_backend, "_resolve_exclude", lambda steps, _spectro: (steps, [0, 1, 2, 3], set()))
+    monkeypatch.setattr(run_backend, "_resolve_tags", lambda steps, _spectro, _cv_pool: (steps, {}))
+    monkeypatch.setattr(run_backend, "_expand_operator_generators", lambda steps: [steps])
+    monkeypatch.setattr(run_backend, "_run_concrete_scores", fake_run_concrete_scores)
+    monkeypatch.setattr(run_backend, "_scores_to_run_result", fake_scores_to_run_result)
+
+    result = run_backend._dispatch_run(
+        pipeline,
+        FakeSpectro(),
+        Path("/tmp/nirs4all-test"),
+        "dataset",
+        None,
+        "dag-ml-cli",
+        None,
+    )
+
+    assert result == "native-result"
+    assert captured["config_name"] == "config_b2d6a46d"
+    assert captured["variant"][2] is model_step
+    assert model_step["model"] is model
+    assert model_step["refit_params"] is refit_params
+
+
+@pytest.mark.parametrize(
+    ("pipeline", "expected_key"),
+    [
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"use_all_partitions": False}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"use_all_partitions": 1}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"use_all_partitions": np.bool_(True)}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"other": True}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {_StringSubclass("use_all_partitions"): True}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": _RefitParamsDict({"use_all_partitions": True})}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": UserDict({"use_all_partitions": True})}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": MappingProxyType({"use_all_partitions": True})}], "refit_params"),
+        ([KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"use_all_partitions": True, "future": "value"}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": _PLSRegressionSubclass(), "refit_params": {"use_all_partitions": True}}], "refit_params"),
+        ([KFold(n_splits=2), {"model": _CustomEstimator(), "refit_params": {"use_all_partitions": True}}], "refit_params"),
+        (
+            [
+                KFold(n_splits=2),
+                PLSRegression(),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"branch": [[{"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}]]},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+                {"model": PLSRegression()},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+                {"branch": [[{"model": PLSRegression()}]]},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+                {"branch": [{"name": "x", "steps": [{"model": PLSRegression()}], "metadata": "x"}]},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {
+                    "branch": [
+                        {
+                            "name": "x",
+                            "steps": [{"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}],
+                            "metadata": "x",
+                        }
+                    ]
+                },
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+                {"refit_params": {"use_all_partitions": True}},
+            ],
+            "refit_params",
+        ),
+        (
+            [
+                KFold(n_splits=2),
+                {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+                {"branch": [[{"refit_params": {"use_all_partitions": True}}]]},
+            ],
+            "refit_params",
+        ),
+        ([KFold(n_splits=2), {"model": PLSRegression()}, {"refit_params": {"use_all_partitions": True}}], "refit_params"),
+        (
+            [
+                KFold(n_splits=2),
+                {
+                    "model": PLSRegression(),
+                    "refit_params": {"use_all_partitions": True},
+                    "train_params": {"epochs": 1},
+                },
+            ],
+            "train_params",
+        ),
+    ],
+    ids=(
+        "false",
+        "integer-one",
+        "numpy-bool",
+        "wrong-sole-key",
+        "string-subclass-key",
+        "dict-subclass",
+        "user-dict",
+        "mapping-proxy",
+        "extra-key",
+        "pls-subclass",
+        "custom-estimator",
+        "bare-model",
+        "nested-only-pair",
+        "multiple-models",
+        "nested-model",
+        "branch-list-wrapper-nested-model",
+        "branch-list-wrapper-nested-refit",
+        "duplicate-refit-key",
+        "nested-refit-key",
+        "refit-key-off-model-step",
+        "train-params",
+    ),
+)
+def test_public_dispatch_rejects_every_refit_shape_outside_proven_noop(pipeline: list[Any], expected_key: str) -> None:
+    """All nearby refit forms must retain the strict native refusal."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    with pytest.raises(NotImplementedError, match=expected_key):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_rejects_cyclic_refit_pipeline_without_recursing() -> None:
+    """A cyclic pipeline is not a no-op proof and still reaches the native refusal."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    model_step = {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}
+    pipeline: list[Any] = [KFold(n_splits=2), model_step]
+    pipeline.append(pipeline)
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_counts_aliased_model_step_as_two_occurrences() -> None:
+    """An alias in a second branch position is another pipeline occurrence."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    model_step = {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}
+    pipeline = [KFold(n_splits=2), model_step, {"branch": [[model_step]]}]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+@pytest.mark.parametrize(
+    "branch_step",
+    [
+        {"branch": [{"_or_": [{"model": PLSRegression()}]}]},
+        {"branch": [{"_or_": [{"refit_params": {"use_all_partitions": True}}]}]},
+        {"branch": {"x": {"_or_": [{"model": PLSRegression()}]}}},
+        {"branch": {"x": {"_or_": [{"refit_params": {"use_all_partitions": True}}]}}},
+        {"branch": {"_or_": [{"model": PLSRegression()}]}},
+        {"branch": {"_or_": [{"refit_params": {"use_all_partitions": True}}]}},
+    ],
+    ids=("list-model", "list-refit", "named-model", "named-refit", "branch-model", "branch-refit"),
+)
+def test_public_dispatch_rejects_refit_noop_with_branch_generator(branch_step: dict[str, Any]) -> None:
+    """An unexpanded branch generator cannot hide a second model or refit key."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+        branch_step,
+    ]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_rejects_nested_refit_inside_branch_generator_before_runtime() -> None:
+    """A generator-contained refit override reaches the native rejection guard."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline = [
+        KFold(n_splits=2),
+        {
+            "branch": [
+                {"_or_": [{"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}]}
+            ]
+        },
+    ]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("candidate", "branch_hidden"),
+    [
+        ({"class": "sklearn.ensemble.RandomForestClassifier"}, False),
+        ({"function": "sklearn.linear_model.LogisticRegression"}, False),
+        ({"instance": "sklearn.ensemble.RandomForestClassifier"}, False),
+        ("sklearn.ensemble.RandomForestClassifier", False),
+        ({"class": "sklearn.ensemble.RandomForestClassifier"}, True),
+        ({"function": "sklearn.linear_model.LogisticRegression"}, True),
+        ({"instance": "sklearn.ensemble.RandomForestClassifier"}, True),
+        ("sklearn.ensemble.RandomForestClassifier", True),
+    ],
+    ids=("top-class", "top-function", "top-instance", "top-fqcn", "branch-class", "branch-function", "branch-instance", "branch-fqcn"),
+)
+def test_public_dispatch_rejects_refit_noop_with_ambiguous_model_representation(candidate: Any, branch_hidden: bool) -> None:
+    """Serialized or string model candidates cannot join the exact PLS proof."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline: list[Any] = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+    ]
+    pipeline.append({"branch": [[candidate]]} if branch_hidden else candidate)
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+@pytest.mark.parametrize("branch_hidden", [False, True], ids=("top", "branch"))
+def test_public_dispatch_rejects_refit_noop_with_framework_factory(branch_hidden: bool) -> None:
+    """A framework-marked factory is too ambiguous for the exact PLS proof."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    def framework_model_factory() -> None:
+        return None
+
+    setattr(framework_model_factory, "framework", "tensorflow")
+    pipeline: list[Any] = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+    ]
+    pipeline.append({"branch": [[framework_model_factory]]} if branch_hidden else framework_model_factory)
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_rejects_refit_noop_with_direct_unknown_item() -> None:
+    """An unclassified direct item cannot join the exact PLS proof."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+        object(),
+    ]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_rejects_refit_noop_with_fit_predict_split_item() -> None:
+    """A model-like object cannot be admitted merely because it has ``split``."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+        _FitPredictSplit(),
+    ]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+@pytest.mark.parametrize(
+    "workflow_step",
+    [
+        {"preprocessing": PLSRegression()},
+        {"split": PLSRegression()},
+        {"custom": PLSRegression()},
+    ],
+    ids=("preprocessing", "split", "custom"),
+)
+def test_public_dispatch_rejects_refit_noop_with_non_model_workflow_dict(workflow_step: dict[str, Any]) -> None:
+    """Only the exact top-level model dict can accompany the PLS no-op."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    pipeline = [
+        KFold(n_splits=2),
+        {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}},
+        workflow_step,
+    ]
+
+    assert not _is_supported_native_refit_params_noop(pipeline)
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            pipeline,
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_public_dispatch_rejects_refit_noop_if_pls_gains_matching_parameter(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A future sklearn PLS parameter must never be silently ignored as a no-op."""
+
+    from nirs4all.pipeline.dagml import run_backend
+
+    original_get_params = PLSRegression.get_params
+
+    def get_params_with_future_refit_option(self: PLSRegression, deep: bool = True) -> dict[str, Any]:
+        params = cast(dict[str, Any], original_get_params(self, deep=deep))
+        if not deep:
+            params["use_all_partitions"] = False
+        return params
+
+    monkeypatch.setattr(PLSRegression, "get_params", get_params_with_future_refit_option)
+
+    with pytest.raises(NotImplementedError, match="refit_params"):
+        run_backend._dispatch_run(
+            [KFold(n_splits=2), {"model": PLSRegression(), "refit_params": {"use_all_partitions": True}}],
+            object(),
+            Path("/tmp/nirs4all-test"),
+            "dataset",
+            None,
+            "dag-ml-cli",
+            None,
+        )
+
+
+def test_training_parameter_rejection_ignores_non_structural_payload_mappings() -> None:
+    """Reserved names inside model and label payloads are not pipeline controls."""
+
+    reject_native_training_param_overrides(
+        [
+            {"model": RandomForestClassifier(), "class_weight": {"refit_params": 1.0}},
+            {"label": {"train_params": "cohort"}},
+        ],
+        context="engine='dag-ml'",
+    )
 
 
 def test_deterministic_finetune_plain_grid_lowers_to_step_grid() -> None:

--- a/tests/unit/pipeline/test_keyword_registry.py
+++ b/tests/unit/pipeline/test_keyword_registry.py
@@ -64,7 +64,7 @@ _VALID_INVALIDATIONS = {
     "not_applicable",
 }
 _VALID_ENGINE_SUPPORT = {"supported", "partial", "planned", "unsupported", "legacy_fallback", "not_applicable"}
-EXPECTED_PUBLISHED_REGISTRY_SHA256 = "8c3fec221ee3657a26f7558dfcee4fb5a432dc7c873b1a7dd89a5b8f61c91689"
+EXPECTED_PUBLISHED_REGISTRY_SHA256 = "bdbf554755652b3c148ca377bea4ce6480ef6c2ce5a194f45e371d75794d0a73"
 
 
 def _entries_by_id() -> dict[str, KeywordEntry]:
@@ -76,7 +76,7 @@ def test_registry_document_has_versioned_stable_shape() -> None:
 
     assert registry["schema_id"] == KEYWORD_REGISTRY_SCHEMA_ID
     assert registry["schema_version"] == KEYWORD_REGISTRY_SCHEMA_VERSION == 1
-    assert registry["registry_version"] == KEYWORD_REGISTRY_VERSION == "1.0.0"
+    assert registry["registry_version"] == KEYWORD_REGISTRY_VERSION == "1.0.1"
     assert registry["scope"] == "lifecycle-v1"
     assert registry["entries"]
     assert public_get_keyword_registry() == registry
@@ -394,9 +394,12 @@ def test_partial_hpo_behaviors_and_dag_training_limits_are_not_overclaimed() -> 
     assert entries["pipeline.step.finetune_params.train_params"]["engine_support"]["dag-ml"] == "unsupported"
     assert "rejects it until optimizer adapters" in entries["pipeline.step.finetune_params.train_params"]["summary"]
     assert entries["pipeline.step.train_params"]["engine_support"]["dag-ml"] == "unsupported"
-    assert entries["pipeline.step.refit_params"]["engine_support"]["dag-ml"] == "unsupported"
+    refit_params = entries["pipeline.step.refit_params"]
+    assert refit_params["engine_support"]["dag-ml"] == "partial"
     assert "rejects it before native execution" in entries["pipeline.step.train_params"]["summary"]
-    assert "rejects it before native execution" in entries["pipeline.step.refit_params"]["summary"]
+    assert "exact {'use_all_partitions': True} no-op" in refit_params["summary"]
+    assert "one top-level exact PLSRegression model step" in refit_params["summary"]
+    assert "every other refit_params shape is rejected before native execution" in refit_params["summary"]
 
 
 def test_planned_python_surfaces_are_absent_or_fail_closed_in_current_public_api() -> None:


### PR DESCRIPTION
## Summary
- lower only the proven legacy no-op refit_params={"use_all_partitions": True} for one exact top-level PLSRegression model without mutating the pipeline or its legacy configuration identity
- retain fail-closed behavior for every neighboring shape, cycles, aliases, nesting, extra model, payload variation, and future sklearn parameter
- update both compatibility ledgers to 86 native / 8 fallback / 1 preflight refusal and document the partial registry contract
- add a merge-proof installed lane: real N4M witness plus targeted compile, baseline, conformance, and ledger nodes

## Validation
- Sol review accepted independently for runtime, ledger policy, and CI/registry phases
- 82 unit/preflight tests and 2 native conformance witnesses
- parity-ledger/docs tests, registry/docs tests, Ruff, targeted mypy, YAML and diff checks
- installed witness is intentionally non-skippable in CI via NIRS4ALL_REQUIRE_N4M=1